### PR TITLE
[field] Add TowerField::min_tower_level(self), and use it to derive ArithExpr tower_level from its constants

### DIFF
--- a/crates/core/src/polynomial/arith_circuit.rs
+++ b/crates/core/src/polynomial/arith_circuit.rs
@@ -119,12 +119,14 @@ pub struct ArithCircuitPoly<F: Field> {
 	retval: CircuitStepArgument<F>,
 	degree: usize,
 	n_vars: usize,
+	tower_level: usize,
 }
 
-impl<F: Field> ArithCircuitPoly<F> {
+impl<F: TowerField> ArithCircuitPoly<F> {
 	pub fn new(expr: ArithExpr<F>) -> Self {
 		let degree = expr.degree();
 		let n_vars = expr.n_vars();
+		let tower_level = expr.binary_tower_level();
 		let (exprs, retval) = circuit_steps_for_expr(&expr);
 
 		Self {
@@ -133,6 +135,7 @@ impl<F: Field> ArithCircuitPoly<F> {
 			retval,
 			degree,
 			n_vars,
+			tower_level,
 		}
 	}
 
@@ -142,6 +145,7 @@ impl<F: Field> ArithCircuitPoly<F> {
 	/// arithmetic expression.
 	pub fn with_n_vars(n_vars: usize, expr: ArithExpr<F>) -> Result<Self, Error> {
 		let degree = expr.degree();
+		let tower_level = expr.binary_tower_level();
 		if n_vars < expr.n_vars() {
 			return Err(Error::IncorrectNumberOfVariables {
 				expected: expr.n_vars(),
@@ -156,6 +160,7 @@ impl<F: Field> ArithCircuitPoly<F> {
 			retval,
 			n_vars,
 			degree,
+			tower_level,
 		})
 	}
 }
@@ -170,7 +175,7 @@ impl<F: TowerField> CompositionPoly<F> for ArithCircuitPoly<F> {
 	}
 
 	fn binary_tower_level(&self) -> usize {
-		F::TOWER_LEVEL
+		self.tower_level
 	}
 
 	fn expression<FE: ExtensionField<F>>(&self) -> ArithExpr<FE> {
@@ -501,7 +506,7 @@ mod tests {
 		let circuit = ArithCircuitPoly::<F>::new(expr);
 
 		let typed_circuit: &dyn CompositionPolyOS<P> = &circuit;
-		assert_eq!(typed_circuit.binary_tower_level(), F::TOWER_LEVEL);
+		assert_eq!(typed_circuit.binary_tower_level(), 0);
 		assert_eq!(typed_circuit.degree(), 1);
 		assert_eq!(typed_circuit.n_vars(), 1);
 
@@ -529,7 +534,7 @@ mod tests {
 		let circuit = ArithCircuitPoly::<F>::new(expr);
 
 		let typed_circuit: &dyn CompositionPolyOS<P> = &circuit;
-		assert_eq!(typed_circuit.binary_tower_level(), F::TOWER_LEVEL);
+		assert_eq!(typed_circuit.binary_tower_level(), 3);
 		assert_eq!(typed_circuit.degree(), 1);
 		assert_eq!(typed_circuit.n_vars(), 1);
 
@@ -549,7 +554,7 @@ mod tests {
 		let circuit = ArithCircuitPoly::<F>::new(expr);
 
 		let typed_circuit: &dyn CompositionPolyOS<P> = &circuit;
-		assert_eq!(typed_circuit.binary_tower_level(), F::TOWER_LEVEL);
+		assert_eq!(typed_circuit.binary_tower_level(), 3);
 		assert_eq!(typed_circuit.degree(), 1);
 		assert_eq!(typed_circuit.n_vars(), 1);
 
@@ -575,7 +580,7 @@ mod tests {
 		let circuit = ArithCircuitPoly::<F>::new(expr);
 
 		let typed_circuit: &dyn CompositionPolyOS<P> = &circuit;
-		assert_eq!(typed_circuit.binary_tower_level(), F::TOWER_LEVEL);
+		assert_eq!(typed_circuit.binary_tower_level(), 0);
 		assert_eq!(typed_circuit.degree(), 13);
 		assert_eq!(typed_circuit.n_vars(), 1);
 
@@ -601,7 +606,7 @@ mod tests {
 		let circuit = ArithCircuitPoly::<F>::new(expr);
 
 		let typed_circuit: &dyn CompositionPolyOS<P> = &circuit;
-		assert_eq!(typed_circuit.binary_tower_level(), F::TOWER_LEVEL);
+		assert_eq!(typed_circuit.binary_tower_level(), 3);
 		assert_eq!(typed_circuit.degree(), 3);
 		assert_eq!(typed_circuit.n_vars(), 2);
 
@@ -722,7 +727,7 @@ mod tests {
 		assert_eq!(circuit.steps.len(), 1);
 
 		let typed_circuit: &dyn CompositionPolyOS<P> = &circuit;
-		assert_eq!(typed_circuit.binary_tower_level(), F::TOWER_LEVEL);
+		assert_eq!(typed_circuit.binary_tower_level(), 1);
 		assert_eq!(typed_circuit.degree(), 1);
 		assert_eq!(typed_circuit.n_vars(), 1);
 
@@ -749,7 +754,7 @@ mod tests {
 		assert_eq!(circuit.steps.len(), 1);
 
 		let typed_circuit: &dyn CompositionPolyOS<P> = &circuit;
-		assert_eq!(typed_circuit.binary_tower_level(), F::TOWER_LEVEL);
+		assert_eq!(typed_circuit.binary_tower_level(), 0);
 		assert_eq!(typed_circuit.degree(), 24);
 		assert_eq!(typed_circuit.n_vars(), 1);
 

--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -78,6 +78,13 @@ impl_arithmetic_using_packed!(AESTowerField128b);
 impl TowerField for AESTowerField8b {
 	type Canonical = BinaryField8b;
 
+	fn min_tower_level(self) -> usize {
+		match self {
+			Self::ZERO | Self::ONE => 0,
+			_ => 3,
+		}
+	}
+
 	fn mul_primitive(self, iota: usize) -> Result<Self, Error> {
 		match iota {
 			0..=1 => Ok(self * ISOMORPHIC_ALPHAS[iota]),

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -48,8 +48,8 @@ where
 	/// Returns the smallest valid `TOWER_LEVEL` in the tower that can fit the same value.
 	///
 	/// Since which `TOWER_LEVEL` values are valid depends on the tower,
-	/// `F::Canonical::from(elem).binary_tower_level()` can return a different result
-	/// from `elem.binary_tower_level()`.
+	/// `F::Canonical::from(elem).min_tower_level()` can return a different result
+	/// from `elem.min_tower_level()`.
 	fn min_tower_level(self) -> usize;
 
 	fn basis(iota: usize, i: usize) -> Result<Self, Error> {

--- a/crates/field/src/binary_field_arithmetic.rs
+++ b/crates/field/src/binary_field_arithmetic.rs
@@ -61,6 +61,10 @@ pub(crate) use impl_arithmetic_using_packed;
 impl TowerField for BinaryField1b {
 	type Canonical = Self;
 
+	fn min_tower_level(self) -> usize {
+		0
+	}
+
 	#[inline]
 	fn mul_primitive(self, _: usize) -> Result<Self, crate::Error> {
 		Err(crate::Error::ExtensionDegreeMismatch)

--- a/crates/field/src/polyval.rs
+++ b/crates/field/src/polyval.rs
@@ -457,6 +457,13 @@ impl BinaryField for BinaryField128bPolyval {
 impl TowerField for BinaryField128bPolyval {
 	type Canonical = BinaryField128b;
 
+	fn min_tower_level(self) -> usize {
+		match self {
+			Self::ZERO | Self::ONE => 0,
+			_ => 7,
+		}
+	}
+
 	fn mul_primitive(self, _iota: usize) -> Result<Self, Error> {
 		// This method could be implemented by multiplying by isomorphic alpha value
 		// But it's not being used as for now

--- a/crates/math/src/arith_expr.rs
+++ b/crates/math/src/arith_expr.rs
@@ -7,7 +7,7 @@ use std::{
 	ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
 };
 
-use binius_field::{Field, PackedField};
+use binius_field::{Field, PackedField, TowerField};
 
 use super::error::Error;
 
@@ -193,6 +193,19 @@ impl<F: Field> ArithExpr<F> {
 					id => Self::Pow(Box::new(id), *exp),
 				}
 			}
+		}
+	}
+}
+
+impl<F: TowerField> ArithExpr<F> {
+	pub fn binary_tower_level(&self) -> usize {
+		match self {
+			Self::Const(value) => value.min_tower_level(),
+			Self::Var(_) => 0,
+			Self::Add(left, right) | Self::Mul(left, right) => {
+				max(left.binary_tower_level(), right.binary_tower_level())
+			}
+			Self::Pow(base, _) => base.binary_tower_level(),
 		}
 	}
 }


### PR DESCRIPTION
In contrast to `TowerField::TOWER_LEVEL`, `TowerField::binary_tower_level(self)` returns the smallest tower level that can fit the current value. This can be useful for shrinking field values to the smaller container that fits them, for the purpose of making arithmetic operations (in particular multiplication) cheaper

Note that depending on the tower family, not all tower level values are valid.
- For BinaryField, tower levels 0, 1, 2, 3, 4, 5, 6, 7 are valid
- For AESTowerField, tower levels 0, 3, 4, 5, 6, 7 are valid
- For Polyval, tower levels 0, 7 are valid
