### PR TITLE
[tower-level]: improve perfs of split

### DIFF
--- a/crates/field/src/tower_levels.rs
+++ b/crates/field/src/tower_levels.rs
@@ -103,16 +103,18 @@ where
 	fn split(
 		data: &Self::Data,
 	) -> (&<Self::Base as TowerLevel<T>>::Data, &<Self::Base as TowerLevel<T>>::Data) {
-		((data[0..32].try_into().unwrap()), (data[32..64].try_into().unwrap()))
+		let left = unsafe { &*(data.as_ptr() as *const [T; 32]) };
+		let right = unsafe { &*(data.as_ptr().add(32) as *const [T; 32]) };
+		(left, right)
 	}
 
 	#[inline(always)]
 	fn split_mut(
 		data: &mut Self::Data,
 	) -> (&mut <Self::Base as TowerLevel<T>>::Data, &mut <Self::Base as TowerLevel<T>>::Data) {
-		let (chunk_1, chunk_2) = data.split_at_mut(32);
-
-		((chunk_1.try_into().unwrap()), (chunk_2.try_into().unwrap()))
+		let left = unsafe { &mut *(data.as_mut_ptr() as *mut [T; 32]) };
+		let right = unsafe { &mut *(data.as_mut_ptr().add(32) as *mut [T; 32]) };
+		(left, right)
 	}
 
 	#[inline(always)]


### PR DESCRIPTION
To demonstrate the perf improvements, I designed a very small example on the Rust playground to mimic old vs new behaviour:

```rust
use std::time::Instant;

const N: usize = 64;
const MID: usize = 32;

fn split_old(data: &[u32; N]) -> (&[u32; MID], &[u32; MID]) {
    let (left, right) = data.split_at(MID);
    (left.try_into().unwrap(), right.try_into().unwrap())
}

fn split_new(data: &[u32; N]) -> (&[u32; MID], &[u32; MID]) {
    let left = unsafe { &*(data.as_ptr() as *const [u32; MID]) };
    let right = unsafe { &*(data.as_ptr().add(MID) as *const [u32; MID]) };
    (left, right)
}

fn main() {
    let data = [0u32; N];

    // Benchmark old method
    let start_old = Instant::now();
    for _ in 0..1_000_000 {
        let _ = split_old(&data);
    }
    let duration_old = start_old.elapsed();

    // Benchmark new method
    let start_new = Instant::now();
    for _ in 0..1_000_000 {
        let _ = split_new(&data);
    }
    let duration_new = start_new.elapsed();

    // Results
    println!("Old method: {:?}", duration_old);
    println!("New method: {:?}", duration_new);
}

```

leading to

```
Old method: 55.605993ms
New method: 11.34485ms
```