### PR TITLE
Fix typo in FRI error message

### DIFF
--- a/crates/core/src/protocols/fri/error.rs
+++ b/crates/core/src/protocols/fri/error.rs
@@ -16,7 +16,7 @@ pub enum Error {
 	InvalidFoldAritySequence,
 	#[error("fold arity at index {index} in sequence is zero")]
 	FoldArityIsZero { index: usize },
-	#[error("the fold arity for the first fold be be at least the log batch size")]
+	#[error("the fold arity for the first fold should be at least the log batch size")]
 	FirstFoldArityTooSmall,
 	#[error("attempted to fold more than maximum of {max_folds} times")]
 	TooManyFoldExecutions { max_folds: usize },


### PR DESCRIPTION
Corrects a duplicated word "be be" in the FirstFoldArityTooSmall error message, replacing it with "should be" for better clarity.