### PR TITLE
High to low sumcheck

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -52,6 +52,10 @@ harness = false
 name = "prodcheck"
 harness = false
 
+[[bench]]
+name = "high_to_low_sumcheck"
+harness = false
+
 [features]
 debug_validate_sumcheck = []
 stable_only = [

--- a/crates/core/benches/high_to_low_sumcheck.rs
+++ b/crates/core/benches/high_to_low_sumcheck.rs
@@ -150,7 +150,7 @@ fn bench_byte_sliced(c: &mut Criterion) {
 	bench_high_to_low_sumcheck::<AESTowerField8b, ByteSlicedAES32x8b>(
 		c,
 		4,
-		"high_to_low_ByteSlicedAES32x8b",
+		"ByteSlicedAES32x8b/high_to_low",
 		true,
 	);
 	bench_high_to_low_sumcheck::<AESTowerField8b, ByteSlicedAES32x8b>(
@@ -165,7 +165,7 @@ fn bench_aes_tower(c: &mut Criterion) {
 	bench_high_to_low_sumcheck::<AESTowerField8b, PackedAESBinaryField32x8b>(
 		c,
 		4,
-		"high_to_low_PackedAESBinaryField32x8b",
+		"PackedAESBinaryField32x8b/high_to_low",
 		true,
 	);
 

--- a/crates/core/benches/high_to_low_sumcheck.rs
+++ b/crates/core/benches/high_to_low_sumcheck.rs
@@ -1,0 +1,181 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use std::iter::repeat_with;
+
+use binius_core::{
+	fiat_shamir::HasherChallenger,
+	polynomial::MultilinearComposite,
+	protocols::{
+		sumcheck::{
+			prove::{
+				batch_prove, high_to_low_batch_prove,
+				high_to_low_sumcheck::HighToLowSumcheckProver, RegularSumcheckProver,
+			},
+			CompositeSumClaim,
+		},
+		test_utils::{AddOneComposition, TestProductComposition},
+	},
+	transcript::TranscriptWriter,
+};
+use binius_field::{
+	packed::set_packed_slice, AESTowerField8b, BinaryField, ByteSlicedAES32x8b, ExtensionField,
+	PackedAESBinaryField32x8b, PackedExtension, PackedField, TowerField,
+};
+use binius_hal::make_portable_backend;
+use binius_math::{
+	CompositionPolyOS, IsomorphicEvaluationDomainFactory, MLEDirectAdapter, MultilinearExtension,
+	MultilinearPoly,
+};
+use criterion::{criterion_group, criterion_main, Criterion};
+use groestl_crypto::Groestl256;
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+fn compute_composite_sum<P, M, Composition>(
+	multilinears: &[M],
+	composition: Composition,
+) -> P::Scalar
+where
+	P: PackedField,
+	M: MultilinearPoly<P> + Send + Sync,
+	Composition: CompositionPolyOS<P>,
+{
+	let n_vars = multilinears
+		.first()
+		.map(|multilinear| multilinear.n_vars())
+		.unwrap_or_default();
+	for multilinear in multilinears.iter() {
+		assert_eq!(multilinear.n_vars(), n_vars);
+	}
+
+	let multilinears = multilinears.iter().collect::<Vec<_>>();
+	let witness = MultilinearComposite::new(n_vars, composition, multilinears.clone()).unwrap();
+	(0..(1 << n_vars))
+		.into_par_iter()
+		.map(|j| witness.evaluate_on_hypercube(j).unwrap())
+		.sum()
+}
+
+fn generate_random_multilinears<P>(
+	mut rng: impl Rng,
+	n_vars: usize,
+	n_multilinears: usize,
+) -> Vec<MultilinearExtension<P>>
+where
+	P: PackedField,
+{
+	repeat_with(|| {
+		let mut values = repeat_with(|| P::random(&mut rng))
+			.take(1 << (n_vars.saturating_sub(P::LOG_WIDTH)))
+			.collect::<Vec<_>>();
+		if n_vars < P::WIDTH {
+			for i in n_vars..P::WIDTH {
+				set_packed_slice(&mut values, i, P::Scalar::zero());
+			}
+		}
+
+		MultilinearExtension::new(n_vars, values).unwrap()
+	})
+	.take(n_multilinears)
+	.collect()
+}
+
+fn bench_high_to_low_sumcheck<FDomain, P>(
+	c: &mut Criterion,
+	n_multilinears: usize,
+	id: &str,
+	high_to_low: bool,
+) where
+	P: PackedField + PackedExtension<FDomain>,
+	P::Scalar: TowerField + ExtensionField<FDomain>,
+	FDomain: BinaryField,
+{
+	let mut group = c.benchmark_group(id);
+
+	for n_vars in [12, 16, 20] {
+		group.bench_function(format!("n_vars={n_vars}"), |bench| {
+			let mut rng = StdRng::seed_from_u64(0);
+
+			let multilins = generate_random_multilinears::<P>(&mut rng, n_vars, n_multilinears)
+				.into_iter()
+				.map(MLEDirectAdapter::<P>::from)
+				.collect::<Vec<_>>();
+			let product_composition = TestProductComposition::new(n_multilinears);
+			let composition = AddOneComposition::new(product_composition);
+			let sum = compute_composite_sum(&multilins, &composition);
+
+			let backend = make_portable_backend();
+			let domain_factory = IsomorphicEvaluationDomainFactory::<FDomain>::default();
+			let mut prover_transcript = TranscriptWriter::<HasherChallenger<Groestl256>>::default();
+			if high_to_low {
+				bench.iter(|| {
+					let prover = HighToLowSumcheckProver::<FDomain, _, _, _, _>::new(
+						multilins.iter().collect(),
+						[CompositeSumClaim {
+							composition: &composition,
+							sum,
+						}],
+						domain_factory.clone(),
+						&backend,
+					)
+					.unwrap();
+
+					high_to_low_batch_prove(vec![prover], &mut prover_transcript)
+						.expect("failed to prove sumcheck");
+				});
+			} else {
+				bench.iter(|| {
+					let prover = RegularSumcheckProver::<FDomain, _, _, _, _>::new(
+						multilins.iter().collect(),
+						[CompositeSumClaim {
+							composition: &composition,
+							sum,
+						}],
+						domain_factory.clone(),
+						|_| 0,
+						&backend,
+					)
+					.unwrap();
+
+					batch_prove(vec![prover], &mut prover_transcript)
+						.expect("failed to prove sumcheck");
+				});
+			}
+		});
+	}
+	group.finish()
+}
+
+fn bench_byte_sliced(c: &mut Criterion) {
+	bench_high_to_low_sumcheck::<AESTowerField8b, ByteSlicedAES32x8b>(
+		c,
+		4,
+		"high_to_low_ByteSlicedAES32x8b",
+		true,
+	);
+	bench_high_to_low_sumcheck::<AESTowerField8b, ByteSlicedAES32x8b>(
+		c,
+		4,
+		"ByteSlicedAES32x8b",
+		false,
+	);
+}
+
+fn bench_aes_tower(c: &mut Criterion) {
+	bench_high_to_low_sumcheck::<AESTowerField8b, PackedAESBinaryField32x8b>(
+		c,
+		4,
+		"high_to_low_PackedAESBinaryField32x8b",
+		true,
+	);
+
+	bench_high_to_low_sumcheck::<AESTowerField8b, PackedAESBinaryField32x8b>(
+		c,
+		4,
+		"PackedAESBinaryField32x8b",
+		false,
+	);
+}
+
+criterion_main!(high_to_low_sumcheck);
+criterion_group!(high_to_low_sumcheck, bench_byte_sliced, bench_aes_tower);

--- a/crates/core/benches/high_to_low_sumcheck.rs
+++ b/crates/core/benches/high_to_low_sumcheck.rs
@@ -45,7 +45,7 @@ where
 		.first()
 		.map(|multilinear| multilinear.n_vars())
 		.unwrap_or_default();
-	for multilinear in multilinears.iter() {
+	for multilinear in multilinears {
 		assert_eq!(multilinear.n_vars(), n_vars);
 	}
 
@@ -81,14 +81,14 @@ where
 	.collect()
 }
 
-fn bench_high_to_low_sumcheck<FDomain, P>(
+fn bench_high_to_low_sumcheck<F, FDomain, P>(
 	c: &mut Criterion,
 	n_multilinears: usize,
 	id: &str,
 	high_to_low: bool,
 ) where
-	P: PackedField + PackedExtension<FDomain>,
-	P::Scalar: TowerField + ExtensionField<FDomain>,
+	P: PackedField<Scalar = F> + PackedExtension<F, PackedSubfield = P> + PackedExtension<FDomain>,
+	F: TowerField + ExtensionField<FDomain>,
 	FDomain: BinaryField,
 {
 	let mut group = c.benchmark_group(id);
@@ -148,13 +148,13 @@ fn bench_high_to_low_sumcheck<FDomain, P>(
 }
 
 fn bench_high_to_low_sumcheck_8b(c: &mut Criterion) {
-	bench_high_to_low_sumcheck::<AESTowerField8b, ByteSlicedAES32x8b>(
+	bench_high_to_low_sumcheck::<_, AESTowerField8b, ByteSlicedAES32x8b>(
 		c,
 		4,
 		"ByteSlicedAES32x8b/high_to_low",
 		true,
 	);
-	bench_high_to_low_sumcheck::<AESTowerField8b, PackedAESBinaryField32x8b>(
+	bench_high_to_low_sumcheck::<_, AESTowerField8b, PackedAESBinaryField32x8b>(
 		c,
 		4,
 		"PackedAESBinaryField32x8b/high_to_low",
@@ -163,13 +163,13 @@ fn bench_high_to_low_sumcheck_8b(c: &mut Criterion) {
 }
 
 fn bench_sumcheck_8b(c: &mut Criterion) {
-	bench_high_to_low_sumcheck::<AESTowerField8b, ByteSlicedAES32x8b>(
+	bench_high_to_low_sumcheck::<_, AESTowerField8b, ByteSlicedAES32x8b>(
 		c,
 		4,
 		"ByteSlicedAES32x8b",
 		false,
 	);
-	bench_high_to_low_sumcheck::<AESTowerField8b, PackedAESBinaryField32x8b>(
+	bench_high_to_low_sumcheck::<_, AESTowerField8b, PackedAESBinaryField32x8b>(
 		c,
 		4,
 		"PackedAESBinaryField32x8b",
@@ -177,13 +177,13 @@ fn bench_sumcheck_8b(c: &mut Criterion) {
 	);
 }
 fn bench_high_to_low_sumcheck_128b(c: &mut Criterion) {
-	bench_high_to_low_sumcheck::<AESTowerField8b, ByteSlicedAES32x128b>(
+	bench_high_to_low_sumcheck::<_, AESTowerField8b, ByteSlicedAES32x128b>(
 		c,
 		4,
 		"ByteSlicedAES32x128b/high_to_low",
 		true,
 	);
-	bench_high_to_low_sumcheck::<AESTowerField8b, PackedAESBinaryField2x128b>(
+	bench_high_to_low_sumcheck::<_, AESTowerField8b, PackedAESBinaryField2x128b>(
 		c,
 		4,
 		"PackedAESBinaryField2x128b/high_to_low",
@@ -192,13 +192,13 @@ fn bench_high_to_low_sumcheck_128b(c: &mut Criterion) {
 }
 
 fn bench_sumcheck_128b(c: &mut Criterion) {
-	bench_high_to_low_sumcheck::<AESTowerField8b, ByteSlicedAES32x128b>(
+	bench_high_to_low_sumcheck::<_, AESTowerField8b, ByteSlicedAES32x128b>(
 		c,
 		4,
 		"ByteSlicedAES32x128b",
 		false,
 	);
-	bench_high_to_low_sumcheck::<AESTowerField8b, PackedAESBinaryField2x128b>(
+	bench_high_to_low_sumcheck::<_, AESTowerField8b, PackedAESBinaryField2x128b>(
 		c,
 		4,
 		"PackedAESBinaryField2x128b",

--- a/crates/core/src/protocols/sumcheck/prove/batch_prove.rs
+++ b/crates/core/src/protocols/sumcheck/prove/batch_prove.rs
@@ -238,7 +238,7 @@ where
 	};
 
 	batch_prove_with_start(start, provers, transcript).map(|mut res| {
-		// Challenges must be reverted because folding happens in reverse order.  
+		// Challenges must be reverted because folding happens in reverse order.
 		res.challenges.reverse();
 		res
 	})

--- a/crates/core/src/protocols/sumcheck/prove/batch_prove.rs
+++ b/crates/core/src/protocols/sumcheck/prove/batch_prove.rs
@@ -221,3 +221,24 @@ where
 
 	Ok(output)
 }
+
+#[instrument(skip_all, name = "sumcheck::batch_prove")]
+pub fn high_to_low_batch_prove<F, Prover, Transcript>(
+	provers: Vec<Prover>,
+	transcript: Transcript,
+) -> Result<BatchSumcheckOutput<F>, Error>
+where
+	F: TowerField,
+	Prover: SumcheckProver<F>,
+	Transcript: CanSample<F> + CanWrite,
+{
+	let start = BatchProveStart {
+		batch_coeffs: Vec::new(),
+		reduction_provers: Vec::<Prover>::new(),
+	};
+
+	batch_prove_with_start(start, provers, transcript).map(|mut res| {
+		res.challenges.reverse();
+		res
+	})
+}

--- a/crates/core/src/protocols/sumcheck/prove/batch_prove.rs
+++ b/crates/core/src/protocols/sumcheck/prove/batch_prove.rs
@@ -222,15 +222,15 @@ where
 	Ok(output)
 }
 
-#[instrument(skip_all, name = "sumcheck::batch_prove")]
-pub fn high_to_low_batch_prove<F, Prover, Transcript>(
+#[instrument(skip_all, name = "sumcheck::high_to_low_batch_prove")]
+pub fn high_to_low_batch_prove<F, Prover, Challenger_>(
 	provers: Vec<Prover>,
-	transcript: Transcript,
+	transcript: &mut ProverTranscript<Challenger_>,
 ) -> Result<BatchSumcheckOutput<F>, Error>
 where
 	F: TowerField,
 	Prover: SumcheckProver<F>,
-	Transcript: CanSample<F> + CanWrite,
+	Challenger_: Challenger,
 {
 	let start = BatchProveStart {
 		batch_coeffs: Vec::new(),

--- a/crates/core/src/protocols/sumcheck/prove/batch_prove.rs
+++ b/crates/core/src/protocols/sumcheck/prove/batch_prove.rs
@@ -238,6 +238,7 @@ where
 	};
 
 	batch_prove_with_start(start, provers, transcript).map(|mut res| {
+		// Challenges must be reverted because folding happens in reverse order.  
 		res.challenges.reverse();
 		res
 	})

--- a/crates/core/src/protocols/sumcheck/prove/high_to_low_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/high_to_low_sumcheck.rs
@@ -96,8 +96,8 @@ where
 
 		let evaluation_points = domains
 			.iter()
-			.max_by_key(|domain| domain.points().len())
-			.map_or_else(|| Vec::new(), |domain| domain.points().to_vec());
+			.max_by_key(|domain| domain.size())
+			.map_or_else(|| Vec::new(), |domain| domain.finite_points().to_vec());
 
 		let state = ProverState::new_with_big_field(
 			multilinears,
@@ -144,7 +144,7 @@ where
 			})
 			.collect::<Vec<_>>();
 
-		let evals = self.state.hight_to_low_calculate_round_evals(&evaluators)?;
+		let evals = self.state.high_to_low_calculate_round_evals(&evaluators)?;
 		self.state
 			.calculate_round_coeffs_from_evals(&evaluators, batch_coeff, evals)
 	}

--- a/crates/core/src/protocols/sumcheck/prove/high_to_low_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/high_to_low_sumcheck.rs
@@ -19,7 +19,6 @@ use crate::{
 	protocols::sumcheck::{
 		common::{CompositeSumClaim, RoundCoeffs},
 		error::Error,
-		immediate_switchover_heuristic,
 		prove::prover_state::SumcheckInterpolator,
 	},
 };
@@ -145,11 +144,10 @@ where
 			.max_by_key(|domain| domain.points().len())
 			.map_or_else(|| Vec::new(), |domain| domain.points().to_vec());
 
-		let state = ProverState::new(
+		let state = ProverState::new_big_field(
 			multilinears,
 			claimed_sums,
 			evaluation_points,
-			immediate_switchover_heuristic,
 			backend,
 		)?;
 		let n_vars = state.n_vars();

--- a/crates/core/src/protocols/sumcheck/prove/high_to_low_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/high_to_low_sumcheck.rs
@@ -144,12 +144,8 @@ where
 			.max_by_key(|domain| domain.points().len())
 			.map_or_else(|| Vec::new(), |domain| domain.points().to_vec());
 
-		let state = ProverState::new_big_field(
-			multilinears,
-			claimed_sums,
-			evaluation_points,
-			backend,
-		)?;
+		let state =
+			ProverState::new_big_field(multilinears, claimed_sums, evaluation_points, backend)?;
 		let n_vars = state.n_vars();
 
 		Ok(Self {

--- a/crates/core/src/protocols/sumcheck/prove/high_to_low_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/high_to_low_sumcheck.rs
@@ -179,7 +179,7 @@ where
 
 	#[instrument("HighToLowSumcheckProver::fold", skip_all, level = "debug")]
 	fn fold(&mut self, challenge: F) -> Result<(), Error> {
-		self.state.fold(challenge)?;
+		self.state.high_to_low_fold(challenge)?;
 		Ok(())
 	}
 

--- a/crates/core/src/protocols/sumcheck/prove/high_to_low_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/high_to_low_sumcheck.rs
@@ -7,9 +7,9 @@ use binius_hal::{ComputationBackend, SumcheckEvaluator};
 use binius_math::{
 	CompositionPolyOS, EvaluationDomainFactory, InterpolationDomain, MultilinearPoly,
 };
+use binius_maybe_rayon::iter::{IntoParallelIterator, ParallelIterator};
 use binius_utils::bail;
 use itertools::izip;
-use rayon::prelude::*;
 use stackalloc::stackalloc_with_default;
 use tracing::instrument;
 

--- a/crates/core/src/protocols/sumcheck/prove/high_to_low_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/high_to_low_sumcheck.rs
@@ -1,0 +1,277 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use std::{marker::PhantomData, ops::Range};
+
+use binius_field::{ExtensionField, Field, PackedExtension, PackedField};
+use binius_hal::{ComputationBackend, SumcheckEvaluator};
+use binius_math::{
+	CompositionPolyOS, EvaluationDomainFactory, InterpolationDomain, MultilinearPoly,
+};
+use binius_utils::bail;
+use itertools::izip;
+use rayon::prelude::*;
+use stackalloc::stackalloc_with_default;
+use tracing::instrument;
+
+use super::{batch_prove::SumcheckProver, prover_state::ProverState};
+use crate::{
+	polynomial::{Error as PolynomialError, MultilinearComposite},
+	protocols::sumcheck::{
+		common::{CompositeSumClaim, RoundCoeffs},
+		error::Error,
+		immediate_switchover_heuristic,
+		prove::prover_state::SumcheckInterpolator,
+	},
+};
+
+pub fn validate_witness<'a, F, P, M, Composition>(
+	multilinears: &[M],
+	sum_claims: impl IntoIterator<Item = CompositeSumClaim<F, &'a Composition>>,
+) -> Result<(), Error>
+where
+	F: Field,
+	P: PackedField<Scalar = F>,
+	M: MultilinearPoly<P> + Send + Sync,
+	Composition: CompositionPolyOS<P> + 'a,
+{
+	let n_vars = multilinears
+		.first()
+		.map(|multilinear| multilinear.n_vars())
+		.unwrap_or_default();
+	for multilinear in multilinears.iter() {
+		if multilinear.n_vars() != n_vars {
+			bail!(Error::NumberOfVariablesMismatch);
+		}
+	}
+
+	let multilinears = multilinears.iter().collect::<Vec<_>>();
+
+	for (i, claim) in sum_claims.into_iter().enumerate() {
+		let CompositeSumClaim {
+			composition,
+			sum: expected_sum,
+			..
+		} = claim;
+		let witness = MultilinearComposite::new(n_vars, composition, multilinears.clone())?;
+		let sum = (0..(1 << n_vars))
+			.into_par_iter()
+			.map(|j| witness.evaluate_on_hypercube(j))
+			.try_reduce(|| F::ZERO, |a, b| Ok(a + b))?;
+
+		if sum != expected_sum {
+			bail!(Error::SumcheckNaiveValidationFailure {
+				composition_index: i,
+			});
+		}
+	}
+	Ok(())
+}
+
+pub struct HighToLowSumcheckProver<'a, FDomain, P, Composition, M, Backend>
+where
+	FDomain: Field,
+	P: PackedField,
+	M: MultilinearPoly<P> + Send + Sync,
+	Backend: ComputationBackend,
+{
+	n_vars: usize,
+	state: ProverState<'a, FDomain, P, M, Backend>,
+	compositions: Vec<Composition>,
+	domains: Vec<InterpolationDomain<FDomain>>,
+}
+
+impl<'a, F, FDomain, P, Composition, M, Backend>
+	HighToLowSumcheckProver<'a, FDomain, P, Composition, M, Backend>
+where
+	F: Field + ExtensionField<FDomain>,
+	FDomain: Field,
+	P: PackedField<Scalar = F> + PackedExtension<FDomain>,
+	Composition: CompositionPolyOS<P>,
+	M: MultilinearPoly<P> + Send + Sync,
+	Backend: ComputationBackend,
+{
+	#[instrument(skip_all, level = "debug", name = "HighToLowSumcheckProver::new")]
+	pub fn new(
+		multilinears: Vec<M>,
+		composite_claims: impl IntoIterator<Item = CompositeSumClaim<F, Composition>>,
+		evaluation_domain_factory: impl EvaluationDomainFactory<FDomain>,
+		backend: &'a Backend,
+	) -> Result<Self, Error> {
+		let composite_claims = composite_claims.into_iter().collect::<Vec<_>>();
+
+		#[cfg(feature = "debug_validate_sumcheck")]
+		{
+			let composite_claims = composite_claims
+				.iter()
+				.map(|x| CompositeSumClaim {
+					sum: x.sum,
+					composition: &x.composition,
+				})
+				.collect::<Vec<_>>();
+			validate_witness(&multilinears, composite_claims)?;
+		}
+
+		for claim in composite_claims.iter() {
+			if claim.composition.n_vars() != multilinears.len() {
+				bail!(Error::InvalidComposition {
+					actual: claim.composition.n_vars(),
+					expected: multilinears.len(),
+				});
+			}
+		}
+
+		let claimed_sums = composite_claims
+			.iter()
+			.map(|composite_claim| composite_claim.sum)
+			.collect();
+
+		let domains = composite_claims
+			.iter()
+			.map(|composite_claim| {
+				let degree = composite_claim.composition.degree();
+				let domain = evaluation_domain_factory.create(degree + 1)?;
+				Ok(domain.into())
+			})
+			.collect::<Result<Vec<InterpolationDomain<FDomain>>, _>>()
+			.map_err(Error::MathError)?;
+
+		let compositions = composite_claims
+			.into_iter()
+			.map(|claim| claim.composition)
+			.collect();
+
+		let evaluation_points = domains
+			.iter()
+			.max_by_key(|domain| domain.points().len())
+			.map_or_else(|| Vec::new(), |domain| domain.points().to_vec());
+
+		let state = ProverState::new(
+			multilinears,
+			claimed_sums,
+			evaluation_points,
+			immediate_switchover_heuristic,
+			backend,
+		)?;
+		let n_vars = state.n_vars();
+
+		Ok(Self {
+			n_vars,
+			state,
+			compositions,
+			domains,
+		})
+	}
+}
+
+impl<F, FDomain, P, Composition, M, Backend> SumcheckProver<F>
+	for HighToLowSumcheckProver<'_, FDomain, P, Composition, M, Backend>
+where
+	F: Field + ExtensionField<FDomain>,
+	FDomain: Field,
+	P: PackedField<Scalar = F> + PackedExtension<FDomain>,
+	Composition: CompositionPolyOS<P>,
+	M: MultilinearPoly<P> + Send + Sync,
+	Backend: ComputationBackend,
+{
+	fn n_vars(&self) -> usize {
+		self.n_vars
+	}
+
+	#[instrument("HighToLowSumcheckProver::fold", skip_all, level = "debug")]
+	fn fold(&mut self, challenge: F) -> Result<(), Error> {
+		self.state.fold(challenge)?;
+		Ok(())
+	}
+
+	#[instrument("HighToLowSumcheckProver::execute", skip_all, level = "debug")]
+	fn execute(&mut self, batch_coeff: F) -> Result<RoundCoeffs<F>, Error> {
+		let evaluators = izip!(&self.compositions, &self.domains)
+			.map(|(composition, interpolation_domain)| RegularSumcheckEvaluator {
+				composition,
+				interpolation_domain,
+				_marker: PhantomData,
+			})
+			.collect::<Vec<_>>();
+
+		let evals = self
+			.state
+			.hight_to_low_calculate_later_round_evals(&evaluators)?;
+		self.state
+			.calculate_round_coeffs_from_evals(&evaluators, batch_coeff, evals)
+	}
+
+	fn finish(self: Box<Self>) -> Result<Vec<F>, Error> {
+		self.state.finish()
+	}
+}
+
+struct RegularSumcheckEvaluator<'a, P, FDomain, Composition>
+where
+	P: PackedField,
+	FDomain: Field,
+{
+	composition: &'a Composition,
+	interpolation_domain: &'a InterpolationDomain<FDomain>,
+	_marker: PhantomData<P>,
+}
+
+impl<F, P, FDomain, Composition> SumcheckEvaluator<P, P, Composition>
+	for RegularSumcheckEvaluator<'_, P, FDomain, Composition>
+where
+	F: Field + ExtensionField<FDomain>,
+	P: PackedField<Scalar = F> + PackedExtension<FDomain>,
+	FDomain: Field,
+	Composition: CompositionPolyOS<P>,
+{
+	fn eval_point_indices(&self) -> Range<usize> {
+		// NB: We skip evaluation of $r(X)$ at $X = 0$ as it is derivable from the
+		// current_round_sum - $r(1)$.
+		1..self.composition.degree() + 1
+	}
+
+	fn process_subcube_at_eval_point(
+		&self,
+		_subcube_vars: usize,
+		_subcube_index: usize,
+		batch_query: &[&[P]],
+	) -> P {
+		let row_len = batch_query.first().map_or(0, |row| row.len());
+
+		stackalloc_with_default(row_len, |evals| {
+			self.composition
+				.batch_evaluate(batch_query, evals)
+				.expect("correct by query construction invariant");
+
+			evals.iter().copied().sum()
+		})
+	}
+
+	fn composition(&self) -> &Composition {
+		self.composition
+	}
+
+	fn eq_ind_partial_eval(&self) -> Option<&[P]> {
+		None
+	}
+}
+
+impl<F, P, FDomain, Composition> SumcheckInterpolator<F>
+	for RegularSumcheckEvaluator<'_, P, FDomain, Composition>
+where
+	F: Field + ExtensionField<FDomain>,
+	P: PackedField<Scalar = F> + PackedExtension<FDomain>,
+	FDomain: Field,
+{
+	fn round_evals_to_coeffs(
+		&self,
+		last_round_sum: F,
+		mut round_evals: Vec<F>,
+	) -> Result<Vec<F>, PolynomialError> {
+		// Given $r(1), \ldots, r(d+1)$, letting $s$ be the current round's claimed sum,
+		// we can compute $r(0)$ using the identity $r(0) = s - r(1)$
+		round_evals.insert(0, last_round_sum - round_evals[0]);
+
+		let coeffs = self.interpolation_domain.interpolate(&round_evals)?;
+		Ok(coeffs)
+	}
+}

--- a/crates/core/src/protocols/sumcheck/prove/mod.rs
+++ b/crates/core/src/protocols/sumcheck/prove/mod.rs
@@ -4,13 +4,16 @@ mod batch_prove;
 mod batch_prove_univariate_zerocheck;
 pub(crate) mod common;
 pub mod front_loaded;
+pub mod high_to_low_sumcheck;
 pub mod oracles;
 pub mod prover_state;
 pub mod regular_sumcheck;
 pub mod univariate;
 pub mod zerocheck;
 
-pub use batch_prove::{batch_prove, batch_prove_with_start, SumcheckProver};
+pub use batch_prove::{
+	batch_prove, batch_prove_with_start, high_to_low_batch_prove, SumcheckProver,
+};
 pub use batch_prove_univariate_zerocheck::{
 	batch_prove_zerocheck_univariate_round, UnivariateZerocheckProver,
 };

--- a/crates/core/src/protocols/sumcheck/prove/prover_state.rs
+++ b/crates/core/src/protocols/sumcheck/prove/prover_state.rs
@@ -131,8 +131,10 @@ where
 		})
 	}
 
+	/// Create a prover state for the case when we work with big fields from the first round.  
+	/// This allows us to avoid using a non-optimal folding in the first round.
 	#[instrument(skip_all, level = "debug", name = "ProverState::new_big_field")]
-	pub fn new_big_field(
+	pub fn new_with_big_field(
 		multilinears: Vec<M>,
 		claimed_sums: Vec<F>,
 		evaluation_points: Vec<FDomain>,
@@ -377,25 +379,23 @@ where
 		)?)
 	}
 
-	/// Calculate the accumulated evaluations for an arbitrary sumcheck round.
+	/// Calculate the accumulated evaluations for an arbitrary high to low sumcheck round.
 	#[instrument(skip_all, level = "debug")]
-	pub fn hight_to_low_calculate_later_round_evals<Evaluator, Composition>(
+	pub fn hight_to_low_calculate_round_evals<Evaluator, Composition>(
 		&self,
 		evaluators: &[Evaluator],
 	) -> Result<Vec<RoundEvals<F>>, Error>
 	where
-		Evaluator: SumcheckEvaluator<P, P, Composition> + Sync,
+		Evaluator: SumcheckEvaluator<F, P, Composition> + Sync,
 		Composition: CompositionPolyOS<P>,
 	{
-		Ok(self
-			.backend
-			.high_to_low_sumcheck_compute_later_round_evals(
-				self.n_vars,
-				self.tensor_query.as_ref().map(Into::into),
-				&self.multilinears,
-				evaluators,
-				&self.evaluation_points,
-			)?)
+		Ok(self.backend.high_to_low_sumcheck_compute_round_evals(
+			self.n_vars,
+			self.tensor_query.as_ref().map(Into::into),
+			&self.multilinears,
+			evaluators,
+			&self.evaluation_points,
+		)?)
 	}
 
 	/// Calculate the batched round coefficients from the domain evaluations.

--- a/crates/core/src/protocols/sumcheck/prove/prover_state.rs
+++ b/crates/core/src/protocols/sumcheck/prove/prover_state.rs
@@ -308,7 +308,7 @@ where
 					SumcheckMultilinear::Folded {
 						ref mut large_field_folded_multilinear,
 					} => {
-						// Post-switchover, simply plug in challenge for the zeroth variable.
+						// Post-switchover, simply plug in challenge for the last variable.
 						*large_field_folded_multilinear = MLEDirectAdapter::from(
 							large_field_folded_multilinear.evaluate_last_variable(challenge)?,
 						);
@@ -381,12 +381,12 @@ where
 
 	/// Calculate the accumulated evaluations for an arbitrary high to low sumcheck round.
 	#[instrument(skip_all, level = "debug")]
-	pub fn hight_to_low_calculate_round_evals<Evaluator, Composition>(
+	pub fn high_to_low_calculate_round_evals<Evaluator, Composition>(
 		&self,
 		evaluators: &[Evaluator],
 	) -> Result<Vec<RoundEvals<F>>, Error>
 	where
-		Evaluator: SumcheckEvaluator<F, P, Composition> + Sync,
+		Evaluator: SumcheckEvaluator<P, Composition> + Sync,
 		Composition: CompositionPolyOS<P>,
 	{
 		Ok(self.backend.high_to_low_sumcheck_compute_round_evals(

--- a/crates/core/src/protocols/sumcheck/prove/prover_state.rs
+++ b/crates/core/src/protocols/sumcheck/prove/prover_state.rs
@@ -354,13 +354,15 @@ where
 		Evaluator: SumcheckEvaluator<P, P, Composition> + Sync,
 		Composition: CompositionPolyOS<P>,
 	{
-		Ok(self.backend.sumcheck_compute_later_round_evals(
-			self.n_vars,
-			self.tensor_query.as_ref().map(Into::into),
-			&self.multilinears,
-			evaluators,
-			&self.evaluation_points,
-		)?)
+		Ok(self
+			.backend
+			.high_to_low_sumcheck_compute_later_round_evals(
+				self.n_vars,
+				self.tensor_query.as_ref().map(Into::into),
+				&self.multilinears,
+				evaluators,
+				&self.evaluation_points,
+			)?)
 	}
 
 	/// Calculate the batched round coefficients from the domain evaluations.

--- a/crates/core/src/protocols/sumcheck/prove/prover_state.rs
+++ b/crates/core/src/protocols/sumcheck/prove/prover_state.rs
@@ -131,11 +131,7 @@ where
 		})
 	}
 
-	#[instrument(
-		skip_all,
-		level = "debug",
-		name = "ProverState::new_with_switchover_rounds"
-	)]
+	#[instrument(skip_all, level = "debug", name = "ProverState::new_big_field")]
 	pub fn new_big_field(
 		multilinears: Vec<M>,
 		claimed_sums: Vec<F>,

--- a/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
@@ -213,7 +213,7 @@ where
 	_marker: PhantomData<P>,
 }
 
-impl<'a, P, FDomain, Composition> RegularSumcheckEvaluator<'_, P, FDomain, Composition>
+impl<'a, P, FDomain, Composition> RegularSumcheckEvaluator<'a, P, FDomain, Composition>
 where
 	P: PackedField,
 	FDomain: Field,

--- a/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
@@ -218,7 +218,7 @@ where
 	P: PackedField,
 	FDomain: Field,
 {
-	pub fn new(
+	pub const fn new(
 		composition: &'a Composition,
 		interpolation_domain: &'a InterpolationDomain<FDomain>,
 	) -> Self {

--- a/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
@@ -203,7 +203,7 @@ where
 	}
 }
 
-struct RegularSumcheckEvaluator<'a, P, FDomain, Composition>
+pub struct RegularSumcheckEvaluator<'a, P, FDomain, Composition>
 where
 	P: PackedField,
 	FDomain: Field,
@@ -211,6 +211,23 @@ where
 	composition: &'a Composition,
 	interpolation_domain: &'a InterpolationDomain<FDomain>,
 	_marker: PhantomData<P>,
+}
+
+impl<'a, P, FDomain, Composition> RegularSumcheckEvaluator<'_, P, FDomain, Composition>
+where
+	P: PackedField,
+	FDomain: Field,
+{
+	pub fn new(
+		composition: &'a Composition,
+		interpolation_domain: &'a InterpolationDomain<FDomain>,
+	) -> Self {
+		Self {
+			composition,
+			interpolation_domain,
+			_marker: PhantomData,
+		}
+	}
 }
 
 impl<F, P, FDomain, Composition> SumcheckEvaluator<P, Composition>

--- a/crates/core/src/protocols/sumcheck/tests.rs
+++ b/crates/core/src/protocols/sumcheck/tests.rs
@@ -40,7 +40,10 @@ use crate::{
 	fiat_shamir::{CanSample, HasherChallenger},
 	polynomial::{IdentityCompositionPoly, MultilinearComposite},
 	protocols::{
-		sumcheck::prove::{high_to_low_sumcheck::HighToLowSumcheckProver, SumcheckProver},
+		sumcheck::{
+			prove::{high_to_low_sumcheck::HighToLowSumcheckProver, SumcheckProver},
+			verify::high_to_low_batch_verify,
+		},
 		test_utils::{AddOneComposition, TestProductComposition},
 	},
 	transcript::ProverTranscript,
@@ -296,7 +299,8 @@ where
 
 	let prover_sample = CanSample::<P::Scalar>::sample(&mut prover_transcript);
 	let mut verifier_transcript = prover_transcript.into_reader();
-	let verifier_reduced_claims = batch_verify(&[claim], &mut verifier_transcript).unwrap();
+	let verifier_reduced_claims =
+		high_to_low_batch_verify(&[claim], &mut verifier_transcript).unwrap();
 
 	// Check that challengers are in the same state
 	assert_eq!(prover_sample, CanSample::<P::Scalar>::sample(&mut verifier_transcript));
@@ -322,10 +326,22 @@ where
 }
 
 #[test]
-pub fn test_prove_verify_high_to_low() {
+pub fn test_prove_verify_high_to_low_byte_sliced() {
 	for n_vars in 2..8 {
 		for n_multilinears in 1..4 {
 			test_high_to_low_prove_verify_product_helper::<ByteSlicedAES32x8b, AESTowerField8b>(
+				n_vars,
+				n_multilinears,
+			);
+		}
+	}
+}
+
+#[test]
+pub fn test_prove_verify_high_to_low() {
+	for n_vars in 2..8 {
+		for n_multilinears in 1..4 {
+			test_high_to_low_prove_verify_product_helper::<BinaryField128b, BinaryField8b>(
 				n_vars,
 				n_multilinears,
 			);

--- a/crates/core/src/protocols/sumcheck/tests.rs
+++ b/crates/core/src/protocols/sumcheck/tests.rs
@@ -254,10 +254,10 @@ fn test_sumcheck_prove_verify_with_nontrivial_packing() {
 	>(n_vars, n_multilinears, switchover_rd);
 }
 
-fn test_high_to_low_prove_verify_product_helper<P, FDomain>(n_vars: usize, n_multilinears: usize)
+fn test_high_to_low_prove_verify_product_helper<F, P, FDomain>(n_vars: usize, n_multilinears: usize)
 where
-	P: PackedField + PackedExtension<FDomain>,
-	P::Scalar: TowerField + ExtensionField<FDomain>,
+	P: PackedField<Scalar = F> + PackedExtension<F, PackedSubfield = P> + PackedExtension<FDomain>,
+	F: TowerField + ExtensionField<FDomain>,
 	FDomain: BinaryField,
 {
 	let mut rng = StdRng::seed_from_u64(0);
@@ -329,7 +329,7 @@ where
 pub fn test_prove_verify_high_to_low_byte_sliced_8b() {
 	for n_vars in 2..8 {
 		for n_multilinears in 1..4 {
-			test_high_to_low_prove_verify_product_helper::<ByteSlicedAES32x8b, AESTowerField8b>(
+			test_high_to_low_prove_verify_product_helper::<_, ByteSlicedAES32x8b, AESTowerField8b>(
 				n_vars,
 				n_multilinears,
 			);
@@ -341,7 +341,7 @@ pub fn test_prove_verify_high_to_low_byte_sliced_8b() {
 pub fn test_prove_verify_high_to_low_byte_sliced_128b() {
 	for n_vars in 2..8 {
 		for n_multilinears in 1..4 {
-			test_high_to_low_prove_verify_product_helper::<ByteSlicedAES32x128b, AESTowerField8b>(
+			test_high_to_low_prove_verify_product_helper::<_, ByteSlicedAES32x128b, AESTowerField8b>(
 				n_vars,
 				n_multilinears,
 			);
@@ -353,10 +353,11 @@ pub fn test_prove_verify_high_to_low_byte_sliced_128b() {
 pub fn test_prove_verify_high_to_low() {
 	for n_vars in 2..8 {
 		for n_multilinears in 1..4 {
-			test_high_to_low_prove_verify_product_helper::<BinaryField128b, BinaryField8b>(
-				n_vars,
-				n_multilinears,
-			);
+			test_high_to_low_prove_verify_product_helper::<
+				BinaryField128b,
+				PackedBinaryField1x128b,
+				BinaryField8b,
+			>(n_vars, n_multilinears);
 		}
 	}
 }

--- a/crates/core/src/protocols/sumcheck/verify.rs
+++ b/crates/core/src/protocols/sumcheck/verify.rs
@@ -188,6 +188,7 @@ where
 	};
 
 	batch_verify_with_start(start, claims, transcript).map(|mut res| {
+		// Challenges must be reverted because folding happens in reverse order.  
 		res.challenges.reverse();
 		res
 	})

--- a/crates/core/src/protocols/sumcheck/verify.rs
+++ b/crates/core/src/protocols/sumcheck/verify.rs
@@ -171,6 +171,28 @@ where
 	})
 }
 
+pub fn high_to_low_batch_verify<F, Composition, Transcript>(
+	claims: &[SumcheckClaim<F, Composition>],
+	transcript: &mut Transcript,
+) -> Result<BatchSumcheckOutput<F>, Error>
+where
+	F: TowerField,
+	Composition: CompositionPolyOS<F>,
+	Transcript: CanSample<F> + CanRead,
+{
+	let start = BatchVerifyStart {
+		batch_coeffs: Vec::new(),
+		sum: F::ZERO,
+		max_degree: 0,
+		skip_rounds: 0,
+	};
+
+	batch_verify_with_start(start, claims, transcript).map(|mut res| {
+		res.challenges.reverse();
+		res
+	})
+}
+
 pub fn compute_expected_batch_composite_evaluation_single_claim<F: Field, Composition>(
 	batch_coeff: F,
 	claim: &SumcheckClaim<F, Composition>,

--- a/crates/core/src/protocols/sumcheck/verify.rs
+++ b/crates/core/src/protocols/sumcheck/verify.rs
@@ -171,14 +171,14 @@ where
 	})
 }
 
-pub fn high_to_low_batch_verify<F, Composition, Transcript>(
+pub fn high_to_low_batch_verify<F, Composition, Challenger_>(
 	claims: &[SumcheckClaim<F, Composition>],
-	transcript: &mut Transcript,
+	transcript: &mut VerifierTranscript<Challenger_>,
 ) -> Result<BatchSumcheckOutput<F>, Error>
 where
 	F: TowerField,
 	Composition: CompositionPolyOS<F>,
-	Transcript: CanSample<F> + CanRead,
+	Challenger_: Challenger,
 {
 	let start = BatchVerifyStart {
 		batch_coeffs: Vec::new(),

--- a/crates/core/src/protocols/sumcheck/verify.rs
+++ b/crates/core/src/protocols/sumcheck/verify.rs
@@ -188,7 +188,7 @@ where
 	};
 
 	batch_verify_with_start(start, claims, transcript).map(|mut res| {
-		// Challenges must be reverted because folding happens in reverse order.  
+		// Challenges must be reverted because folding happens in reverse order.
 		res.challenges.reverse();
 		res
 	})

--- a/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
+++ b/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
@@ -56,16 +56,9 @@ macro_rules! define_byte_sliced {
 			const LOG_WIDTH: usize = 5;
 
 			unsafe fn get_unchecked(&self, i: usize) -> Self::Scalar {
-				let mut result_underlier = 0;
-				for (byte_index, val) in self.data.iter().enumerate() {
-					// Safety:
-					// - `byte_index` is less than 16
-					// - `i` must be less than 32 due to safety conditions of this method
-					unsafe {
-						result_underlier
-							.set_subvalue(byte_index, val.get_unchecked(i).to_underlier())
-					}
-				}
+				let result_underlier = <Self::Scalar as WithUnderlier>::Underlier::from_fn(|j| {
+					self.data[j].get_unchecked(i).to_underlier()
+				});
 
 				Self::Scalar::from_underlier(result_underlier)
 			}

--- a/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
+++ b/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
@@ -472,7 +472,6 @@ macro_rules! define_8b_extension_packed_subfield_for_byte_sliced {
 	};
 }
 
-
 define_8b_extension_packed_subfield_for_byte_sliced!(
 	_ByteSlicedAES512x8b,
 	16,

--- a/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
+++ b/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
@@ -308,6 +308,9 @@ macro_rules! define_byte_sliced {
 				base
 			}
 		}
+
+		unsafe impl bytemuck::NoUninit for $name {}
+		unsafe impl bytemuck::AnyBitPattern for $name {}
 	};
 }
 
@@ -316,3 +319,335 @@ define_byte_sliced!(ByteSlicedAES32x64b, AESTowerField64b, TowerLevel8);
 define_byte_sliced!(ByteSlicedAES32x32b, AESTowerField32b, TowerLevel4);
 define_byte_sliced!(ByteSlicedAES32x16b, AESTowerField16b, TowerLevel2);
 define_byte_sliced!(ByteSlicedAES32x8b, AESTowerField8b, TowerLevel1);
+
+macro_rules! define_8b_extension_packed_subfield_for_byte_sliced {
+	($name:ident, $data_width:expr, $log_width:expr, $original_byte_sliced:ty) => {
+		#[derive(Default, Clone, Debug, Copy, PartialEq, Eq, Zeroable)]
+		pub struct $name {
+			pub(super) data: [PackedAESBinaryField32x8b; $data_width],
+		}
+
+		impl $name {
+			pub const BYTES: usize = PackedAESBinaryField32x8b::WIDTH * $data_width;
+
+			/// Get the byte at the given index.
+			///
+			/// # Safety
+			/// The caller must ensure that `byte_index` is less than `BYTES`.
+			#[allow(clippy::modulo_one)]
+			pub unsafe fn get_byte_unchecked(&self, byte_index: usize) -> u8 {
+				self.data[byte_index % $data_width]
+					.get(byte_index / $data_width)
+					.to_underlier()
+			}
+		}
+
+		impl PackedField for $name {
+			type Scalar = AESTowerField8b;
+
+			const LOG_WIDTH: usize = $log_width;
+
+			unsafe fn get_unchecked(&self, i: usize) -> Self::Scalar {
+				self.data
+					.get_unchecked(i % $data_width)
+					.get_unchecked(i % $data_width)
+			}
+
+			unsafe fn set_unchecked(&mut self, i: usize, scalar: Self::Scalar) {
+				self.data
+					.get_unchecked_mut(i / $data_width)
+					.set_unchecked(i % $data_width, scalar);
+			}
+
+			fn random(mut rng: impl rand::RngCore) -> Self {
+				Self::from_scalars(std::iter::repeat_with(|| Self::Scalar::random(&mut rng)))
+			}
+
+			fn broadcast(scalar: Self::Scalar) -> Self {
+				let column = PackedAESBinaryField32x8b::broadcast(scalar);
+				Self {
+					data: [column; $data_width],
+				}
+			}
+
+			fn from_fn(mut f: impl FnMut(usize) -> Self::Scalar) -> Self {
+				let mut result = Self::default();
+
+				for i in 0..Self::WIDTH {
+					//SAFETY: i doesn't exceed Self::WIDTH
+					unsafe { result.set_unchecked(i, f(i)) };
+				}
+
+				result
+			}
+
+			fn square(self) -> Self {
+				Self {
+					data: array::from_fn(|i| self.data[i].square()),
+				}
+			}
+
+			fn invert_or_zero(self) -> Self {
+				Self {
+					data: array::from_fn(|i| self.data[i].invert_or_zero()),
+				}
+			}
+
+			fn interleave(self, other: Self, log_block_len: usize) -> (Self, Self) {
+				let mut result1 = Self::default();
+				let mut result2 = Self::default();
+
+				for byte_num in 0..$data_width {
+					let (this_byte_result1, this_byte_result2) =
+						self.data[byte_num].interleave(other.data[byte_num], log_block_len);
+
+					result1.data[byte_num] = this_byte_result1;
+					result2.data[byte_num] = this_byte_result2;
+				}
+
+				(result1, result2)
+			}
+		}
+
+		impl Add for $name {
+			type Output = Self;
+
+			fn add(self, rhs: Self) -> Self {
+				Self {
+					data: array::from_fn(|byte_number| {
+						self.data[byte_number] + rhs.data[byte_number]
+					}),
+				}
+			}
+		}
+
+		impl Add<AESTowerField8b> for $name {
+			type Output = Self;
+
+			fn add(self, rhs: AESTowerField8b) -> $name {
+				self + Self::broadcast(rhs)
+			}
+		}
+
+		impl AddAssign for $name {
+			fn add_assign(&mut self, rhs: Self) {
+				for (data, rhs) in zip(&mut self.data, &rhs.data) {
+					*data += *rhs
+				}
+			}
+		}
+
+		impl AddAssign<AESTowerField8b> for $name {
+			fn add_assign(&mut self, rhs: AESTowerField8b) {
+				*self += Self::broadcast(rhs)
+			}
+		}
+
+		impl Sub for $name {
+			type Output = Self;
+
+			fn sub(self, rhs: Self) -> Self {
+				self.add(rhs)
+			}
+		}
+
+		impl Sub<AESTowerField8b> for $name {
+			type Output = Self;
+
+			fn sub(self, rhs: AESTowerField8b) -> $name {
+				self.add(rhs)
+			}
+		}
+
+		impl SubAssign for $name {
+			fn sub_assign(&mut self, rhs: Self) {
+				self.add_assign(rhs);
+			}
+		}
+
+		impl SubAssign<AESTowerField8b> for $name {
+			fn sub_assign(&mut self, rhs: AESTowerField8b) {
+				self.add_assign(rhs)
+			}
+		}
+
+		impl Mul for $name {
+			type Output = Self;
+
+			fn mul(self, rhs: Self) -> Self {
+				Self {
+					data: array::from_fn(|byte_number| {
+						self.data[byte_number] * rhs.data[byte_number]
+					}),
+				}
+			}
+		}
+
+		impl Mul<AESTowerField8b> for $name {
+			type Output = Self;
+
+			fn mul(self, rhs: AESTowerField8b) -> $name {
+				self * Self::broadcast(rhs)
+			}
+		}
+
+		impl MulAssign for $name {
+			fn mul_assign(&mut self, rhs: Self) {
+				*self = *self * rhs;
+			}
+		}
+
+		impl MulAssign<AESTowerField8b> for $name {
+			fn mul_assign(&mut self, rhs: AESTowerField8b) {
+				*self *= Self::broadcast(rhs);
+			}
+		}
+
+		impl Product for $name {
+			fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
+				let mut result = Self::one();
+
+				let mut is_first_item = true;
+				for item in iter {
+					if is_first_item {
+						result = item;
+					} else {
+						result *= item;
+					}
+
+					is_first_item = false;
+				}
+
+				result
+			}
+		}
+
+		impl Sum for $name {
+			fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+				let mut result = Self::zero();
+
+				for item in iter {
+					result += item;
+				}
+
+				result
+			}
+		}
+
+		impl PackedExtension<AESTowerField8b> for $name {
+			type PackedSubfield = Self;
+
+			fn cast_bases(packed: &[Self]) -> &[Self::PackedSubfield] {
+				packed
+			}
+
+			fn cast_bases_mut(packed: &mut [Self]) -> &mut [Self::PackedSubfield] {
+				packed
+			}
+
+			fn cast_exts(packed: &[Self::PackedSubfield]) -> &[Self] {
+				packed
+			}
+
+			fn cast_exts_mut(packed: &mut [Self::PackedSubfield]) -> &mut [Self] {
+				packed
+			}
+
+			fn cast_base(self) -> Self::PackedSubfield {
+				self
+			}
+
+			fn cast_base_ref(&self) -> &Self::PackedSubfield {
+				self
+			}
+
+			fn cast_base_mut(&mut self) -> &mut Self::PackedSubfield {
+				self
+			}
+
+			fn cast_ext(base: Self::PackedSubfield) -> Self {
+				base
+			}
+
+			fn cast_ext_ref(base: &Self::PackedSubfield) -> &Self {
+				base
+			}
+
+			fn cast_ext_mut(base: &mut Self::PackedSubfield) -> &mut Self {
+				base
+			}
+		}
+
+		unsafe impl bytemuck::NoUninit for $name {}
+		unsafe impl bytemuck::AnyBitPattern for $name {}
+
+		impl PackedExtension<AESTowerField8b> for $original_byte_sliced {
+			type PackedSubfield = $name;
+
+			fn cast_bases(packed: &[Self]) -> &[Self::PackedSubfield] {
+				bytemuck::must_cast_slice(packed)
+			}
+
+			fn cast_bases_mut(packed: &mut [Self]) -> &mut [Self::PackedSubfield] {
+				bytemuck::must_cast_slice_mut(packed)
+			}
+
+			fn cast_exts(packed: &[Self::PackedSubfield]) -> &[Self] {
+				bytemuck::must_cast_slice(packed)
+			}
+
+			fn cast_exts_mut(packed: &mut [Self::PackedSubfield]) -> &mut [Self] {
+				bytemuck::must_cast_slice_mut(packed)
+			}
+
+			fn cast_base(self) -> Self::PackedSubfield {
+				Self::PackedSubfield { data: self.data }
+			}
+
+			fn cast_base_ref(&self) -> &Self::PackedSubfield {
+				bytemuck::must_cast_ref(self)
+			}
+
+			fn cast_base_mut(&mut self) -> &mut Self::PackedSubfield {
+				bytemuck::must_cast_mut(self)
+			}
+
+			fn cast_ext(base: Self::PackedSubfield) -> Self {
+				Self { data: base.data }
+			}
+
+			fn cast_ext_ref(base: &Self::PackedSubfield) -> &Self {
+				bytemuck::must_cast_ref(base)
+			}
+
+			fn cast_ext_mut(base: &mut Self::PackedSubfield) -> &mut Self {
+				bytemuck::must_cast_mut(base)
+			}
+		}
+	};
+}
+
+define_8b_extension_packed_subfield_for_byte_sliced!(
+	_ByteSlicedAES512x8b,
+	16,
+	9,
+	ByteSlicedAES32x128b
+);
+define_8b_extension_packed_subfield_for_byte_sliced!(
+	_ByteSlicedAES256x8b,
+	8,
+	8,
+	ByteSlicedAES32x64b
+);
+define_8b_extension_packed_subfield_for_byte_sliced!(
+	_ByteSlicedAES128x8b,
+	4,
+	7,
+	ByteSlicedAES32x32b
+);
+define_8b_extension_packed_subfield_for_byte_sliced!(
+	_ByteSlicedAES64x8b,
+	2,
+	6,
+	ByteSlicedAES32x16b
+);

--- a/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
+++ b/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
@@ -322,6 +322,8 @@ define_byte_sliced!(ByteSlicedAES32x8b, AESTowerField8b, TowerLevel1);
 
 macro_rules! define_8b_extension_packed_subfield_for_byte_sliced {
 	($name:ident, $data_width:expr, $original_byte_sliced:ty) => {
+		#[doc = concat!("This is a PackedFields helper that is used like a PackedSubfield of [`PackedExtension<AESTowerField8b>`] for [`", stringify!($original_byte_sliced), "`]")]
+		/// and has no particular meaning outside of this purpose.
 		#[derive(Default, Clone, Debug, Copy, PartialEq, Eq, Zeroable)]
 		pub struct $name {
 			pub(super) data: [PackedAESBinaryField32x8b; $data_width],
@@ -469,6 +471,7 @@ macro_rules! define_8b_extension_packed_subfield_for_byte_sliced {
 		}
 	};
 }
+
 
 define_8b_extension_packed_subfield_for_byte_sliced!(
 	_ByteSlicedAES512x8b,

--- a/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
+++ b/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
@@ -15,7 +15,7 @@ use crate::{
 	tower_levels::*,
 	underlier::{UnderlierWithBitOps, WithUnderlier},
 	AESTowerField128b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField8b,
-	PackedField,
+	PackedExtension, PackedField,
 };
 
 /// Represents 32 AES Tower Field elements in byte-sliced form backed by Packed 32x8b AES fields.
@@ -262,6 +262,50 @@ macro_rules! define_byte_sliced {
 				}
 
 				result
+			}
+		}
+
+		impl PackedExtension<$scalar_type> for $name {
+			type PackedSubfield = Self;
+
+			fn cast_bases(packed: &[Self]) -> &[Self::PackedSubfield] {
+				packed
+			}
+
+			fn cast_bases_mut(packed: &mut [Self]) -> &mut [Self::PackedSubfield] {
+				packed
+			}
+
+			fn cast_exts(packed: &[Self::PackedSubfield]) -> &[Self] {
+				packed
+			}
+
+			fn cast_exts_mut(packed: &mut [Self::PackedSubfield]) -> &mut [Self] {
+				packed
+			}
+
+			fn cast_base(self) -> Self::PackedSubfield {
+				self
+			}
+
+			fn cast_base_ref(&self) -> &Self::PackedSubfield {
+				self
+			}
+
+			fn cast_base_mut(&mut self) -> &mut Self::PackedSubfield {
+				self
+			}
+
+			fn cast_ext(base: Self::PackedSubfield) -> Self {
+				base
+			}
+
+			fn cast_ext_ref(base: &Self::PackedSubfield) -> &Self {
+				base
+			}
+
+			fn cast_ext_mut(base: &mut Self::PackedSubfield) -> &mut Self {
+				base
 			}
 		}
 	};

--- a/crates/hal/src/backend.rs
+++ b/crates/hal/src/backend.rs
@@ -136,11 +136,11 @@ where
 
 	fn high_to_low_sumcheck_compute_later_round_evals<FDomain, F, P, M, Evaluator, Composition>(
 		&self,
-		n_vars: usize,
-		tensor_query: Option<MultilinearQueryRef<P>>,
-		multilinears: &[SumcheckMultilinear<P, M>],
-		evaluators: &[Evaluator],
-		evaluation_points: &[FDomain],
+		_n_vars: usize,
+		_tensor_query: Option<MultilinearQueryRef<P>>,
+		_multilinears: &[SumcheckMultilinear<P, M>],
+		_evaluators: &[Evaluator],
+		_evaluation_points: &[FDomain],
 	) -> Result<Vec<RoundEvals<P::Scalar>>, Error>
 	where
 		FDomain: Field,

--- a/crates/hal/src/backend.rs
+++ b/crates/hal/src/backend.rs
@@ -58,6 +58,22 @@ pub trait ComputationBackend: Send + Sync + Debug {
 		Evaluator: SumcheckEvaluator<P, Composition> + Sync,
 		Composition: CompositionPolyOS<P>;
 
+	fn high_to_low_sumcheck_compute_later_round_evals<FDomain, F, P, M, Evaluator, Composition>(
+		&self,
+		n_vars: usize,
+		tensor_query: Option<MultilinearQueryRef<P>>,
+		multilinears: &[SumcheckMultilinear<P, M>],
+		evaluators: &[Evaluator],
+		evaluation_points: &[FDomain],
+	) -> Result<Vec<RoundEvals<P::Scalar>>, Error>
+	where
+		FDomain: Field,
+		F: Field + ExtensionField<FDomain>,
+		P: PackedField<Scalar = F> + PackedExtension<FDomain>,
+		M: MultilinearPoly<P> + Send + Sync,
+		Evaluator: SumcheckEvaluator<P, P, Composition> + Sync,
+		Composition: CompositionPolyOS<P>;
+
 	/// Partially evaluate the polynomial with assignment to the high-indexed variables.
 	fn evaluate_partial_high<P: PackedField>(
 		&self,
@@ -116,6 +132,25 @@ where
 		query_expansion: MultilinearQueryRef<P>,
 	) -> Result<MultilinearExtension<P>, Error> {
 		T::evaluate_partial_high(self, multilinear, query_expansion)
+	}
+
+	fn high_to_low_sumcheck_compute_later_round_evals<FDomain, F, P, M, Evaluator, Composition>(
+		&self,
+		n_vars: usize,
+		tensor_query: Option<MultilinearQueryRef<P>>,
+		multilinears: &[SumcheckMultilinear<P, M>],
+		evaluators: &[Evaluator],
+		evaluation_points: &[FDomain],
+	) -> Result<Vec<RoundEvals<P::Scalar>>, Error>
+	where
+		FDomain: Field,
+		F: Field + ExtensionField<FDomain>,
+		P: PackedField<Scalar = F> + PackedExtension<FDomain>,
+		M: MultilinearPoly<P> + Send + Sync,
+		Evaluator: SumcheckEvaluator<P, P, Composition> + Sync,
+		Composition: CompositionPolyOS<P>,
+	{
+		todo!()
 	}
 }
 

--- a/crates/hal/src/backend.rs
+++ b/crates/hal/src/backend.rs
@@ -59,7 +59,7 @@ pub trait ComputationBackend: Send + Sync + Debug {
 		Composition: CompositionPolyOS<P>;
 
 	/// Calculate the accumulated evaluations for an arbitrary round of high to low sumcheck
-	fn high_to_low_sumcheck_compute_round_evals<FDomain, F, P, M, Evaluator, Composition>(
+	fn high_to_low_sumcheck_compute_round_evals<FDomain, P, M, Evaluator, Composition>(
 		&self,
 		n_vars: usize,
 		tensor_query: Option<MultilinearQueryRef<P>>,
@@ -69,12 +69,9 @@ pub trait ComputationBackend: Send + Sync + Debug {
 	) -> Result<Vec<RoundEvals<P::Scalar>>, Error>
 	where
 		FDomain: Field,
-		F: Field + ExtensionField<FDomain>,
-		P: PackedField<Scalar = F>
-			+ PackedExtension<F, PackedSubfield = P>
-			+ PackedExtension<FDomain>,
+		P: PackedField<Scalar: ExtensionField<FDomain>> + PackedExtension<FDomain>,
 		M: MultilinearPoly<P> + Send + Sync,
-		Evaluator: SumcheckEvaluator<F, P, Composition> + Sync,
+		Evaluator: SumcheckEvaluator<P, Composition> + Sync,
 		Composition: CompositionPolyOS<P>;
 
 	/// Partially evaluate the polynomial with assignment to the high-indexed variables.
@@ -137,7 +134,7 @@ where
 		T::evaluate_partial_high(self, multilinear, query_expansion)
 	}
 
-	fn high_to_low_sumcheck_compute_round_evals<FDomain, F, P, M, Evaluator, Composition>(
+	fn high_to_low_sumcheck_compute_round_evals<FDomain, P, M, Evaluator, Composition>(
 		&self,
 		_n_vars: usize,
 		_tensor_query: Option<MultilinearQueryRef<P>>,
@@ -147,12 +144,9 @@ where
 	) -> Result<Vec<RoundEvals<P::Scalar>>, Error>
 	where
 		FDomain: Field,
-		F: Field + ExtensionField<FDomain>,
-		P: PackedField<Scalar = F>
-			+ PackedExtension<F, PackedSubfield = P>
-			+ PackedExtension<FDomain>,
+		P: PackedField<Scalar: ExtensionField<FDomain>> + PackedExtension<FDomain>,
 		M: MultilinearPoly<P> + Send + Sync,
-		Evaluator: SumcheckEvaluator<F, P, Composition> + Sync,
+		Evaluator: SumcheckEvaluator<P, Composition> + Sync,
 		Composition: CompositionPolyOS<P>,
 	{
 		todo!()

--- a/crates/hal/src/backend.rs
+++ b/crates/hal/src/backend.rs
@@ -58,7 +58,8 @@ pub trait ComputationBackend: Send + Sync + Debug {
 		Evaluator: SumcheckEvaluator<P, Composition> + Sync,
 		Composition: CompositionPolyOS<P>;
 
-	fn high_to_low_sumcheck_compute_later_round_evals<FDomain, F, P, M, Evaluator, Composition>(
+	/// Calculate the accumulated evaluations for an arbitrary round of high to low sumcheck
+	fn high_to_low_sumcheck_compute_round_evals<FDomain, F, P, M, Evaluator, Composition>(
 		&self,
 		n_vars: usize,
 		tensor_query: Option<MultilinearQueryRef<P>>,
@@ -69,9 +70,11 @@ pub trait ComputationBackend: Send + Sync + Debug {
 	where
 		FDomain: Field,
 		F: Field + ExtensionField<FDomain>,
-		P: PackedField<Scalar = F> + PackedExtension<FDomain>,
+		P: PackedField<Scalar = F>
+			+ PackedExtension<F, PackedSubfield = P>
+			+ PackedExtension<FDomain>,
 		M: MultilinearPoly<P> + Send + Sync,
-		Evaluator: SumcheckEvaluator<P, P, Composition> + Sync,
+		Evaluator: SumcheckEvaluator<F, P, Composition> + Sync,
 		Composition: CompositionPolyOS<P>;
 
 	/// Partially evaluate the polynomial with assignment to the high-indexed variables.
@@ -134,7 +137,7 @@ where
 		T::evaluate_partial_high(self, multilinear, query_expansion)
 	}
 
-	fn high_to_low_sumcheck_compute_later_round_evals<FDomain, F, P, M, Evaluator, Composition>(
+	fn high_to_low_sumcheck_compute_round_evals<FDomain, F, P, M, Evaluator, Composition>(
 		&self,
 		_n_vars: usize,
 		_tensor_query: Option<MultilinearQueryRef<P>>,
@@ -145,9 +148,11 @@ where
 	where
 		FDomain: Field,
 		F: Field + ExtensionField<FDomain>,
-		P: PackedField<Scalar = F> + PackedExtension<FDomain>,
+		P: PackedField<Scalar = F>
+			+ PackedExtension<F, PackedSubfield = P>
+			+ PackedExtension<FDomain>,
 		M: MultilinearPoly<P> + Send + Sync,
-		Evaluator: SumcheckEvaluator<P, P, Composition> + Sync,
+		Evaluator: SumcheckEvaluator<F, P, Composition> + Sync,
 		Composition: CompositionPolyOS<P>,
 	{
 		todo!()

--- a/crates/hal/src/cpu.rs
+++ b/crates/hal/src/cpu.rs
@@ -64,7 +64,7 @@ impl ComputationBackend for CpuBackend {
 		Ok(multilinear.evaluate_partial_high(query_expansion)?)
 	}
 
-	fn high_to_low_sumcheck_compute_later_round_evals<FDomain, F, P, M, Evaluator, Composition>(
+	fn high_to_low_sumcheck_compute_round_evals<FDomain, F, P, M, Evaluator, Composition>(
 		&self,
 		n_vars: usize,
 		tensor_query: Option<MultilinearQueryRef<P>>,
@@ -75,12 +75,14 @@ impl ComputationBackend for CpuBackend {
 	where
 		FDomain: Field,
 		F: Field + ExtensionField<FDomain>,
-		P: PackedField<Scalar = F> + PackedExtension<FDomain>,
+		P: PackedField<Scalar = F>
+			+ PackedExtension<F, PackedSubfield = P>
+			+ PackedExtension<FDomain>,
 		M: MultilinearPoly<P> + Send + Sync,
-		Evaluator: SumcheckEvaluator<P, P, Composition> + Sync,
+		Evaluator: SumcheckEvaluator<F, P, Composition> + Sync,
 		Composition: CompositionPolyOS<P>,
 	{
-		high_to_low_calculate_later_round_evals(
+		high_to_low_calculate_round_evals(
 			n_vars,
 			tensor_query,
 			multilinears,

--- a/crates/hal/src/cpu.rs
+++ b/crates/hal/src/cpu.rs
@@ -63,4 +63,23 @@ impl ComputationBackend for CpuBackend {
 	) -> Result<MultilinearExtension<P>, Error> {
 		Ok(multilinear.evaluate_partial_high(query_expansion)?)
 	}
+
+	fn high_to_low_sumcheck_compute_later_round_evals<FDomain, F, P, M, Evaluator, Composition>(
+		&self,
+		n_vars: usize,
+		tensor_query: Option<MultilinearQueryRef<P>>,
+		multilinears: &[SumcheckMultilinear<P, M>],
+		evaluators: &[Evaluator],
+		evaluation_points: &[FDomain],
+	) -> Result<Vec<RoundEvals<P::Scalar>>, Error>
+	where
+		FDomain: Field,
+		F: Field + ExtensionField<FDomain>,
+		P: PackedField<Scalar = F> + PackedExtension<FDomain>,
+		M: MultilinearPoly<P> + Send + Sync,
+		Evaluator: SumcheckEvaluator<P, P, Composition> + Sync,
+		Composition: CompositionPolyOS<P>,
+	{
+		todo!()
+	}
 }

--- a/crates/hal/src/cpu.rs
+++ b/crates/hal/src/cpu.rs
@@ -80,6 +80,12 @@ impl ComputationBackend for CpuBackend {
 		Evaluator: SumcheckEvaluator<P, P, Composition> + Sync,
 		Composition: CompositionPolyOS<P>,
 	{
-		todo!()
+		high_to_low_calculate_later_round_evals(
+			n_vars,
+			tensor_query,
+			multilinears,
+			evaluators,
+			evaluation_points,
+		)
 	}
 }

--- a/crates/hal/src/cpu.rs
+++ b/crates/hal/src/cpu.rs
@@ -10,8 +10,8 @@ use binius_math::{
 use tracing::instrument;
 
 use crate::{
-	sumcheck_round_calculator::calculate_round_evals, ComputationBackend, Error, RoundEvals,
-	SumcheckEvaluator, SumcheckMultilinear,
+	sumcheck_round_calculator::{calculate_round_evals, high_to_low_calculate_round_evals},
+	ComputationBackend, Error, RoundEvals, SumcheckEvaluator, SumcheckMultilinear,
 };
 
 /// Implementation of ComputationBackend for the default Backend that uses the CPU for all computations.
@@ -64,7 +64,7 @@ impl ComputationBackend for CpuBackend {
 		Ok(multilinear.evaluate_partial_high(query_expansion)?)
 	}
 
-	fn high_to_low_sumcheck_compute_round_evals<FDomain, F, P, M, Evaluator, Composition>(
+	fn high_to_low_sumcheck_compute_round_evals<FDomain, P, M, Evaluator, Composition>(
 		&self,
 		n_vars: usize,
 		tensor_query: Option<MultilinearQueryRef<P>>,
@@ -74,12 +74,9 @@ impl ComputationBackend for CpuBackend {
 	) -> Result<Vec<RoundEvals<P::Scalar>>, Error>
 	where
 		FDomain: Field,
-		F: Field + ExtensionField<FDomain>,
-		P: PackedField<Scalar = F>
-			+ PackedExtension<F, PackedSubfield = P>
-			+ PackedExtension<FDomain>,
+		P: PackedField<Scalar: ExtensionField<FDomain>> + PackedExtension<FDomain>,
 		M: MultilinearPoly<P> + Send + Sync,
-		Evaluator: SumcheckEvaluator<F, P, Composition> + Sync,
+		Evaluator: SumcheckEvaluator<P, Composition> + Sync,
 		Composition: CompositionPolyOS<P>,
 	{
 		high_to_low_calculate_round_evals(

--- a/crates/hal/src/sumcheck_round_calculator.rs
+++ b/crates/hal/src/sumcheck_round_calculator.rs
@@ -100,9 +100,9 @@ where
 		.iter()
 		.map(|evaluator| evaluator.eval_point_indices().len());
 
-	/// Process batches of vertices in parallel, accumulating the round evaluations.
-	const MAX_SUBCUBE_VARS: usize = 5;
-	let subcube_vars = MAX_SUBCUBE_VARS.min(n_vars) - 1;
+	// Process batches of vertices in parallel, accumulating the round evaluations.
+	let max_subcube_vars: usize = (P::LOG_WIDTH + 1).max(5);
+	let subcube_vars = max_subcube_vars.min(n_vars) - 1;
 
 	// Compute the union of all evaluation point index ranges.
 	let eval_point_indices = evaluators

--- a/crates/hal/src/sumcheck_round_calculator.rs
+++ b/crates/hal/src/sumcheck_round_calculator.rs
@@ -114,7 +114,7 @@ where
 	let packed_accumulators = (0..(1 << (n_vars - 1 - subcube_vars)))
 		.into_par_iter()
 		.fold(
-			|| ParFoldStates::new(n_multilinears, n_round_evals.clone(), subcube_vars),
+			|| ParFoldStates::new(n_multilinears, n_round_evals.clone(), subcube_vars, high_to_low),
 			|mut par_fold_states, subcube_index| {
 				let ParFoldStates {
 					multilinear_evals,
@@ -288,6 +288,7 @@ impl<PBase: PackedField, P: PackedField> ParFoldStates<PBase, P> {
 		n_multilinears: usize,
 		n_round_evals: impl Iterator<Item = usize>,
 		subcube_vars: usize,
+		high_to_low: bool,
 	) -> Self {
 		Self {
 			multilinear_evals: (0..n_multilinears)
@@ -295,7 +296,11 @@ impl<PBase: PackedField, P: PackedField> ParFoldStates<PBase, P> {
 				.collect(),
 			interleaved_evals: vec![
 				PBase::default();
-				1 << (subcube_vars + 1).saturating_sub(PBase::LOG_WIDTH)
+				if high_to_low {
+					0
+				} else {
+					1 << (subcube_vars + 1).saturating_sub(PBase::LOG_WIDTH)
+				}
 			],
 			round_evals: n_round_evals
 				.map(|n_round_evals| zeroed_vec(n_round_evals))

--- a/crates/math/src/mle_adapters.rs
+++ b/crates/math/src/mle_adapters.rs
@@ -11,6 +11,7 @@ use binius_field::{
 use binius_utils::bail;
 
 use super::{Error, MultilinearExtension, MultilinearPoly, MultilinearQueryRef};
+use crate::MultilinearQuery;
 
 /// An adapter for [`MultilinearExtension`] that implements [`MultilinearPoly`] over a packed
 /// extension field.
@@ -311,9 +312,9 @@ where
 		let evals = multilin.evals();
 
 		if evals.len() == 1 {
-			let single_variable_query = MultilinearQueryRef::expand(&[r]);
+			let single_variable_query = MultilinearQuery::expand(&[r]);
 
-			return self.evaluate_partial_high(single_variable_query);
+			return self.evaluate_partial_high(single_variable_query.to_ref());
 		}
 
 		let (low, high) = evals.split_at(evals.len() / 2);

--- a/crates/math/src/mle_adapters.rs
+++ b/crates/math/src/mle_adapters.rs
@@ -319,7 +319,9 @@ where
 
 		let (low, high) = evals.split_at(evals.len() / 2);
 
-		let result: Vec<P> = low
+		let r = P::broadcast(r);
+
+		let result = low
 			.iter()
 			.zip(high)
 			.map(|(&l, &h)| (h - l) * r + l)


### PR DESCRIPTION
This prover processes the polynomial from the highest to the lowest variable, which allows minimizing interaction with Scalars instead of PackedFields compared to `RegularSumcheckProver`.

Also, minimizing the use of scalars allows taking full advantage of all the `ByteSliced` benefits.

```
ByteSlicedAES32x128b/hight_to_low/n_vars=24/n_multilinears=2
sumcheck::high_to_low_batch_prove [ 66.60ms | 100.00% ]
└── sumcheck::batch_prove [ 66.60ms | 100.00% ]
   ├── HighToLowSumcheckProver::execute [ 9.64ms | 14.47% ]
   │  └── hight_to_low_calculate_later_round_evals [ 9.63ms | 14.46% ]
   ├── HighToLowSumcheckProver::fold [ 20.01ms | 30.05% ]
   │  └── ProverState::high_to_low_fold [ 20.01ms | 30.04% ]


PackedBinaryPolyval2x128b/hight_to_low/n_vars=24/n_multilinears=2
sumcheck::high_to_low_batch_prove [ 65.00ms | 100.00% ]
└── sumcheck::batch_prove [ 65.00ms | 100.00% ]
   ├── HighToLowSumcheckProver::execute [ 10.29ms | 15.82% ]
   │  └── hight_to_low_calculate_later_round_evals [ 10.28ms | 15.82% ]
   ├── HighToLowSumcheckProver::fold [ 19.29ms | 29.68% ]
   │  └── ProverState::high_to_low_fold [ 19.29ms | 29.68% ]


PackedAESBinaryField2x128b/hight_to_low/n_vars=24/n_multilinears=2
sumcheck::high_to_low_batch_prove [ 306.76ms | 100.00% ]
└── sumcheck::batch_prove [ 306.75ms | 100.00% ]
   ├── HighToLowSumcheckProver::execute [ 33.38ms | 10.88% ]
   │  └── hight_to_low_calculate_later_round_evals [ 33.38ms | 10.88% ]
   ├── HighToLowSumcheckProver::fold [ 116.05ms | 37.83% ]
   │  └── ProverState::high_to_low_fold [ 116.05ms | 37.83% ]

ByteSlicedAES32x128b/hight_to_low/n_vars=24/n_multilinears=3
sumcheck::high_to_low_batch_prove [ 85.57ms | 100.00% ]
└── sumcheck::batch_prove [ 85.57ms | 100.00% ]
   ├── HighToLowSumcheckProver::execute [ 13.92ms | 16.27% ]
   │  └── hight_to_low_calculate_later_round_evals [ 13.92ms | 16.27% ]
   ├── HighToLowSumcheckProver::fold [ 25.92ms | 30.30% ]
   │  └── ProverState::high_to_low_fold [ 25.92ms | 30.29% ]


PackedBinaryPolyval2x128b/hight_to_low/n_vars=24/n_multilinears=3
sumcheck::high_to_low_batch_prove [ 93.85ms | 100.00% ]
└── sumcheck::batch_prove [ 93.85ms | 100.00% ]
   ├── HighToLowSumcheckProver::execute [ 19.16ms | 20.41% ]
   │  └── hight_to_low_calculate_later_round_evals [ 19.16ms | 20.41% ]
   ├── HighToLowSumcheckProver::fold [ 25.48ms | 27.15% ]
   │  └── ProverState::high_to_low_fold [ 25.48ms | 27.15% ]

PackedAESBinaryField2x128b/hight_to_low/n_vars=24/n_multilinears=3
sumcheck::high_to_low_batch_prove [ 389.11ms | 100.00% ]
└── sumcheck::batch_prove [ 389.11ms | 100.00% ]
   ├── HighToLowSumcheckProver::execute [ 73.84ms | 18.98% ]
   │  └── hight_to_low_calculate_later_round_evals [ 73.84ms | 18.98% ]
   ├── HighToLowSumcheckProver::fold [ 116.58ms | 29.96% ]
   │  └── ProverState::high_to_low_fold [ 116.58ms | 29.96% ]

ByteSlicedAES32x128b/hight_to_low/n_vars=24/n_multilinears=4
sumcheck::high_to_low_batch_prove [ 123.62ms | 100.00% ]
└── sumcheck::batch_prove [ 123.62ms | 100.00% ]
   ├── HighToLowSumcheckProver::execute [ 23.16ms | 18.73% ]
   │  └── hight_to_low_calculate_later_round_evals [ 23.15ms | 18.73% ]
   ├── HighToLowSumcheckProver::fold [ 34.86ms | 28.20% ]
   │  └── ProverState::high_to_low_fold [ 34.85ms | 28.20% ]

PackedBinaryPolyval2x128b/hight_to_low/n_vars=24/n_multilinears=4
sumcheck::high_to_low_batch_prove [ 138.81ms | 100.00% ]
└── sumcheck::batch_prove [ 138.81ms | 100.00% ]
   ├── HighToLowSumcheckProver::execute [ 33.38ms | 24.05% ]
   │  └── hight_to_low_calculate_later_round_evals [ 33.38ms | 24.04% ]
   ├── HighToLowSumcheckProver::fold [ 33.38ms | 24.05% ]
   │  └── ProverState::high_to_low_fold [ 33.38ms | 24.05% ]


PackedAESBinaryField2x128b/hight_to_low/n_vars=24/n_multilinears=4
sumcheck::high_to_low_batch_prove [ 475.80ms | 100.00% ]
└── sumcheck::batch_prove [ 475.80ms | 100.00% ]
   ├── HighToLowSumcheckProver::execute [ 117.87ms | 24.77% ]
   │  └── hight_to_low_calculate_later_round_evals [ 117.86ms | 24.77% ]
   ├── HighToLowSumcheckProver::fold [ 117.17ms | 24.63% ]
   │  └── ProverState::high_to_low_fold [ 117.17ms | 24.63% ]
```