### PR TITLE
[matrix]: simplify scale_row

### DIFF
--- a/crates/math/src/matrix.rs
+++ b/crates/math/src/matrix.rs
@@ -186,8 +186,6 @@ impl<F: Field> Matrix<F> {
 	}
 
 	fn scale_row(&mut self, i: usize, scalar: F) {
-		assert!(i < self.m);
-
 		for x in self.row_mut(i) {
 			*x *= scalar;
 		}


### PR DESCRIPTION
The check `assert!(i < self.m);` is already done in `self.row_mut(i)`