### PR TITLE
[ntt] Refactor AdditiveNTT to support more choices of NTT domain

### DIFF
--- a/crates/core/src/protocols/sumcheck/prove/univariate.rs
+++ b/crates/core/src/protocols/sumcheck/prove/univariate.rs
@@ -659,8 +659,8 @@ fn ntt_extrapolate<NTT, P>(
 	extrapolated_evals: &mut [P],
 ) -> Result<(), Error>
 where
-	P: PackedFieldIndexable,
-	NTT: AdditiveNTT<P> + AdditiveNTT<P::Scalar>,
+	P: PackedFieldIndexable<Scalar: BinaryField>,
+	NTT: AdditiveNTT<P::Scalar>,
 {
 	let subcube_vars = skip_rounds + log_batch;
 	debug_assert_eq!(
@@ -672,7 +672,7 @@ where
 		extrapolated_evals.len()
 	);
 	debug_assert!(
-		<NTT as AdditiveNTT<P>>::log_domain_size(ntt)
+		NTT::log_domain_size(ntt)
 			>= log2_ceil_usize(domain_size(composition_max_degree, skip_rounds))
 	);
 
@@ -702,8 +702,8 @@ fn ntt_extrapolate_chunks_exact<NTT, P>(
 	extrapolated_evals: &mut [P],
 ) -> Result<(), Error>
 where
-	P: PackedField,
-	NTT: AdditiveNTT<P>,
+	P: PackedField<Scalar: BinaryField>,
+	NTT: AdditiveNTT<P::Scalar>,
 {
 	debug_assert!(interleaved_evals.len().is_power_of_two());
 	debug_assert!(extrapolated_evals.len() % interleaved_evals.len() == 0);

--- a/crates/core/src/protocols/sumcheck/prove/univariate.rs
+++ b/crates/core/src/protocols/sumcheck/prove/univariate.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, iter::repeat_n};
 
 use binius_field::{
-	get_packed_subfields_at_pe_idx, recast_packed_mut, util::inner_product_unchecked,
+	get_packed_subfields_at_pe_idx, recast_packed_mut, util::inner_product_unchecked, BinaryField,
 	ExtensionField, Field, PackedExtension, PackedField, PackedFieldIndexable, PackedSubfield,
 	TowerField,
 };

--- a/crates/core/src/reed_solomon/reed_solomon.rs
+++ b/crates/core/src/reed_solomon/reed_solomon.rs
@@ -69,7 +69,7 @@ where
 		})
 	}
 
-	pub const fn get_ntt(&self) -> &impl AdditiveNTT<P> {
+	pub const fn get_ntt(&self) -> &impl AdditiveNTT<P::Scalar> {
 		&self.ntt
 	}
 

--- a/crates/hash/src/vision.rs
+++ b/crates/hash/src/vision.rs
@@ -15,7 +15,7 @@ use binius_field::{
 };
 use binius_ntt::{
 	twiddle::{OnTheFlyTwiddleAccess, TwiddleAccess},
-	SingleThreadedNTT,
+	AdditiveNTT, SingleThreadedNTT,
 };
 use lazy_static::lazy_static;
 

--- a/crates/math/src/binary_subspace.rs
+++ b/crates/math/src/binary_subspace.rs
@@ -9,17 +9,19 @@ use super::error::Error;
 ///
 /// The subspace is defined by a basis of elements from a binary field. The basis elements are
 /// ordered, which implies an ordering on the subspace elements.
-///
-/// ## Invariants
-///
-/// This struct requires that if the subspace dimension is non-zero, then the 0'th basis element is
-/// `F::ONE`.
 #[derive(Debug, Clone)]
 pub struct BinarySubspace<F: BinaryField> {
 	basis: Vec<F>,
 }
 
 impl<F: BinaryField> BinarySubspace<F> {
+	/// Creates a new subspace from a vector of ordered basis elements.
+	///
+	/// This constructor does not check that the basis elements are linearly independent.
+	pub const fn new_unchecked(basis: Vec<F>) -> Self {
+		Self { basis }
+	}
+
 	/// Creates a new subspace of this binary subspace with the given dimension.
 	///
 	/// This creates a new sub-subspace using a prefix of the default $\mathbb{F}_2$ basis elements
@@ -46,7 +48,7 @@ impl<F: BinaryField> BinarySubspace<F> {
 		if dim > self.dim() {
 			bail!(Error::DomainSizeTooLarge);
 		}
-		Ok(BinarySubspace {
+		Ok(Self {
 			basis: self.basis[..dim].to_vec(),
 		})
 	}

--- a/crates/math/src/binary_subspace.rs
+++ b/crates/math/src/binary_subspace.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_field::BinaryField;
-use binius_utils::iter::IterExtensions;
+use binius_utils::{bail, iter::IterExtensions};
 
 use super::error::Error;
 
@@ -9,12 +9,64 @@ use super::error::Error;
 ///
 /// The subspace is defined by a basis of elements from a binary field. The basis elements are
 /// ordered, which implies an ordering on the subspace elements.
+///
+/// ## Invariants
+///
+/// This struct requires that if the subspace dimension is non-zero, then the 0'th basis element is
+/// `F::ONE`.
 #[derive(Debug, Clone)]
 pub struct BinarySubspace<F: BinaryField> {
 	basis: Vec<F>,
 }
 
 impl<F: BinaryField> BinarySubspace<F> {
+	/// Creates a new subspace of this binary subspace with the given dimension.
+	///
+	/// This creates a new sub-subspace using a prefix of the default $\mathbb{F}_2$ basis elements
+	/// of the field.
+	///
+	/// ## Throws
+	///
+	/// * `Error::DomainSizeTooLarge` if `dim` is greater than this subspace's dimension.
+	pub fn with_dim(dim: usize) -> Result<Self, Error> {
+		let basis = (0..dim)
+			.map(|i| F::basis(i).map_err(|_| Error::DomainSizeTooLarge))
+			.collect::<Result<Vec<_>, _>>()?;
+		Ok(Self { basis })
+	}
+
+	/// Creates a new subspace of this binary subspace with reduced dimension.
+	///
+	/// This creates a new sub-subspace using a prefix of the ordered basis elements.
+	///
+	/// ## Throws
+	///
+	/// * `Error::DomainSizeTooLarge` if `dim` is greater than this subspace's dimension.
+	pub fn reduce_dim(&self, dim: usize) -> Result<Self, Error> {
+		if dim > self.dim() {
+			bail!(Error::DomainSizeTooLarge);
+		}
+		Ok(BinarySubspace {
+			basis: self.basis[..dim].to_vec(),
+		})
+	}
+
+	/// Creates a new subspace isomorphic to the given one.
+	pub fn isomorphic<FIso>(&self) -> BinarySubspace<FIso>
+	where
+		FIso: BinaryField + From<F>,
+	{
+		BinarySubspace {
+			basis: self.basis.iter().copied().map(FIso::from).collect(),
+		}
+	}
+
+	/// Returns the dimension of the subspace.
+	pub fn dim(&self) -> usize {
+		self.basis.len()
+	}
+
+	/// Returns the slice of ordered basis elements.
 	pub fn basis(&self) -> &[F] {
 		&self.basis
 	}

--- a/crates/ntt/benches/additive_ntt.rs
+++ b/crates/ntt/benches/additive_ntt.rs
@@ -15,15 +15,16 @@ use criterion::{
 use rand::thread_rng;
 
 trait BenchTransformationFunc {
-	fn run_bench<P>(
+	fn run_bench<F, P>(
 		group: &mut BenchmarkGroup<WallTime>,
-		ntt: &impl AdditiveNTT<P>,
+		ntt: &impl AdditiveNTT<F>,
 		data: &mut [P],
 		name: &str,
 		param: &str,
 		log_batch_size: usize,
 	) where
-		P: PackedField<Scalar: BinaryField>;
+		F: BinaryField,
+		P: PackedField<Scalar = F>;
 }
 
 fn bench_helper<P, BT: BenchTransformationFunc>(
@@ -102,15 +103,16 @@ fn bench_forward_transform(c: &mut Criterion) {
 	struct ForwardBench;
 
 	impl BenchTransformationFunc for ForwardBench {
-		fn run_bench<P>(
+		fn run_bench<F, P>(
 			group: &mut BenchmarkGroup<WallTime>,
-			ntt: &impl AdditiveNTT<P>,
+			ntt: &impl AdditiveNTT<F>,
 			data: &mut [P],
 			name: &str,
 			param: &str,
 			log_batch_size: usize,
 		) where
-			P: PackedField<Scalar: BinaryField>,
+			F: BinaryField,
+			P: PackedField<Scalar = F>,
 		{
 			group.bench_function(BenchmarkId::new(name, param), |b| {
 				b.iter(|| ntt.forward_transform(data, 0, log_batch_size));
@@ -125,15 +127,16 @@ fn bench_inverse_transform(c: &mut Criterion) {
 	struct InverseBench;
 
 	impl BenchTransformationFunc for InverseBench {
-		fn run_bench<P>(
+		fn run_bench<F, P>(
 			group: &mut BenchmarkGroup<WallTime>,
-			ntt: &impl AdditiveNTT<P>,
+			ntt: &impl AdditiveNTT<F>,
 			data: &mut [P],
 			name: &str,
 			param: &str,
 			log_batch_size: usize,
 		) where
-			P: PackedField<Scalar: BinaryField>,
+			F: BinaryField,
+			P: PackedField<Scalar = F>,
 		{
 			group.bench_function(BenchmarkId::new(name, param), |b| {
 				b.iter(|| ntt.inverse_transform(data, 0, log_batch_size));

--- a/crates/ntt/src/additive_ntt.rs
+++ b/crates/ntt/src/additive_ntt.rs
@@ -1,13 +1,14 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use binius_field::{ExtensionField, PackedField, RepackedExtension};
+use binius_field::{BinaryField, ExtensionField, PackedExtension, PackedField};
+use binius_utils::checked_arithmetics::log2_strict_usize;
 
 use super::error::Error;
 
 /// The additive NTT defined in [LCH14].
 ///
 /// [LCH14]: <https://arxiv.org/abs/1404.3458>
-pub trait AdditiveNTT<P: PackedField> {
+pub trait AdditiveNTT<F: BinaryField> {
 	/// Base-2 logarithm of the size of the NTT domain.
 	fn log_domain_size(&self) -> usize;
 
@@ -17,7 +18,7 @@ pub trait AdditiveNTT<P: PackedField> {
 	///
 	/// * `i` must be less than `self.log_domain_size()`
 	/// * `j` must be less than `self.log_domain_size() - i`
-	fn get_subspace_eval(&self, i: usize, j: usize) -> P::Scalar;
+	fn get_subspace_eval(&self, i: usize, j: usize) -> F;
 
 	/// Forward transformation defined in [LCH14] on a batch of inputs.
 	///
@@ -25,12 +26,14 @@ pub trait AdditiveNTT<P: PackedField> {
 	/// The batched inputs are interleaved, which improves the cache-efficiency of the computation.
 	///
 	/// [LCH14]: <https://arxiv.org/abs/1404.3458>
-	fn forward_transform(
+	fn forward_transform<P>(
 		&self,
 		data: &mut [P],
 		coset: u32,
 		log_batch_size: usize,
-	) -> Result<(), Error>;
+	) -> Result<(), Error>
+	where
+		P: PackedField<Scalar = F>;
 
 	/// Inverse transformation defined in [LCH14] on a batch of inputs.
 	///
@@ -38,26 +41,20 @@ pub trait AdditiveNTT<P: PackedField> {
 	/// The batched inputs are interleaved, which improves the cache-efficiency of the computation.
 	///
 	/// [LCH14]: https://arxiv.org/abs/1404.3458
-	fn inverse_transform(
+	fn inverse_transform<P>(
 		&self,
 		data: &mut [P],
 		coset: u32,
 		log_batch_size: usize,
-	) -> Result<(), Error>;
+	) -> Result<(), Error>
+	where
+		P: PackedField<Scalar = F>;
 
-	fn forward_transform_ext<PE: RepackedExtension<P>>(
-		&self,
-		data: &mut [PE],
-		coset: u32,
-	) -> Result<(), Error> {
-		self.forward_transform(PE::cast_bases_mut(data), coset, PE::Scalar::LOG_DEGREE)
+	fn forward_transform_ext<PE: PackedExtension<F>>(&self, data: &mut [PE], coset: u32) -> Result<(), Error> {
+		self.forward_transform(PE::cast_bases_mut(data), coset, log_batch_size)
 	}
 
-	fn inverse_transform_ext<PE: RepackedExtension<P>>(
-		&self,
-		data: &mut [PE],
-		coset: u32,
-	) -> Result<(), Error> {
+	fn inverse_transform_ext<PE: PackedExtension<F>>(&self, data: &mut [PE], coset: u32) -> Result<(), Error> {
 		self.inverse_transform(PE::cast_bases_mut(data), coset, PE::Scalar::LOG_DEGREE)
 	}
 }

--- a/crates/ntt/src/additive_ntt.rs
+++ b/crates/ntt/src/additive_ntt.rs
@@ -1,6 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_field::{BinaryField, ExtensionField, PackedExtension, PackedField};
+use binius_math::BinarySubspace;
 use binius_utils::checked_arithmetics::log2_strict_usize;
 
 use super::error::Error;
@@ -10,7 +11,12 @@ use super::error::Error;
 /// [LCH14]: <https://arxiv.org/abs/1404.3458>
 pub trait AdditiveNTT<F: BinaryField> {
 	/// Base-2 logarithm of the size of the NTT domain.
-	fn log_domain_size(&self) -> usize;
+	fn log_domain_size(&self) -> usize {
+		self.subspace().dim()
+	}
+
+	/// Returns the binary subspace describing the evaluation domain.
+	fn subspace(&self) -> &BinarySubspace<F>;
 
 	/// Get the normalized subspace polynomial evaluation $\hat{W}_i(\beta_j)$.
 	///

--- a/crates/ntt/src/additive_ntt.rs
+++ b/crates/ntt/src/additive_ntt.rs
@@ -2,21 +2,39 @@
 
 use binius_field::{BinaryField, ExtensionField, PackedExtension, PackedField};
 use binius_math::BinarySubspace;
-use binius_utils::checked_arithmetics::log2_strict_usize;
 
 use super::error::Error;
 
-/// The additive NTT defined in [LCH14].
+/// The binary field additive NTT.
+///
+/// A number-theoretic transform (NTT) is a linear transformation on a finite field analogous to
+/// the discrete fourier transform. The version of the additive NTT we use is originally described
+/// in [LCH14]. In [DP24] Section 3.1, the authors present the LCH additive NTT algorithm in a way
+/// that makes apparent its compatibility with the FRI proximity test. Throughout the
+/// documentation, we will refer to the notation used in [DP24].
+///
+/// The additive NTT is parameterized by a binary field $K$ and $\mathbb{F}_2$-linear subspace. We
+/// write $\beta_0, \ldots, \beta_{\ell-1}$ for the ordered basis elements of the subspace and
+/// require $\beta_0 = 1$. The basis determines a novel polynomial basis and an evaluation domain.
+/// In the forward direction, the additive NTT transforms a vector of polynomial coefficients, with
+/// respect to the novel polynomial basis, into a vector of their evaluations over the evaluation
+/// domain. The inverse transformation interpolates polynomial values over the domain into novel
+/// polynomial basis coefficients.
 ///
 /// [LCH14]: <https://arxiv.org/abs/1404.3458>
+/// [DP24]: <https://eprint.iacr.org/2024/504>
 pub trait AdditiveNTT<F: BinaryField> {
-	/// Base-2 logarithm of the size of the NTT domain.
-	fn log_domain_size(&self) -> usize {
-		self.subspace().dim()
-	}
+	/// Base-2 logarithm of the maximum size of the NTT domain, $\ell$.
+	fn log_domain_size(&self) -> usize;
 
-	/// Returns the binary subspace describing the evaluation domain.
-	fn subspace(&self) -> &BinarySubspace<F>;
+	/// Returns the binary subspace $S^(i)$.
+	///
+	/// The domain will have dimension $\ell - i$.
+	///
+	/// ## Preconditions
+	///
+	/// * `i` must be less than `self.log_domain_size()`
+	fn subspace(&self, i: usize) -> BinarySubspace<F>;
 
 	/// Get the normalized subspace polynomial evaluation $\hat{W}_i(\beta_j)$.
 	///
@@ -32,14 +50,12 @@ pub trait AdditiveNTT<F: BinaryField> {
 	/// The batched inputs are interleaved, which improves the cache-efficiency of the computation.
 	///
 	/// [LCH14]: <https://arxiv.org/abs/1404.3458>
-	fn forward_transform<P>(
+	fn forward_transform<P: PackedField<Scalar = F>>(
 		&self,
 		data: &mut [P],
 		coset: u32,
 		log_batch_size: usize,
-	) -> Result<(), Error>
-	where
-		P: PackedField<Scalar = F>;
+	) -> Result<(), Error>;
 
 	/// Inverse transformation defined in [LCH14] on a batch of inputs.
 	///
@@ -47,20 +63,26 @@ pub trait AdditiveNTT<F: BinaryField> {
 	/// The batched inputs are interleaved, which improves the cache-efficiency of the computation.
 	///
 	/// [LCH14]: https://arxiv.org/abs/1404.3458
-	fn inverse_transform<P>(
+	fn inverse_transform<P: PackedField<Scalar = F>>(
 		&self,
 		data: &mut [P],
 		coset: u32,
 		log_batch_size: usize,
-	) -> Result<(), Error>
-	where
-		P: PackedField<Scalar = F>;
+	) -> Result<(), Error>;
 
-	fn forward_transform_ext<PE: PackedExtension<F>>(&self, data: &mut [PE], coset: u32) -> Result<(), Error> {
-		self.forward_transform(PE::cast_bases_mut(data), coset, log_batch_size)
+	fn forward_transform_ext<PE: PackedExtension<F>>(
+		&self,
+		data: &mut [PE],
+		coset: u32,
+	) -> Result<(), Error> {
+		self.forward_transform(PE::cast_bases_mut(data), coset, PE::Scalar::LOG_DEGREE)
 	}
 
-	fn inverse_transform_ext<PE: PackedExtension<F>>(&self, data: &mut [PE], coset: u32) -> Result<(), Error> {
+	fn inverse_transform_ext<PE: PackedExtension<F>>(
+		&self,
+		data: &mut [PE],
+		coset: u32,
+	) -> Result<(), Error> {
 		self.inverse_transform(PE::cast_bases_mut(data), coset, PE::Scalar::LOG_DEGREE)
 	}
 }

--- a/crates/ntt/src/dynamic_dispatch.rs
+++ b/crates/ntt/src/dynamic_dispatch.rs
@@ -90,12 +90,12 @@ impl<F: BinaryField> AdditiveNTT<F> for DynamicDispatchNTT<F> {
 		}
 	}
 
-	fn subspace(&self) -> &BinarySubspace<F> {
+	fn subspace(&self, i: usize) -> BinarySubspace<F> {
 		match self {
-			DynamicDispatchNTT::SingleThreaded(ntt) => ntt.subspace(),
-			DynamicDispatchNTT::SingleThreadedPrecompute(ntt) => ntt.subspace(),
-			DynamicDispatchNTT::MultiThreaded(ntt) => ntt.subspace(),
-			DynamicDispatchNTT::MultiThreadedPrecompute(ntt) => ntt.subspace(),
+			Self::SingleThreaded(ntt) => ntt.subspace(i),
+			Self::SingleThreadedPrecompute(ntt) => ntt.subspace(i),
+			Self::MultiThreaded(ntt) => ntt.subspace(i),
+			Self::MultiThreadedPrecompute(ntt) => ntt.subspace(i),
 		}
 	}
 
@@ -108,15 +108,12 @@ impl<F: BinaryField> AdditiveNTT<F> for DynamicDispatchNTT<F> {
 		}
 	}
 
-	fn forward_transform<P>(
+	fn forward_transform<P: PackedField<Scalar = F>>(
 		&self,
 		data: &mut [P],
 		coset: u32,
 		log_batch_size: usize,
-	) -> Result<(), Error>
-	where
-		P: PackedField<Scalar = F>,
-	{
+	) -> Result<(), Error> {
 		match self {
 			Self::SingleThreaded(ntt) => ntt.forward_transform(data, coset, log_batch_size),
 			Self::SingleThreadedPrecompute(ntt) => {
@@ -129,15 +126,12 @@ impl<F: BinaryField> AdditiveNTT<F> for DynamicDispatchNTT<F> {
 		}
 	}
 
-	fn inverse_transform<P>(
+	fn inverse_transform<P: PackedField<Scalar = F>>(
 		&self,
 		data: &mut [P],
 		coset: u32,
 		log_batch_size: usize,
-	) -> Result<(), Error>
-	where
-		P: PackedField<Scalar = F>,
-	{
+	) -> Result<(), Error> {
 		match self {
 			Self::SingleThreaded(ntt) => ntt.inverse_transform(data, coset, log_batch_size),
 			Self::SingleThreadedPrecompute(ntt) => {

--- a/crates/ntt/src/dynamic_dispatch.rs
+++ b/crates/ntt/src/dynamic_dispatch.rs
@@ -1,6 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_field::{BinaryField, PackedField};
+use binius_math::BinarySubspace;
 use binius_utils::rayon::get_log_max_threads;
 
 use super::{
@@ -86,6 +87,15 @@ impl<F: BinaryField> AdditiveNTT<F> for DynamicDispatchNTT<F> {
 			Self::SingleThreadedPrecompute(ntt) => ntt.log_domain_size(),
 			Self::MultiThreaded(ntt) => ntt.log_domain_size(),
 			Self::MultiThreadedPrecompute(ntt) => ntt.log_domain_size(),
+		}
+	}
+
+	fn subspace(&self) -> &BinarySubspace<F> {
+		match self {
+			DynamicDispatchNTT::SingleThreaded(ntt) => ntt.subspace(),
+			DynamicDispatchNTT::SingleThreadedPrecompute(ntt) => ntt.subspace(),
+			DynamicDispatchNTT::MultiThreaded(ntt) => ntt.subspace(),
+			DynamicDispatchNTT::MultiThreadedPrecompute(ntt) => ntt.subspace(),
 		}
 	}
 

--- a/crates/ntt/src/error.rs
+++ b/crates/ntt/src/error.rs
@@ -8,6 +8,8 @@ pub enum Error {
 	FieldTooSmall { log_domain_size: usize },
 	#[error("domain size is less than 2**{log_required_domain_size}")]
 	DomainTooSmall { log_required_domain_size: usize },
+	#[error("evaluation subspace must include the 1 element")]
+	DomainMustIncludeOne,
 	#[error("the packing width must divide the code dimension")]
 	PackingWidthMustDivideDimension,
 	#[error("the input length must be a power of two")]

--- a/crates/ntt/src/multithreaded.rs
+++ b/crates/ntt/src/multithreaded.rs
@@ -59,11 +59,10 @@ impl<F: BinaryField, TA: TwiddleAccess<F> + Sync> SingleThreadedNTT<F, TA> {
 	}
 }
 
-impl<F, TA, P> AdditiveNTT<P> for MultithreadedNTT<F, TA>
+impl<F, TA: TwiddleAccess<F> + Sync> AdditiveNTT<F> for MultithreadedNTT<F, TA>
 where
 	F: BinaryField,
-	TA: TwiddleAccess<F> + Sync,
-	P: PackedField<Scalar = F>,
+	TA: TwiddleAccess<F>,
 {
 	fn log_domain_size(&self) -> usize {
 		self.log_domain_size()
@@ -73,12 +72,15 @@ where
 		self.get_subspace_eval(i, j)
 	}
 
-	fn forward_transform(
+	fn forward_transform<P>(
 		&self,
 		data: &mut [P],
 		coset: u32,
 		log_batch_size: usize,
-	) -> Result<(), Error> {
+	) -> Result<(), Error>
+	where
+		P: PackedField<Scalar = F>,
+	{
 		forward_transform(
 			self.log_domain_size(),
 			self.single_threaded.twiddles(),
@@ -89,12 +91,15 @@ where
 		)
 	}
 
-	fn inverse_transform(
+	fn inverse_transform<P>(
 		&self,
 		data: &mut [P],
 		coset: u32,
 		log_batch_size: usize,
-	) -> Result<(), Error> {
+	) -> Result<(), Error>
+	where
+		P: PackedField<Scalar = F>,
+	{
 		inverse_transform(
 			self.log_domain_size(),
 			self.single_threaded.twiddles(),

--- a/crates/ntt/src/multithreaded.rs
+++ b/crates/ntt/src/multithreaded.rs
@@ -2,6 +2,7 @@
 
 use binius_field::{BinaryField, PackedField};
 use binius_maybe_rayon::prelude::*;
+use binius_math::BinarySubspace;
 use binius_utils::rayon::get_log_max_threads;
 
 use super::{
@@ -21,23 +22,6 @@ pub struct MultithreadedNTT<
 > {
 	single_threaded: SingleThreadedNTT<F, TA>,
 	log_max_threads: usize,
-}
-
-impl<F: BinaryField, TA: TwiddleAccess<F> + Sync> MultithreadedNTT<F, TA> {
-	/// Base-2 logarithm of the size of the NTT domain.
-	pub fn log_domain_size(&self) -> usize {
-		self.single_threaded.log_domain_size()
-	}
-
-	/// Get the normalized subspace polynomial evaluation $\hat{W}_i(\beta_j)$.
-	///
-	/// ## Preconditions
-	///
-	/// * `i` must be less than `self.log_domain_size()`
-	/// * `j` must be less than `self.log_domain_size() - i`
-	pub fn get_subspace_eval(&self, i: usize, j: usize) -> F {
-		self.single_threaded.get_subspace_eval(i, j)
-	}
 }
 
 impl<F: BinaryField, TA: TwiddleAccess<F> + Sync> SingleThreadedNTT<F, TA> {
@@ -65,11 +49,15 @@ where
 	TA: TwiddleAccess<F>,
 {
 	fn log_domain_size(&self) -> usize {
-		self.log_domain_size()
+		self.single_threaded.log_domain_size()
+	}
+
+	fn subspace(&self) -> &BinarySubspace<F> {
+		self.single_threaded.subspace()
 	}
 
 	fn get_subspace_eval(&self, i: usize, j: usize) -> F {
-		self.get_subspace_eval(i, j)
+		self.single_threaded.get_subspace_eval(i, j)
 	}
 
 	fn forward_transform<P>(

--- a/crates/ntt/src/odd_interpolate.rs
+++ b/crates/ntt/src/odd_interpolate.rs
@@ -19,6 +19,9 @@ impl<F: BinaryField> OddInterpolate<F> {
 	where
 		TA: TwiddleAccess<F>,
 	{
+		// TODO: This constructor should accept an `impl AdditiveNTT` instead of an
+		// `impl TwiddleAccess`. It can use `AdditiveNTT::get_subspace_eval` instead of the twiddle
+		// accessors directly. `AdditiveNTT` is a more public interface.
 		let vandermonde = novel_vandermonde(d, ell, twiddle_access)?;
 
 		let mut vandermonde_inverse = Matrix::zeros(d, d);

--- a/crates/ntt/src/single_threaded.rs
+++ b/crates/ntt/src/single_threaded.rs
@@ -72,11 +72,10 @@ impl<F: BinaryField, TA: TwiddleAccess<F>> SingleThreadedNTT<F, TA> {
 	}
 }
 
-impl<F, TA, P> AdditiveNTT<P> for SingleThreadedNTT<F, TA>
+impl<F, TA: TwiddleAccess<F>> AdditiveNTT<F> for SingleThreadedNTT<F, TA>
 where
 	F: BinaryField,
 	TA: TwiddleAccess<F>,
-	P: PackedField<Scalar = F>,
 {
 	fn log_domain_size(&self) -> usize {
 		self.log_domain_size()
@@ -86,22 +85,28 @@ where
 		self.get_subspace_eval(i, j)
 	}
 
-	fn forward_transform(
+	fn forward_transform<P>(
 		&self,
 		data: &mut [P],
 		coset: u32,
 		log_batch_size: usize,
-	) -> Result<(), Error> {
+	) -> Result<(), Error>
+	where
+		P: PackedField<Scalar = F>,
+	{
 		let log_n = data.len().ilog2() as usize + P::LOG_WIDTH - log_batch_size;
 		forward_transform(self.log_domain_size(), &self.s_evals, data, coset, log_batch_size, log_n)
 	}
 
-	fn inverse_transform(
+	fn inverse_transform<P>(
 		&self,
 		data: &mut [P],
 		coset: u32,
 		log_batch_size: usize,
-	) -> Result<(), Error> {
+	) -> Result<(), Error>
+	where
+		P: PackedField<Scalar = F>,
+	{
 		let log_n = data.len().ilog2() as usize + P::LOG_WIDTH - log_batch_size;
 		inverse_transform(self.log_domain_size(), &self.s_evals, data, coset, log_batch_size, log_n)
 	}

--- a/crates/ntt/src/single_threaded.rs
+++ b/crates/ntt/src/single_threaded.rs
@@ -12,7 +12,7 @@ use crate::twiddle::{expand_subspace_evals, OnTheFlyTwiddleAccess, PrecomputedTw
 #[derive(Debug)]
 pub struct SingleThreadedNTT<F: BinaryField, TA: TwiddleAccess<F> = OnTheFlyTwiddleAccess<F>> {
 	subspace: BinarySubspace<F>,
-	// TODO: Can I remove?
+	// TODO: Figure out how to make this private, it should not be `pub(super)`.
 	pub(super) s_evals: Vec<TA>,
 }
 

--- a/crates/ntt/src/tests/ntt_tests.rs
+++ b/crates/ntt/src/tests/ntt_tests.rs
@@ -10,8 +10,8 @@ use binius_field::{
 		packed_8::PackedBinaryField1x8b,
 	},
 	underlier::{NumCast, WithUnderlier},
-	AESTowerField8b, BinaryField, BinaryField8b, ExtensionField, PackedBinaryField16x32b,
-	PackedBinaryField8x32b, PackedExtension, PackedField, RepackedExtension,
+	AESTowerField8b, BinaryField, BinaryField8b, PackedBinaryField16x32b, PackedBinaryField8x32b,
+	PackedExtension, PackedField, RepackedExtension,
 };
 use rand::{rngs::StdRng, SeedableRng};
 

--- a/crates/ntt/src/tests/ntt_tests.rs
+++ b/crates/ntt/src/tests/ntt_tests.rs
@@ -10,8 +10,8 @@ use binius_field::{
 		packed_8::PackedBinaryField1x8b,
 	},
 	underlier::{NumCast, WithUnderlier},
-	AESTowerField8b, BinaryField, BinaryField8b, PackedBinaryField16x32b, PackedBinaryField8x32b,
-	PackedField, RepackedExtension,
+	AESTowerField8b, BinaryField, BinaryField8b, ExtensionField, PackedBinaryField16x32b,
+	PackedBinaryField8x32b, PackedExtension, PackedField, RepackedExtension,
 };
 use rand::{rngs::StdRng, SeedableRng};
 
@@ -19,13 +19,16 @@ use crate::{dynamic_dispatch::DynamicDispatchNTT, AdditiveNTT, SingleThreadedNTT
 
 /// Check that forward and inverse transformation of `ntt` on `data` is the same as forward and inverse transformation of `reference_ntt` on `data`
 /// and that the result of the roundtrip is the same as the original data.
-fn check_roundtrip_with_reference<P: PackedField>(
-	reference_ntt: &impl AdditiveNTT<P>,
-	ntt: &impl AdditiveNTT<P>,
+fn check_roundtrip_with_reference<F, P>(
+	reference_ntt: &impl AdditiveNTT<F>,
+	ntt: &impl AdditiveNTT<F>,
 	data: &mut [P],
 	cosets: Range<u32>,
 	log_batch_size: usize,
-) {
+) where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+{
 	let data_copy = data.to_vec();
 	let mut data_copy_2 = data.to_vec();
 
@@ -144,12 +147,15 @@ fn tests_field_512_bits() {
 	check_roundtrip_all_ntts::<PackedBinaryField16x32b>(12, 6, 4, 0);
 }
 
-fn check_packed_extension_roundtrip_with_reference<P: PackedField, PE: RepackedExtension<P>>(
-	reference_ntt: &impl AdditiveNTT<P>,
-	ntt: &impl AdditiveNTT<P>,
+fn check_packed_extension_roundtrip_with_reference<F, PE>(
+	reference_ntt: &impl AdditiveNTT<F>,
+	ntt: &impl AdditiveNTT<F>,
 	data: &mut [PE],
 	cosets: Range<u32>,
-) {
+) where
+	F: BinaryField,
+	PE: PackedExtension<F>,
+{
 	let data_copy = data.to_vec();
 	let mut data_copy_2 = data.to_vec();
 

--- a/crates/ntt/src/tests/reference.rs
+++ b/crates/ntt/src/tests/reference.rs
@@ -162,26 +162,28 @@ pub struct SimpleAdditiveNTT<F: BinaryField, TA: TwiddleAccess<F>> {
 	_marker: PhantomData<F>,
 }
 
-impl<F, TA, P> AdditiveNTT<P> for SimpleAdditiveNTT<F, TA>
+impl<F, TA: TwiddleAccess<F>> AdditiveNTT<F> for SimpleAdditiveNTT<F, TA>
 where
 	F: BinaryField,
 	TA: TwiddleAccess<F>,
-	P: PackedField<Scalar = F>,
 {
 	fn log_domain_size(&self) -> usize {
 		self.log_domain_size
 	}
 
-	fn get_subspace_eval(&self, _i: usize, _j: usize) -> <P as PackedField>::Scalar {
+	fn get_subspace_eval(&self, _i: usize, _j: usize) -> F {
 		unimplemented!()
 	}
 
-	fn forward_transform(
+	fn forward_transform<P>(
 		&self,
 		data: &mut [P],
 		coset: u32,
 		log_batch_size: usize,
-	) -> Result<(), Error> {
+	) -> Result<(), Error>
+	where
+		P: PackedField<Scalar = F>,
+	{
 		for batch_index in 0..1 << log_batch_size {
 			let mut batch = BatchedPackedFieldSlice::new(data, log_batch_size, batch_index);
 			forward_transform_simple(self.log_domain_size, &self.s_evals, &mut batch, coset)?;
@@ -190,12 +192,15 @@ where
 		Ok(())
 	}
 
-	fn inverse_transform(
+	fn inverse_transform<P>(
 		&self,
 		data: &mut [P],
 		coset: u32,
 		log_batch_size: usize,
-	) -> Result<(), Error> {
+	) -> Result<(), Error>
+	where
+		P: PackedField<Scalar = F>,
+	{
 		for batch_index in 0..1 << log_batch_size {
 			let mut batch = BatchedPackedFieldSlice::new(data, log_batch_size, batch_index);
 			inverse_transform_simple(self.log_domain_size, &self.s_evals, &mut batch, coset)?;

--- a/crates/ntt/src/tests/reference.rs
+++ b/crates/ntt/src/tests/reference.rs
@@ -1,11 +1,10 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use std::marker::PhantomData;
-
 use binius_field::{
 	packed::{get_packed_slice, set_packed_slice},
 	BinaryField, ExtensionField, PackedField,
 };
+use binius_math::BinarySubspace;
 
 use crate::{twiddle::TwiddleAccess, AdditiveNTT, Error, SingleThreadedNTT};
 
@@ -157,9 +156,8 @@ where
 
 /// Simple NTT implementation that uses the reference implementation for the forward and inverse NTT.
 pub struct SimpleAdditiveNTT<F: BinaryField, TA: TwiddleAccess<F>> {
-	log_domain_size: usize,
+	subspace: BinarySubspace<F>,
 	s_evals: Vec<TA>,
-	_marker: PhantomData<F>,
 }
 
 impl<F, TA: TwiddleAccess<F>> AdditiveNTT<F> for SimpleAdditiveNTT<F, TA>
@@ -167,8 +165,8 @@ where
 	F: BinaryField,
 	TA: TwiddleAccess<F>,
 {
-	fn log_domain_size(&self) -> usize {
-		self.log_domain_size
+	fn subspace(&self) -> &BinarySubspace<F> {
+		&self.subspace
 	}
 
 	fn get_subspace_eval(&self, _i: usize, _j: usize) -> F {
@@ -186,7 +184,7 @@ where
 	{
 		for batch_index in 0..1 << log_batch_size {
 			let mut batch = BatchedPackedFieldSlice::new(data, log_batch_size, batch_index);
-			forward_transform_simple(self.log_domain_size, &self.s_evals, &mut batch, coset)?;
+			forward_transform_simple(self.log_domain_size(), &self.s_evals, &mut batch, coset)?;
 		}
 
 		Ok(())
@@ -203,7 +201,7 @@ where
 	{
 		for batch_index in 0..1 << log_batch_size {
 			let mut batch = BatchedPackedFieldSlice::new(data, log_batch_size, batch_index);
-			inverse_transform_simple(self.log_domain_size, &self.s_evals, &mut batch, coset)?;
+			inverse_transform_simple(self.log_domain_size(), &self.s_evals, &mut batch, coset)?;
 		}
 
 		Ok(())
@@ -217,9 +215,8 @@ where
 {
 	pub(super) fn into_simple_ntt(self) -> SimpleAdditiveNTT<F, TA> {
 		SimpleAdditiveNTT {
-			log_domain_size: self.log_domain_size(),
+			subspace: self.subspace().clone(),
 			s_evals: self.s_evals,
-			_marker: PhantomData,
 		}
 	}
 }

--- a/crates/ntt/src/twiddle.rs
+++ b/crates/ntt/src/twiddle.rs
@@ -3,6 +3,7 @@
 use std::{marker::PhantomData, ops::Deref};
 
 use binius_field::{BinaryField, Field};
+use binius_math::BinarySubspace;
 
 use crate::Error;
 
@@ -88,10 +89,9 @@ pub struct OnTheFlyTwiddleAccess<F, SEvals = Vec<F>> {
 
 impl<F: BinaryField> OnTheFlyTwiddleAccess<F> {
 	/// Generate a vector of OnTheFlyTwiddleAccess objects, one for each NTT round.
-	pub fn generate<DomainField: BinaryField + Into<F>>(
-		log_domain_size: usize,
-	) -> Result<Vec<Self>, Error> {
-		let s_evals = precompute_subspace_evals::<F, DomainField>(log_domain_size)?
+	pub fn generate(subspace: &BinarySubspace<F>) -> Result<Vec<Self>, Error> {
+		let log_domain_size = subspace.dim();
+		let s_evals = precompute_subspace_evals(subspace)?
 			.into_iter()
 			.enumerate()
 			.map(|(i, s_evals_i)| Self {
@@ -164,10 +164,8 @@ pub struct PrecomputedTwiddleAccess<F, SEvals = Vec<F>> {
 }
 
 impl<F: BinaryField> PrecomputedTwiddleAccess<F> {
-	pub fn generate<DomainField: BinaryField + Into<F>>(
-		log_domain_size: usize,
-	) -> Result<Vec<Self>, Error> {
-		let on_the_fly = OnTheFlyTwiddleAccess::<F, _>::generate::<DomainField>(log_domain_size)?;
+	pub fn generate(subspace: &BinarySubspace<F>) -> Result<Vec<Self>, Error> {
+		let on_the_fly = OnTheFlyTwiddleAccess::generate(subspace)?;
 		Ok(expand_subspace_evals(&on_the_fly))
 	}
 }
@@ -210,11 +208,14 @@ where
 /// Let $\hat{W}\_i(X)$ be the normalized subspace polynomial of degree $2^i$ that vanishes on $U_i$
 /// and is $1$ on $\beta_i$.
 /// Return a vector whose $i$th entry is a vector of evaluations of $\hat{W}\_i$ at $\beta_{i+1},\ldots ,\beta_{d-1}$.
-fn precompute_subspace_evals<F: BinaryField, DomainField: BinaryField + Into<F>>(
-	log_domain_size: usize,
+fn precompute_subspace_evals<F: BinaryField>(
+	subspace: &BinarySubspace<F>,
 ) -> Result<Vec<Vec<F>>, Error> {
-	if DomainField::N_BITS < log_domain_size {
-		return Err(Error::FieldTooSmall { log_domain_size });
+	let log_domain_size = subspace.dim();
+	if log_domain_size == 0 {
+		return Err(Error::DomainTooSmall {
+			log_required_domain_size: 1,
+		});
 	}
 
 	let mut s_evals = Vec::with_capacity(log_domain_size);
@@ -224,14 +225,7 @@ fn precompute_subspace_evals<F: BinaryField, DomainField: BinaryField + Into<F>>
 	// $\beta_0 = 1$ and $W\_0(X) = X$, so $W\_0(\beta_0) = \beta_0 = 1$
 	normalization_consts.push(F::ONE);
 	//`s0_evals` = $(\beta_1,\ldots ,\beta_{d-1}) = (W\_0(\beta_1), \ldots , W\_0(\beta_{d-1}))$
-	let s0_evals = (1..log_domain_size)
-		.map(|i| {
-			DomainField::basis(i)
-				.expect("basis vector must exist because of FieldTooSmall check above")
-				.into()
-		})
-		.collect::<Vec<F>>();
-
+	let s0_evals = subspace.basis()[1..].to_vec();
 	s_evals.push(s0_evals);
 	// let $W\_i(X)$ be the *unnormalized* subspace polynomial, i.e., $\prod_{u\in U_{i}}(X-u)$.
 	// Then $W\_{i+1}(X) = W\_i(X)(W\_i(X)+W\_i(\beta_i))$. This crucially uses the "linearity" of
@@ -279,6 +273,7 @@ fn precompute_subspace_evals<F: BinaryField, DomainField: BinaryField + Into<F>>
 fn subspace_map<F: Field>(elem: F, constant: F) -> F {
 	elem.square() + constant * elem
 }
+
 /// Given `OnTheFlyTwiddleAccess` instances for each NTT round, returns a vector of `PrecomputedTwiddleAccess` objects,
 /// one for each NTT round.
 ///
@@ -321,6 +316,7 @@ where
 #[cfg(test)]
 mod tests {
 	use binius_field::{BinaryField, BinaryField16b, BinaryField32b, BinaryField8b};
+	use binius_math::BinarySubspace;
 	use lazy_static::lazy_static;
 	use proptest::prelude::*;
 
@@ -330,19 +326,19 @@ mod tests {
 		// Precomputed and OnTheFlytwiddle access objects for various binary field sizes.
 		// We avoided doing the 32B precomputed twiddle access because the tests take too long.
 		static ref PRECOMPUTED_TWIDDLE_ACCESS_8B: Vec<PrecomputedTwiddleAccess<BinaryField8b>> =
-			PrecomputedTwiddleAccess::<BinaryField8b>::generate::<BinaryField8b>(8).unwrap();
+			PrecomputedTwiddleAccess::<BinaryField8b>::generate(&BinarySubspace::default()).unwrap();
 
 		static ref OTF_TWIDDLE_ACCESS_8B: Vec<OnTheFlyTwiddleAccess<BinaryField8b>> =
-			OnTheFlyTwiddleAccess::<BinaryField8b>::generate::<BinaryField8b>(8).unwrap();
+			OnTheFlyTwiddleAccess::<BinaryField8b>::generate(&BinarySubspace::default()).unwrap();
 
 		static ref PRECOMPUTED_TWIDDLE_ACCESS_16B: Vec<PrecomputedTwiddleAccess<BinaryField16b>> =
-			PrecomputedTwiddleAccess::<BinaryField16b>::generate::<BinaryField16b>(16).unwrap();
+			PrecomputedTwiddleAccess::<BinaryField16b>::generate(&BinarySubspace::default()).unwrap();
 
 		static ref OTF_TWIDDLE_ACCESS_16B: Vec<OnTheFlyTwiddleAccess<BinaryField16b>> =
-			OnTheFlyTwiddleAccess::<BinaryField16b>::generate::<BinaryField16b>(16).unwrap();
+			OnTheFlyTwiddleAccess::<BinaryField16b>::generate(&BinarySubspace::default()).unwrap();
 
 		static ref OTF_TWIDDLE_ACCESS_32B: Vec<OnTheFlyTwiddleAccess<BinaryField32b>> =
-			OnTheFlyTwiddleAccess::<BinaryField32b>::generate::<BinaryField32b>(32).unwrap();
+			OnTheFlyTwiddleAccess::<BinaryField32b>::generate(&BinarySubspace::default()).unwrap();
 	}
 
 	// Tests that `PrecomputedTwiddleAccess` and `OnTheFlyTwiddleAccess`is linear.


### PR DESCRIPTION
This is a refactor that

* Changes `AdditiveNTT` to be parameterized by `F: Field` instead of `P: PackedField`
* Exposes the NTT domain as a `BinarySubspace`

These changes are intended to support future changes that enable NTTs on FRI-compatible additive subspaces. The way NTT domains work currently, additive NTTs created for differently sized domains over the same basis elements are not FRI-compatible.