### PR TITLE
Configurable evaluation order in GPA

### DIFF
--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -212,6 +212,7 @@ where
 
 	let GrandProductBatchProveOutput { final_layer_claims } =
 		gkr_gpa::batch_prove::<FFastExt<Tower>, _, FFastExt<Tower>, _, _>(
+			EvaluationOrder::LowToHigh,
 			all_gpa_witnesses,
 			&all_gpa_claims,
 			&fast_domain_factory,

--- a/crates/core/src/constraint_system/verify.rs
+++ b/crates/core/src/constraint_system/verify.rs
@@ -135,6 +135,7 @@ where
 
 	// Verify grand products
 	let mut final_layer_claims = gkr_gpa::batch_verify(
+		EvaluationOrder::LowToHigh,
 		[flush_prodcheck_claims, non_zero_prodcheck_claims].concat(),
 		&mut transcript,
 	)?;

--- a/crates/core/src/protocols/gkr_gpa/prove.rs
+++ b/crates/core/src/protocols/gkr_gpa/prove.rs
@@ -32,6 +32,7 @@ use crate::{
 /// * The ith witness corresponds to the ith claim
 #[instrument(skip_all, name = "gkr_gpa::batch_prove", level = "debug")]
 pub fn batch_prove<F, P, FDomain, Challenger_, Backend>(
+	evaluation_order: EvaluationOrder,
 	witnesses: impl IntoIterator<Item = GrandProductWitness<P>>,
 	claims: &[GrandProductClaim<F>],
 	evaluation_domain_factory: impl EvaluationDomainFactory<FDomain>,
@@ -89,6 +90,7 @@ where
 		// Step 2: Create sumcheck batch proof
 		let batch_sumcheck_output = {
 			let gpa_sumcheck_prover = GrandProductProverState::stage_gpa_sumcheck_provers(
+				evaluation_order,
 				&sorted_provers,
 				evaluation_domain_factory.clone(),
 			)?;
@@ -248,6 +250,7 @@ where
 	#[allow(clippy::type_complexity)]
 	#[instrument(skip_all, level = "debug")]
 	fn stage_gpa_sumcheck_provers<FDomain>(
+		evaluation_order: EvaluationOrder,
 		provers: &[Self],
 		evaluation_domain_factory: impl EvaluationDomainFactory<FDomain>,
 	) -> Result<
@@ -295,7 +298,7 @@ where
 			.collect::<Vec<_>>();
 
 		Ok(GPAProver::new(
-			EvaluationOrder::LowToHigh,
+			evaluation_order,
 			multilinears,
 			Some(first_layer_mle_advice),
 			composite_claims,

--- a/crates/core/src/protocols/gkr_gpa/prove.rs
+++ b/crates/core/src/protocols/gkr_gpa/prove.rs
@@ -1,6 +1,6 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use binius_field::{Field, PackedExtension, PackedField, PackedFieldIndexable, TowerField};
+use binius_field::{Field, PackedExtension, PackedField, TowerField};
 use binius_hal::ComputationBackend;
 use binius_math::{
 	extrapolate_line_scalar, EvaluationDomainFactory, EvaluationOrder, MLEDirectAdapter,
@@ -41,9 +41,7 @@ pub fn batch_prove<F, P, FDomain, Challenger_, Backend>(
 ) -> Result<GrandProductBatchProveOutput<F>, Error>
 where
 	F: TowerField,
-	P: PackedFieldIndexable<Scalar = F>
-		+ PackedExtension<F, PackedSubfield = P>
-		+ PackedExtension<FDomain>,
+	P: PackedField<Scalar = F> + PackedExtension<FDomain>,
 	FDomain: Field,
 	Challenger_: Challenger,
 	Backend: ComputationBackend,
@@ -135,7 +133,7 @@ fn process_finished_provers<F, P, Backend>(
 ) -> Result<(), Error>
 where
 	F: TowerField,
-	P: PackedFieldIndexable<Scalar = F> + PackedExtension<F, PackedSubfield = P>,
+	P: PackedField<Scalar = F>,
 	Backend: ComputationBackend,
 {
 	while let Some(prover) = sorted_provers.last() {
@@ -179,7 +177,7 @@ where
 impl<'a, F, P, Backend> GrandProductProverState<'a, F, P, Backend>
 where
 	F: TowerField + From<P::Scalar>,
-	P: PackedFieldIndexable<Scalar = F> + PackedExtension<F, PackedSubfield = P>,
+	P: PackedField<Scalar = F>,
 	Backend: ComputationBackend,
 {
 	/// Create a new GrandProductProverState


### PR DESCRIPTION
Adapting GKR GPA to support varying evaluation orders and weakening type bounds to enable byte slice field usage.

Unfortunately work still needs to happen for a potential POLYVAL dethrone (if it's even possible), as evidenced by latest SM benchmarks:

```
gpa_polyval_128b/n_vars=12
                        time:   [36.455 ms 36.751 ms 37.046 ms]
                        thrpt:  [1.1056 Melem/s 1.1145 Melem/s 1.1236 Melem/s]
gpa_polyval_128b/n_vars=16
                        time:   [81.938 ms 82.689 ms 83.378 ms]
                        thrpt:  [7.8601 Melem/s 7.9256 Melem/s 7.9982 Melem/s]
gpa_polyval_128b/n_vars=20
                        time:   [278.98 ms 282.01 ms 284.48 ms]
                        thrpt:  [36.859 Melem/s 37.183 Melem/s 37.586 Melem/s]
gpa_polyval_128b/n_vars=24
                        time:   [2.6647 s 2.6853 s 2.7066 s]
                        thrpt:  [61.987 Melem/s 62.478 Melem/s 62.962 Melem/s]

gpa_polyval_128b_high_to_low/n_vars=12
                        time:   [35.173 ms 35.509 ms 35.825 ms]
                        thrpt:  [1.1433 Melem/s 1.1535 Melem/s 1.1645 Melem/s]
gpa_polyval_128b_high_to_low/n_vars=16
                        time:   [82.704 ms 83.237 ms 83.956 ms]
                        thrpt:  [7.8060 Melem/s 7.8735 Melem/s 7.9242 Melem/s]
gpa_polyval_128b_high_to_low/n_vars=20
                        time:   [297.20 ms 301.10 ms 304.95 ms]
                        thrpt:  [34.385 Melem/s 34.824 Melem/s 35.282 Melem/s]
gpa_polyval_128b_high_to_low/n_vars=24
                        time:   [2.9751 s 2.9858 s 2.9970 s]
                        thrpt:  [55.980 Melem/s 56.189 Melem/s 56.392 Melem/s]

gpa_binary_128b/n_vars=12
                        time:   [99.391 ms 99.832 ms 100.24 ms]
                        thrpt:  [408.63 Kelem/s 410.29 Kelem/s 412.11 Kelem/s]
gpa_binary_128b/n_vars=16
                        time:   [290.00 ms 292.14 ms 294.32 ms]
                        thrpt:  [2.2267 Melem/s 2.2433 Melem/s 2.2599 Melem/s]
gpa_binary_128b/n_vars=20
                        time:   [1.4764 s 1.4832 s 1.4908 s]
                        thrpt:  [7.0337 Melem/s 7.0696 Melem/s 7.1021 Melem/s]
gpa_binary_128b/n_vars=24
                        time:   [18.252 s 18.301 s 18.345 s]
                        thrpt:  [9.1455 Melem/s 9.1675 Melem/s 9.1922 Melem/s]

gpa_byte_sliced_aes_128b/n_vars=16
                        time:   [113.76 ms 114.40 ms 114.77 ms]
                        thrpt:  [5.7103 Melem/s 5.7286 Melem/s 5.7608 Melem/s]
gpa_byte_sliced_aes_128b/n_vars=20
                        time:   [619.47 ms 624.12 ms 629.05 ms]
                        thrpt:  [16.669 Melem/s 16.801 Melem/s 16.927 Melem/s]
gpa_byte_sliced_aes_128b/n_vars=24
                        time:   [8.0507 s 8.0735 s 8.0995 s]
                        thrpt:  [20.714 Melem/s 20.781 Melem/s 20.840 Melem/s]
gpa_byte_sliced_aes_256b/n_vars=12
                        time:   [47.565 ms 47.739 ms 47.926 ms]
                        thrpt:  [854.65 Kelem/s 858.00 Kelem/s 861.14 Kelem/s]
gpa_byte_sliced_aes_256b/n_vars=16
                        time:   [117.89 ms 118.26 ms 118.44 ms]
                        thrpt:  [5.5331 Melem/s 5.5419 Melem/s 5.5590 Melem/s]

gpa_byte_sliced_aes_256b/n_vars=20
                        time:   [615.99 ms 620.79 ms 625.45 ms]
                        thrpt:  [16.765 Melem/s 16.891 Melem/s 17.023 Melem/s]
gpa_byte_sliced_aes_256b/n_vars=24
                        time:   [7.9340 s 7.9650 s 7.9942 s]
                        thrpt:  [20.987 Melem/s 21.064 Melem/s 21.146 Melem/s]
gpa_byte_sliced_aes_512b/n_vars=12
                        time:   [55.550 ms 55.722 ms 55.865 ms]
                        thrpt:  [733.20 Kelem/s 735.08 Kelem/s 737.36 Kelem/s]
gpa_byte_sliced_aes_512b/n_vars=16
                        time:   [126.47 ms 127.06 ms 127.76 ms]
                        thrpt:  [5.1298 Melem/s 5.1578 Melem/s 5.1820 Melem/s]
gpa_byte_sliced_aes_512b/n_vars=20
                        time:   [574.36 ms 577.83 ms 581.18 ms]
                        thrpt:  [18.042 Melem/s 18.147 Melem/s 18.256 Melem/s]
gpa_byte_sliced_aes_512b/n_vars=24
                        time:   [6.9695 s 6.9819 s 6.9946 s]
                        thrpt:  [23.986 Melem/s 24.029 Melem/s 24.072 Melem/s]

gpa_binary_128b_isomorphic/n_vars=12
                        time:   [39.703 ms 40.391 ms 41.006 ms]
                        thrpt:  [998.89 Kelem/s 1.0141 Melem/s 1.0316 Melem/s]
gpa_binary_128b_isomorphic/n_vars=16
                        time:   [151.45 ms 152.18 ms 152.72 ms]
                        thrpt:  [4.2912 Melem/s 4.3066 Melem/s 4.3273 Melem/s]
gpa_binary_128b_isomorphic/n_vars=20
                        time:   [1.3819 s 1.4069 s 1.4318 s]
                        thrpt:  [7.3236 Melem/s 7.4531 Melem/s 7.5878 Melem/s]
gpa_binary_128b_isomorphic/n_vars=24
                        time:   [20.391 s 20.445 s 20.527 s]
                        thrpt:  [8.1732 Melem/s 8.2061 Melem/s 8.2278 Melem/s]
```