### PR TITLE
Karatsuba interpolation in sumchecks

### DIFF
--- a/crates/core/src/protocols/gkr_gpa/gpa_sumcheck/prove.rs
+++ b/crates/core/src/protocols/gkr_gpa/gpa_sumcheck/prove.rs
@@ -214,7 +214,7 @@ where
 					.filter(|_| round == 0);
 
 				let composition_at_infinity =
-					ArithCircuitPoly::new(composition.expression().highest_degree_only().1);
+					ArithCircuitPoly::new(composition.expression().leading_term());
 
 				GPAEvaluator {
 					composition,

--- a/crates/core/src/protocols/gkr_gpa/gpa_sumcheck/tests.rs
+++ b/crates/core/src/protocols/gkr_gpa/gpa_sumcheck/tests.rs
@@ -6,8 +6,7 @@ use binius_field::{
 	arch::OptimalUnderlier512b,
 	as_packed_field::{PackScalar, PackedType},
 	underlier::UnderlierType,
-	BinaryField, BinaryField128b, BinaryField8b, ExtensionField, PackedField, PackedFieldIndexable,
-	TowerField,
+	BinaryField128b, BinaryField8b, ExtensionField, PackedField, PackedFieldIndexable, TowerField,
 };
 use binius_hal::make_portable_backend;
 use binius_math::{
@@ -34,7 +33,7 @@ fn test_prove_verify_bivariate_product_helper<U, F, FDomain>(
 ) where
 	U: UnderlierType + PackScalar<F> + PackScalar<FDomain>,
 	F: TowerField + ExtensionField<FDomain>,
-	FDomain: BinaryField,
+	FDomain: TowerField,
 	PackedType<U, F>: PackedFieldIndexable,
 {
 	let mut rng = StdRng::seed_from_u64(0);

--- a/crates/core/src/protocols/gkr_gpa/prove.rs
+++ b/crates/core/src/protocols/gkr_gpa/prove.rs
@@ -132,7 +132,7 @@ fn process_finished_provers<F, P, Backend>(
 	reverse_sorted_final_layer_claims: &mut Vec<LayerClaim<F>>,
 ) -> Result<(), Error>
 where
-	F: Field,
+	F: TowerField,
 	P: PackedFieldIndexable<Scalar = F> + PackedExtension<F, PackedSubfield = P>,
 	Backend: ComputationBackend,
 {
@@ -176,7 +176,7 @@ where
 
 impl<'a, F, P, Backend> GrandProductProverState<'a, F, P, Backend>
 where
-	F: Field + From<P::Scalar>,
+	F: TowerField + From<P::Scalar>,
 	P: PackedFieldIndexable<Scalar = F> + PackedExtension<F, PackedSubfield = P>,
 	Backend: ComputationBackend,
 {
@@ -314,7 +314,7 @@ where
 		if self.current_layer_no() >= self.input_vars() {
 			bail!(Error::TooManyRounds);
 		}
-		let new_eval = extrapolate_line_scalar(zero_eval, one_eval, gpa_challenge);
+		let new_eval = extrapolate_line_scalar::<F, F>(zero_eval, one_eval, gpa_challenge);
 		let mut layer_challenge = sumcheck_challenge;
 		layer_challenge.push(gpa_challenge);
 

--- a/crates/core/src/protocols/sumcheck/error.rs
+++ b/crates/core/src/protocols/sumcheck/error.rs
@@ -45,6 +45,10 @@ pub enum Error {
 		oracle: String,
 		hypercube_index: usize,
 	},
+	#[error("evaluation domain should start with zero and one, and contain Karatsuba infinity for degrees above 1")]
+	IncorrectSumcheckEvaluationDomain,
+	#[error("evaluation domains are not proper prefixes of each other")]
+	NonProperPrefixEvaluationDomain,
 	#[error("constraint set contains multilinears of different heights")]
 	ConstraintSetNumberOfVariablesMismatch,
 	#[error("batching sumchecks and zerochecks is not supported yet")]

--- a/crates/core/src/protocols/sumcheck/prove/prover_state.rs
+++ b/crates/core/src/protocols/sumcheck/prove/prover_state.rs
@@ -61,7 +61,7 @@ where
 	#[getset(get_copy = "pub")]
 	n_vars: usize,
 	multilinears: Vec<SumcheckMultilinear<P, M>>,
-	evaluation_points: Vec<FDomain>,
+	nontrivial_evaluation_points: Vec<FDomain>,
 	tensor_query: Option<MultilinearQuery<P>>,
 	last_coeffs_or_sums: ProverStateCoeffsOrSums<P::Scalar>,
 	backend: &'a Backend,
@@ -78,7 +78,7 @@ where
 	pub fn new(
 		multilinears: Vec<M>,
 		claimed_sums: Vec<F>,
-		evaluation_points: Vec<FDomain>,
+		nontrivial_evaluation_points: Vec<FDomain>,
 		switchover_fn: impl Fn(usize) -> usize,
 		backend: &'a Backend,
 	) -> Result<Self, Error> {
@@ -87,7 +87,7 @@ where
 			multilinears,
 			&switchover_rounds,
 			claimed_sums,
-			evaluation_points,
+			nontrivial_evaluation_points,
 			backend,
 		)
 	}
@@ -101,7 +101,7 @@ where
 		multilinears: Vec<M>,
 		switchover_rounds: &[usize],
 		claimed_sums: Vec<F>,
-		evaluation_points: Vec<FDomain>,
+		nontrivial_evaluation_points: Vec<FDomain>,
 		backend: &'a Backend,
 	) -> Result<Self, Error> {
 		let n_vars = equal_n_vars_check(&multilinears)?;
@@ -123,7 +123,7 @@ where
 		Ok(Self {
 			n_vars,
 			multilinears,
-			evaluation_points,
+			nontrivial_evaluation_points,
 			tensor_query: Some(tensor_query),
 			last_coeffs_or_sums: ProverStateCoeffsOrSums::Sums(claimed_sums),
 			backend,
@@ -260,7 +260,7 @@ where
 			self.tensor_query.as_ref().map(Into::into),
 			&self.multilinears,
 			evaluators,
-			&self.evaluation_points,
+			&self.nontrivial_evaluation_points,
 		)?)
 	}
 

--- a/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
@@ -184,7 +184,7 @@ where
 		let evaluators = izip!(&self.compositions, &self.domains)
 			.map(|(composition, interpolation_domain)| {
 				let composition_at_infinity =
-					ArithCircuitPoly::new(composition.expression().highest_degree_only().1);
+					ArithCircuitPoly::new(composition.expression().leading_term());
 
 				RegularSumcheckEvaluator {
 					composition,

--- a/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
@@ -182,13 +182,16 @@ where
 	#[instrument("RegularSumcheckProver::execute", skip_all, level = "debug")]
 	fn execute(&mut self, batch_coeff: F) -> Result<RoundCoeffs<F>, Error> {
 		let evaluators = izip!(&self.compositions, &self.domains)
-			.map(|(composition, interpolation_domain)| RegularSumcheckEvaluator {
-				composition,
-				composition_highest_degree_only: ArithCircuitPoly::new(
-					composition.expression().highest_degree_only().1,
-				),
-				interpolation_domain,
-				_marker: PhantomData,
+			.map(|(composition, interpolation_domain)| {
+				let composition_at_infinity =
+					ArithCircuitPoly::new(composition.expression().highest_degree_only().1);
+
+				RegularSumcheckEvaluator {
+					composition,
+					composition_at_infinity,
+					interpolation_domain,
+					_marker: PhantomData,
+				}
 			})
 			.collect::<Vec<_>>();
 
@@ -208,7 +211,7 @@ where
 	FDomain: Field,
 {
 	composition: &'a Composition,
-	composition_highest_degree_only: ArithCircuitPoly<P::Scalar>,
+	composition_at_infinity: ArithCircuitPoly<P::Scalar>,
 	interpolation_domain: &'a InterpolationDomain<FDomain>,
 	_marker: PhantomData<P>,
 }
@@ -238,7 +241,7 @@ where
 
 		stackalloc_with_default(row_len, |evals| {
 			if is_infinity_point {
-				self.composition_highest_degree_only
+				self.composition_at_infinity
 					.batch_evaluate(batch_query, evals)
 					.expect("correct by query construction invariant");
 			} else {
@@ -277,8 +280,10 @@ where
 		round_evals.insert(0, last_round_sum - round_evals[0]);
 
 		if round_evals.len() > 3 {
-			// Reorder eval at infinity point from index 2 to the last position
-			// (as expected by the InterpolationDomain).
+			// SumcheckRoundCalculator orders interpolation points as 0, 1, "infinity", then subspace points.
+			// InterpolationDomain expects "infinity" at the last position, thus reordering is needed.
+			// Putting "special" evaluation points at the beginning of domain allows benefitting from
+			// faster/skipped interpolation even in case of mixed degree compositions .
 			let infinity_round_eval = round_evals.remove(2);
 			round_evals.push(infinity_round_eval);
 		}

--- a/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
@@ -2,7 +2,7 @@
 
 use std::{marker::PhantomData, ops::Range};
 
-use binius_field::{Field, PackedExtension, PackedField};
+use binius_field::{ExtensionField, Field, PackedExtension, PackedField, TowerField};
 use binius_hal::{ComputationBackend, SumcheckEvaluator};
 use binius_math::{CompositionPoly, EvaluationDomainFactory, InterpolationDomain, MultilinearPoly};
 use binius_maybe_rayon::prelude::*;
@@ -13,9 +13,9 @@ use tracing::instrument;
 
 use super::{batch_prove::SumcheckProver, prover_state::ProverState};
 use crate::{
-	polynomial::{Error as PolynomialError, MultilinearComposite},
+	polynomial::{ArithCircuitPoly, Error as PolynomialError, MultilinearComposite},
 	protocols::sumcheck::{
-		common::{CompositeSumClaim, RoundCoeffs},
+		common::{get_nontrivial_evaluation_points, CompositeSumClaim, RoundCoeffs},
 		error::Error,
 		prove::prover_state::SumcheckInterpolator,
 	},
@@ -127,7 +127,8 @@ where
 			.iter()
 			.map(|composite_claim| {
 				let degree = composite_claim.composition.degree();
-				let domain = evaluation_domain_factory.create(degree + 1)?;
+				let domain =
+					evaluation_domain_factory.create_with_infinity(degree + 1, degree >= 2)?;
 				Ok(domain.into())
 			})
 			.collect::<Result<Vec<InterpolationDomain<FDomain>>, _>>()
@@ -138,15 +139,12 @@ where
 			.map(|claim| claim.composition)
 			.collect();
 
-		let evaluation_points = domains
-			.iter()
-			.max_by_key(|domain| domain.size())
-			.map_or_else(|| Vec::new(), |domain| domain.finite_points().to_vec());
+		let nontrivial_evaluation_points = get_nontrivial_evaluation_points(&domains)?;
 
 		let state = ProverState::new(
 			multilinears,
 			claimed_sums,
-			evaluation_points,
+			nontrivial_evaluation_points,
 			switchover_fn,
 			backend,
 		)?;
@@ -164,7 +162,7 @@ where
 impl<F, FDomain, P, Composition, M, Backend> SumcheckProver<F>
 	for RegularSumcheckProver<'_, FDomain, P, Composition, M, Backend>
 where
-	F: Field,
+	F: TowerField + ExtensionField<FDomain>,
 	FDomain: Field,
 	P: PackedField<Scalar = F> + PackedExtension<F, PackedSubfield = P> + PackedExtension<FDomain>,
 	Composition: CompositionPoly<P>,
@@ -186,6 +184,9 @@ where
 		let evaluators = izip!(&self.compositions, &self.domains)
 			.map(|(composition, interpolation_domain)| RegularSumcheckEvaluator {
 				composition,
+				composition_highest_degree_only: ArithCircuitPoly::new(
+					composition.expression().highest_degree_only().1,
+				),
 				interpolation_domain,
 				_marker: PhantomData,
 			})
@@ -207,6 +208,7 @@ where
 	FDomain: Field,
 {
 	composition: &'a Composition,
+	composition_highest_degree_only: ArithCircuitPoly<P::Scalar>,
 	interpolation_domain: &'a InterpolationDomain<FDomain>,
 	_marker: PhantomData<P>,
 }
@@ -214,7 +216,7 @@ where
 impl<F, P, FDomain, Composition> SumcheckEvaluator<P, Composition>
 	for RegularSumcheckEvaluator<'_, P, FDomain, Composition>
 where
-	F: Field,
+	F: TowerField + ExtensionField<FDomain>,
 	P: PackedField<Scalar = F> + PackedExtension<F, PackedSubfield = P> + PackedExtension<FDomain>,
 	FDomain: Field,
 	Composition: CompositionPoly<P>,
@@ -229,14 +231,21 @@ where
 		&self,
 		_subcube_vars: usize,
 		_subcube_index: usize,
+		is_infinity_point: bool,
 		batch_query: &[&[P]],
 	) -> P {
 		let row_len = batch_query.first().map_or(0, |row| row.len());
 
 		stackalloc_with_default(row_len, |evals| {
-			self.composition
-				.batch_evaluate(batch_query, evals)
-				.expect("correct by query construction invariant");
+			if is_infinity_point {
+				self.composition_highest_degree_only
+					.batch_evaluate(batch_query, evals)
+					.expect("correct by query construction invariant");
+			} else {
+				self.composition
+					.batch_evaluate(batch_query, evals)
+					.expect("correct by query construction invariant");
+			}
 
 			evals.iter().copied().sum()
 		})
@@ -266,6 +275,13 @@ where
 		// Given $r(1), \ldots, r(d+1)$, letting $s$ be the current round's claimed sum,
 		// we can compute $r(0)$ using the identity $r(0) = s - r(1)$
 		round_evals.insert(0, last_round_sum - round_evals[0]);
+
+		if round_evals.len() > 3 {
+			// Reorder eval at infinity point from index 2 to the last position
+			// (as expected by the InterpolationDomain).
+			let infinity_round_eval = round_evals.remove(2);
+			round_evals.push(infinity_round_eval);
+		}
 
 		let coeffs = self.interpolation_domain.interpolate(&round_evals)?;
 		Ok(coeffs)

--- a/crates/core/src/protocols/sumcheck/prove/zerocheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/zerocheck.rs
@@ -566,7 +566,7 @@ where
 			let evaluators = izip!(&self.compositions, &self.domains)
 				.map(|(composition, interpolation_domain)| {
 					let composition_at_infinity =
-						ArithCircuitPoly::new(composition.expression().highest_degree_only().1);
+						ArithCircuitPoly::new(composition.expression().leading_term());
 
 					ZerocheckFirstRoundEvaluator {
 						composition,
@@ -583,7 +583,7 @@ where
 			let evaluators = izip!(&self.compositions, &self.domains)
 				.map(|(composition, interpolation_domain)| {
 					let composition_at_infinity =
-						ArithCircuitPoly::new(composition.expression().highest_degree_only().1);
+						ArithCircuitPoly::new(composition.expression().leading_term());
 
 					ZerocheckLaterRoundEvaluator {
 						composition,

--- a/crates/core/src/protocols/sumcheck/tests.rs
+++ b/crates/core/src/protocols/sumcheck/tests.rs
@@ -267,7 +267,7 @@ fn make_test_sumcheck<'a, F, FDomain, P, PExt, Backend>(
 	impl SumcheckProver<F> + 'a,
 )
 where
-	F: Field,
+	F: TowerField + ExtensionField<P::Scalar> + ExtensionField<FDomain>,
 	FDomain: Field,
 	P: PackedField,
 	PExt: PackedField<Scalar = F>

--- a/crates/core/src/protocols/sumcheck/zerocheck.rs
+++ b/crates/core/src/protocols/sumcheck/zerocheck.rs
@@ -172,7 +172,7 @@ where
 	}
 
 	fn expression(&self) -> ArithExpr<P::Scalar> {
-		self.inner.expression() * ArithExpr::Var(self.inner.n_vars() - 1)
+		self.inner.expression() * ArithExpr::Var(self.inner.n_vars())
 	}
 
 	fn evaluate(&self, query: &[P]) -> Result<P, binius_math::Error> {

--- a/crates/hal/src/backend.rs
+++ b/crates/hal/src/backend.rs
@@ -49,7 +49,7 @@ pub trait ComputationBackend: Send + Sync + Debug {
 		tensor_query: Option<MultilinearQueryRef<P>>,
 		multilinears: &[SumcheckMultilinear<P, M>],
 		evaluators: &[Evaluator],
-		evaluation_points: &[FDomain],
+		nontrivial_evaluation_points: &[FDomain],
 	) -> Result<Vec<RoundEvals<P::Scalar>>, Error>
 	where
 		FDomain: Field,
@@ -91,7 +91,7 @@ where
 		tensor_query: Option<MultilinearQueryRef<P>>,
 		multilinears: &[SumcheckMultilinear<P, M>],
 		evaluators: &[Evaluator],
-		evaluation_points: &[FDomain],
+		nontrivial_evaluation_points: &[FDomain],
 	) -> Result<Vec<RoundEvals<P::Scalar>>, Error>
 	where
 		FDomain: Field,
@@ -106,7 +106,7 @@ where
 			tensor_query,
 			multilinears,
 			evaluators,
-			evaluation_points,
+			nontrivial_evaluation_points,
 		)
 	}
 

--- a/crates/hal/src/cpu.rs
+++ b/crates/hal/src/cpu.rs
@@ -43,7 +43,7 @@ impl ComputationBackend for CpuBackend {
 		tensor_query: Option<MultilinearQueryRef<P>>,
 		multilinears: &[SumcheckMultilinear<P, M>],
 		evaluators: &[Evaluator],
-		evaluation_points: &[FDomain],
+		nontrivial_evaluation_points: &[FDomain],
 	) -> Result<Vec<RoundEvals<P::Scalar>>, Error>
 	where
 		FDomain: Field,
@@ -52,7 +52,13 @@ impl ComputationBackend for CpuBackend {
 		Evaluator: SumcheckEvaluator<P, Composition> + Sync,
 		Composition: CompositionPoly<P>,
 	{
-		calculate_round_evals(n_vars, tensor_query, multilinears, evaluators, evaluation_points)
+		calculate_round_evals(
+			n_vars,
+			tensor_query,
+			multilinears,
+			evaluators,
+			nontrivial_evaluation_points,
+		)
 	}
 
 	#[instrument(skip_all, name = "CpuBackend::evaluate_partial_high")]

--- a/crates/hal/src/error.rs
+++ b/crates/hal/src/error.rs
@@ -11,6 +11,8 @@ pub enum Error {
 	MathError(#[from] binius_math::Error),
 	#[error("the query must have size {expected}")]
 	IncorrectQuerySize { expected: usize },
+	#[error("provided nontrivial evaluation points are of incorrect length")]
+	IncorrectNontrivialEvalPointsLength,
 	#[error("{0}")]
 	FieldError(#[from] binius_field::Error),
 }

--- a/crates/hal/src/sumcheck_evaluator.rs
+++ b/crates/hal/src/sumcheck_evaluator.rs
@@ -23,6 +23,7 @@ pub trait SumcheckEvaluator<P: PackedField, Composition> {
 		&self,
 		subcube_vars: usize,
 		subcube_index: usize,
+		is_infinity_point: bool,
 		batch_query: &[&[P]],
 	) -> P;
 

--- a/crates/hal/src/sumcheck_evaluator.rs
+++ b/crates/hal/src/sumcheck_evaluator.rs
@@ -18,6 +18,9 @@ pub trait SumcheckEvaluator<P: PackedField, Composition> {
 	/// `batch_query` should contain multilinears evals over a subcube represented
 	/// by `subcube_vars` and `subcube_index`.
 	///
+	/// See doc comments to [EvaluationDomain](binius_math::EvaluationDomain) for the intuition
+	/// behind `is_infinity_point`.
+	///
 	/// Returns a packed sum (which may be spread across scalars).
 	fn process_subcube_at_eval_point(
 		&self,

--- a/crates/math/src/univariate.rs
+++ b/crates/math/src/univariate.rs
@@ -16,6 +16,12 @@ use crate::Matrix;
 ///
 /// An evaluation domain of size d + 1 along with polynomial values on that domain are sufficient
 /// to reconstruct a degree <= d. This struct supports Barycentric extrapolation.
+///
+/// A domain may optionally include a Karatsuba "infinity" point, "evaluating" a polynomial at which
+/// results in taking the coefficient at the highest degree term. This point requires special treatment
+/// but sometimes unlocks optimization opportunities. The "Evaluation" section of the Wikipedia article
+/// on [Toom-Cook multiplication](https://en.wikipedia.org/wiki/Toom%E2%80%93Cook_multiplication) gives
+/// a great explanation of the concept.
 #[derive(Debug, Clone)]
 pub struct EvaluationDomain<F: Field> {
 	finite_points: Vec<F>,

--- a/crates/math/src/univariate.rs
+++ b/crates/math/src/univariate.rs
@@ -91,7 +91,7 @@ where
 		}
 		let points =
 			make_evaluation_points(&self.subspace, size - if with_infinity { 1 } else { 0 })?;
-		EvaluationDomain::from_points(points.into_iter().map(Into::into).collect(), false)
+		EvaluationDomain::from_points(points.into_iter().map(Into::into).collect(), with_infinity)
 	}
 }
 


### PR DESCRIPTION
This MR adds support for the Karatsuba infinity point when interpolating, where we take a binary subspace evaluation domain and replace the third point (after zero and one) with an infinity: 

$$
f(z, xs) = f(0, xs) + z (f(1,xs) - f(0,xs)) 
$$
$$
f(\infty, xs) = lim_{z \rightarrow \infty} \frac{f(z,xs)}{z} = f(1,xs) - f(0, xs)
$$

This saves a multiplication in one point (which is a large-by-large in POLYVAL case) and allows sumchecking quadratic constraints without using multiplications for interpolation at all. There is a caveat though - we cannot use the original composition polynomial $C$ in this point, and should use $lim_{z \rightarrow \infty} \frac{C(f(z, xs))}{{z^{deg C}}} z^{deg C}$ instead. Luckily having `expression()` in `CompositionPolyOS` and `ArithExpr`/`ArithCircuitPoly` makes this pretty straightforward.

This optimization is prover-only and provides consistent 10-15% improvement on single threaded GPA sumchecks, and should never cause a regression, though its benefit is best felt on domains not capable of small by large multiplication (like POLYVAL) and composition polynomials which get simpler when only the highest degree term is concerned.

It is however somewhat invasive in a sense that sumcheck evaluator should be acutely aware of the infinity point existence - while we are likely to only support regular & equality indicator sumchecks going forward, this is still code to maintain. I would like a second opinion whether it's worth merging this.