### PR TITLE
Improve test compilation time

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [build]
 rustdocflags = ["-Dwarnings", "--html-in-header", "doc/katex-header.html"]
+
+[alias]
+fast_test = "test --tests"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,4 +137,4 @@ opt-level = 1
 debug = true
 debug-assertions = true
 overflow-checks = true
-lto = false
+lto = "off"


### PR DESCRIPTION
This MR addresses tow issues that make `cargo test` slow:
1. Thin LTO slows down compilation of all the crates a bit.
2. It takes quite a time to compile and link all the examples with `test` profile which are not actually executed. So I've added an alias to compile and run tests only for fast local usage.

But the main problem is still with `binius_field` tests compilation taking too long when `opt_level` is 1:
![image](https://github.com/user-attachments/assets/432ce68e-44b9-4d97-ad1d-b013bc70e131)
And we can't change this setting to 0 even for this crate only, otherwise circuit tests are becoming too slow and test running time only increases. The problem seems to be that one of the codegen units in the crate takes more than a minute to compile while other ones are small:
![image](https://github.com/user-attachments/assets/f2776727-d317-42ba-beeb-f1de3fd9d734)

That seems to be a problem how those codegen units are created by `rustc`, increasing max number of units or splitting up the code doesn't help, for some reason all heavy prop tests are merged into one codegen unit. And without debugging `rustc` it's really hard to say why.

What else I tried and it **didn't** work:
1. Using `nextest` to run tests. `cargo nextest run` works better in case when some of the tests are slow because `nextest` launch all tests from all the crates in parallel unlike `cargo test` which runs concurrently only tests for the same crate. However with `opt-level=1` there is no significant difference
2. Using `mold` as a linker. In this case linker is not a bottleneck.
3. Using `cranelift` as a compiler backend. `cranelift` seems to show good performance compiling the code, however it produces very slow binaries (even slower as LLVM backend with `opt-level` 0) and has issues with unsupported intrinsics, also one of the trivial tests failed, so seems to be pretty buggy as well. 