### PR TITLE
[sparse_index] Extend SparseIndex API, and remove `T: Clone` requirement

### DIFF
--- a/crates/core/src/piop/commit.rs
+++ b/crates/core/src/piop/commit.rs
@@ -39,7 +39,7 @@ pub fn make_oracle_commit_meta<F: TowerField>(
 	}
 
 	// First pass: count the number of multilinears and index within buckets
-	let mut first_pass_index = SparseIndex::new(oracles.size());
+	let mut first_pass_index = SparseIndex::with_capacity(oracles.size());
 	let mut n_multilins_by_vars = ResizeableIndex::<usize>::new();
 	for oracle in oracles.iter() {
 		if matches!(oracle.variant, MultilinearPolyVariant::Committed) {
@@ -60,7 +60,7 @@ pub fn make_oracle_commit_meta<F: TowerField>(
 	let commit_meta = CommitMeta::new(n_multilins_by_vars.into_vec());
 
 	// Second pass: use commit_meta counts to finalized indices with offsets
-	let mut index = SparseIndex::new(oracles.size());
+	let mut index = SparseIndex::with_capacity(oracles.size());
 	for id in 0..oracles.size() {
 		if let Some(CommitIDFirstPass {
 			n_packed_vars,

--- a/crates/utils/src/sparse_index.rs
+++ b/crates/utils/src/sparse_index.rs
@@ -51,32 +51,32 @@ impl<T> SparseIndex<T> {
 		self.entries.iter().flatten().count()
 	}
 
-	pub fn iter(&self) -> impl Iterator<Item = (usize, &T)> {
+	pub fn iter(&self) -> impl DoubleEndedIterator<Item = (usize, &T)> {
 		self.entries
 			.iter()
 			.enumerate()
 			.filter_map(|(i, v)| v.as_ref().map(|v| (i, v)))
 	}
 
-	pub fn iter_mut(&mut self) -> impl Iterator<Item = (usize, &mut T)> {
+	pub fn iter_mut(&mut self) -> impl DoubleEndedIterator<Item = (usize, &mut T)> {
 		self.entries
 			.iter_mut()
 			.enumerate()
 			.filter_map(|(i, v)| v.as_mut().map(|v| (i, v)))
 	}
 
-	pub fn keys(&self) -> impl Iterator<Item = usize> + '_ {
+	pub fn keys(&self) -> impl DoubleEndedIterator<Item = usize> + '_ {
 		self.entries
 			.iter()
 			.enumerate()
 			.filter_map(|(i, v)| v.as_ref().map(|_| i))
 	}
 
-	pub fn values(&self) -> impl Iterator<Item = &T> {
+	pub fn values(&self) -> impl DoubleEndedIterator<Item = &T> {
 		self.entries.iter().flatten()
 	}
 
-	pub fn values_mut(&mut self) -> impl Iterator<Item = &mut T> {
+	pub fn values_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut T> {
 		self.entries.iter_mut().flatten()
 	}
 }

--- a/crates/utils/src/sparse_index.rs
+++ b/crates/utils/src/sparse_index.rs
@@ -45,6 +45,10 @@ impl<T> SparseIndex<T> {
 		self.get(id).is_some()
 	}
 
+	pub fn is_empty(&self) -> bool {
+		self.entries.iter().all(|v| v.is_none())
+	}
+
 	pub fn len(&self) -> usize {
 		self.entries.iter().flatten().count()
 	}
@@ -76,7 +80,7 @@ impl<T> IntoIterator for SparseIndex<T> {
 
 impl<T> std::iter::FromIterator<(usize, T)> for SparseIndex<T> {
 	fn from_iter<I: IntoIterator<Item = (usize, T)>>(iter: I) -> Self {
-		let mut index = SparseIndex::new();
+		let mut index = Self::new();
 		for (i, v) in iter {
 			index.set(i, v);
 		}

--- a/crates/utils/src/sparse_index.rs
+++ b/crates/utils/src/sparse_index.rs
@@ -11,17 +11,17 @@ impl<T> SparseIndex<T> {
 		Self::default()
 	}
 
+	pub fn with_capacity(capacity: usize) -> Self {
+		let mut entries = Vec::with_capacity(capacity);
+		entries.resize_with(capacity, || None);
+		Self { entries }
+	}
+
 	pub fn entry(&mut self, id: usize) -> Entry<T> {
 		if self.entries.len() <= id {
 			self.entries.resize_with(id + 1, || None);
 		}
 		Entry(&mut self.entries[id])
-	}
-
-	pub fn with_capacity(capacity: usize) -> Self {
-		let mut entries = Vec::with_capacity(capacity);
-		entries.resize_with(capacity, || None);
-		Self { entries }
 	}
 
 	pub fn get(&self, id: usize) -> Option<&T> {

--- a/crates/utils/src/sparse_index.rs
+++ b/crates/utils/src/sparse_index.rs
@@ -1,16 +1,14 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 /// An index mapping positive integer IDs to optional values.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct SparseIndex<T> {
 	entries: Vec<Option<T>>,
 }
 
 impl<T> SparseIndex<T> {
 	pub fn new() -> Self {
-		Self {
-			entries: Vec::new(),
-		}
+		Self::default()
 	}
 
 	pub fn entry(&mut self, id: usize) -> Entry<T> {
@@ -42,7 +40,7 @@ impl<T> SparseIndex<T> {
 	}
 
 	pub fn contains_key(&self, id: usize) -> bool {
-		self.get(id).is_some()
+		self.entries.get(id).map(|x| x.is_some()).unwrap_or(false)
 	}
 
 	pub fn is_empty(&self) -> bool {
@@ -80,6 +78,14 @@ impl<T> SparseIndex<T> {
 
 	pub fn values_mut(&mut self) -> impl Iterator<Item = &mut T> {
 		self.entries.iter_mut().flatten()
+	}
+}
+
+impl<T> Default for SparseIndex<T> {
+	fn default() -> Self {
+		Self {
+			entries: Vec::new(),
+		}
 	}
 }
 

--- a/crates/utils/src/sparse_index.rs
+++ b/crates/utils/src/sparse_index.rs
@@ -1,26 +1,111 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 /// An index mapping positive integer IDs to optional values.
-#[derive(Debug)]
+#[derive(Debug, Clone, Default)]
 pub struct SparseIndex<T> {
 	entries: Vec<Option<T>>,
 }
 
-impl<T: Clone> SparseIndex<T> {
-	pub fn new(id_bound: usize) -> Self {
+impl<T> SparseIndex<T> {
+	pub fn new() -> Self {
 		Self {
-			entries: vec![None; id_bound],
+			entries: Vec::new(),
 		}
+	}
+
+	pub fn entry(&mut self, id: usize) -> Entry<T> {
+		if self.entries.len() <= id {
+			self.entries.resize_with(id + 1, || None);
+		}
+		Entry(&mut self.entries[id])
+	}
+
+	pub fn with_capacity(capacity: usize) -> Self {
+		let mut entries = Vec::with_capacity(capacity);
+		entries.resize_with(capacity, || None);
+		Self { entries }
 	}
 
 	pub fn get(&self, id: usize) -> Option<&T> {
 		self.entries.get(id)?.as_ref()
 	}
 
+	pub fn get_mut(&mut self, id: usize) -> Option<&mut T> {
+		self.entries.get_mut(id)?.as_mut()
+	}
+
 	pub fn set(&mut self, id: usize, val: T) {
 		if self.entries.len() <= id {
-			self.entries.resize(id + 1, None);
+			self.entries.resize_with(id + 1, || None);
 		}
 		self.entries[id] = Some(val);
+	}
+
+	pub fn contains_key(&self, id: usize) -> bool {
+		self.get(id).is_some()
+	}
+
+	pub fn len(&self) -> usize {
+		self.entries.iter().flatten().count()
+	}
+
+	pub fn iter(&self) -> impl Iterator<Item = &T> {
+		self.entries.iter().flatten()
+	}
+
+	pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
+		self.entries.iter_mut().flatten()
+	}
+
+	pub fn keys(&self) -> impl Iterator<Item = usize> + '_ {
+		self.entries
+			.iter()
+			.enumerate()
+			.filter_map(|(i, v)| v.as_ref().map(|_| i))
+	}
+}
+
+impl<T> IntoIterator for SparseIndex<T> {
+	type Item = T;
+	type IntoIter = std::iter::Flatten<std::vec::IntoIter<Option<Self::Item>>>;
+
+	fn into_iter(self) -> Self::IntoIter {
+		self.entries.into_iter().flatten()
+	}
+}
+
+impl<T> std::iter::FromIterator<(usize, T)> for SparseIndex<T> {
+	fn from_iter<I: IntoIterator<Item = (usize, T)>>(iter: I) -> Self {
+		let mut index = SparseIndex::new();
+		for (i, v) in iter {
+			index.set(i, v);
+		}
+		index
+	}
+}
+
+impl<T> std::ops::Index<usize> for SparseIndex<T> {
+	type Output = T;
+
+	fn index(&self, index: usize) -> &Self::Output {
+		self.get(index).unwrap()
+	}
+}
+
+impl<T> std::ops::IndexMut<usize> for SparseIndex<T> {
+	fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+		self.get_mut(index).unwrap()
+	}
+}
+
+pub struct Entry<'a, V: 'a>(&'a mut Option<V>);
+
+impl<'a, V: 'a> Entry<'a, V> {
+	pub fn or_insert(self, default: V) -> &'a mut V {
+		self.0.get_or_insert(default)
+	}
+
+	pub fn or_insert_with(self, f: impl FnOnce() -> V) -> &'a mut V {
+		self.0.get_or_insert_with(f)
 	}
 }

--- a/crates/utils/src/sparse_index.rs
+++ b/crates/utils/src/sparse_index.rs
@@ -53,12 +53,18 @@ impl<T> SparseIndex<T> {
 		self.entries.iter().flatten().count()
 	}
 
-	pub fn iter(&self) -> impl Iterator<Item = &T> {
-		self.entries.iter().flatten()
+	pub fn iter(&self) -> impl Iterator<Item = (usize, &T)> {
+		self.entries
+			.iter()
+			.enumerate()
+			.filter_map(|(i, v)| v.as_ref().map(|v| (i, v)))
 	}
 
-	pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
-		self.entries.iter_mut().flatten()
+	pub fn iter_mut(&mut self) -> impl Iterator<Item = (usize, &mut T)> {
+		self.entries
+			.iter_mut()
+			.enumerate()
+			.filter_map(|(i, v)| v.as_mut().map(|v| (i, v)))
 	}
 
 	pub fn keys(&self) -> impl Iterator<Item = usize> + '_ {
@@ -67,14 +73,28 @@ impl<T> SparseIndex<T> {
 			.enumerate()
 			.filter_map(|(i, v)| v.as_ref().map(|_| i))
 	}
+
+	pub fn values(&self) -> impl Iterator<Item = &T> {
+		self.entries.iter().flatten()
+	}
+
+	pub fn values_mut(&mut self) -> impl Iterator<Item = &mut T> {
+		self.entries.iter_mut().flatten()
+	}
 }
 
 impl<T> IntoIterator for SparseIndex<T> {
-	type Item = T;
-	type IntoIter = std::iter::Flatten<std::vec::IntoIter<Option<Self::Item>>>;
+	type Item = (usize, T);
+	type IntoIter = std::iter::FilterMap<
+		std::iter::Enumerate<std::vec::IntoIter<Option<T>>>,
+		fn((usize, Option<T>)) -> Option<(usize, T)>,
+	>;
 
 	fn into_iter(self) -> Self::IntoIter {
-		self.entries.into_iter().flatten()
+		self.entries
+			.into_iter()
+			.enumerate()
+			.filter_map(|(i, v)| v.map(|v| (i, v)))
 	}
 }
 


### PR DESCRIPTION
Adds more methods that are similar to other std collection methods