### PR TITLE
[benches] Add Bytesliced additive NTT benchmark

### DIFF
--- a/crates/ntt/benches/large_transform.rs
+++ b/crates/ntt/benches/large_transform.rs
@@ -3,17 +3,17 @@
 use std::iter::repeat_with;
 
 use binius_field::{
-	arch::OptimalUnderlier, as_packed_field::PackedType, BinaryField32b, PackedField,
+	arch::OptimalUnderlier, as_packed_field::PackedType, AESTowerField32b, BinaryField32b,
+	ByteSlicedAES16x32b, PackedField, TowerField,
 };
 use binius_ntt::{AdditiveNTT, SingleThreadedNTT};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use rand::thread_rng;
 
-fn bench_large_transform(c: &mut Criterion) {
-	type U = OptimalUnderlier;
-	type F = BinaryField32b;
-	type P = PackedType<U, F>;
-
+fn bench_large_transform<F: TowerField, P: PackedField<Scalar = F>>(
+	c: &mut Criterion,
+	field: &str,
+) {
 	let mut group = c.benchmark_group("slow/transform");
 	for log_n in std::iter::once(17) {
 		for log_batch_size in [4, 6] {
@@ -23,7 +23,7 @@ fn bench_large_transform(c: &mut Criterion) {
 				.take(data_len)
 				.collect::<Vec<_>>();
 
-			let params = format!("field=BinaryField32b/log_n={log_n}/log_b={log_batch_size}");
+			let params = format!("{field}/log_n={log_n}/log_b={log_batch_size}");
 			group.throughput(Throughput::Bytes((data_len * size_of::<P>()) as u64));
 
 			let ntt = SingleThreadedNTT::<F>::new(log_n)
@@ -44,9 +44,29 @@ fn bench_large_transform(c: &mut Criterion) {
 	}
 }
 
+// We are ignoring the transposition associated with byte slicing
+fn bench_byte_sliced(c: &mut Criterion) {
+	type F = AESTowerField32b;
+	type PByteSliced = ByteSlicedAES16x32b;
+
+	bench_large_transform::<F, PByteSliced>(c, "bytesliced=ByteSlicedAES16x32b")
+}
+
+fn bench_packed32(c: &mut Criterion) {
+	bench_large_transform::<BinaryField32b, PackedType<OptimalUnderlier, BinaryField32b>>(
+		c,
+		"field=BinaryField32b",
+	);
+
+	bench_large_transform::<AESTowerField32b, PackedType<OptimalUnderlier, AESTowerField32b>>(
+		c,
+		"field=AESTowerField32b",
+	);
+}
+
 criterion_group! {
 	name = large_transform;
 	config = Criterion::default().sample_size(10);
-	targets = bench_large_transform
+	targets = bench_packed32, bench_byte_sliced
 }
 criterion_main!(large_transform);

--- a/crates/ntt/benches/large_transform.rs
+++ b/crates/ntt/benches/large_transform.rs
@@ -3,13 +3,37 @@
 use std::iter::repeat_with;
 
 use binius_field::{
-	arch::OptimalUnderlier, as_packed_field::PackedType, AESTowerField32b, BinaryField32b,
-	ByteSlicedAES16x32b, PackedField, TowerField,
+	arch::OptimalUnderlier, as_packed_field::PackedType, AESTowerField32b, BinaryField,
+	BinaryField32b, ByteSlicedAES16x32b, ByteSlicedAES32x32b, ByteSlicedAES64x32b, PackedField,
+	TowerField,
 };
 use binius_maybe_rayon::prelude::*;
 use binius_ntt::{AdditiveNTT, SingleThreadedNTT};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use rand::thread_rng;
+
+fn transform<P: PackedField<Scalar: BinaryField>>(
+	data: &mut [P],
+	log_dim: usize,
+	log_batch_size: usize,
+	log_inv_rate: usize,
+	ntt: &(impl AdditiveNTT<P::Scalar> + Sync),
+	multi_threaded: bool,
+) {
+	let msgs_len = ((1 << log_dim) / P::WIDTH) << log_batch_size;
+	if multi_threaded {
+		(0..(1 << log_inv_rate))
+			.into_par_iter()
+			.zip(data.par_chunks_exact_mut(msgs_len))
+			.try_for_each(|(i, data)| ntt.forward_transform(data, i, log_batch_size))
+			.expect("Failed to run ntt")
+	} else {
+		(0..(1 << log_inv_rate))
+			.zip(data.chunks_exact_mut(msgs_len))
+			.try_for_each(|(i, data)| ntt.forward_transform(data, i, log_batch_size))
+			.expect("Failed to run ntt")
+	}
+}
 
 fn bench_large_transform<F: TowerField, P: PackedField<Scalar = F>>(
 	c: &mut Criterion,
@@ -17,56 +41,49 @@ fn bench_large_transform<F: TowerField, P: PackedField<Scalar = F>>(
 ) {
 	let mut group = c.benchmark_group("slow/transform");
 	const LOG_BATCH_SIZE: usize = 6;
-	for log_dim in std::iter::once(16) {
-		for log_inv_rate in [1, 2] {
-			let data_len = 1 << (log_dim + LOG_BATCH_SIZE + log_inv_rate - P::LOG_WIDTH);
-			let mut rng = thread_rng();
-			let mut data = repeat_with(|| P::random(&mut rng))
-				.take(data_len)
-				.collect::<Vec<_>>();
+	const LOG_DIM: usize = 16;
+	for log_inv_rate in [1, 2] {
+		let data_len = 1 << (LOG_DIM + LOG_BATCH_SIZE + log_inv_rate - P::LOG_WIDTH);
+		let mut rng = thread_rng();
+		let mut data = repeat_with(|| P::random(&mut rng))
+			.take(data_len)
+			.collect::<Vec<_>>();
 
-			let params = format!(
-				"{field}/log_dim={log_dim}/log_inv_rate={log_inv_rate}/log_b={LOG_BATCH_SIZE}"
-			);
-			group.throughput(Throughput::Bytes((data_len * size_of::<P>()) as u64));
+		let params =
+			format!("{field}/log_dim={LOG_DIM}/log_inv_rate={log_inv_rate}/log_b={LOG_BATCH_SIZE}");
+		group.throughput(Throughput::Bytes((data_len * size_of::<P>()) as u64));
 
-			let ntt = SingleThreadedNTT::<F>::new(log_dim + log_inv_rate)
-				.unwrap()
-				.precompute_twiddles();
-			group.bench_function(BenchmarkId::new("single-thread/precompute", &params), |b| {
-				let msgs_len = ((1 << log_dim) / P::WIDTH) << LOG_BATCH_SIZE;
-				b.iter(|| {
-					(0..(1 << log_inv_rate))
-						.zip(data.chunks_exact_mut(msgs_len))
-						.try_for_each(|(i, data)| ntt.forward_transform(data, i, LOG_BATCH_SIZE))
-						.expect("Failed to run ntt")
-				});
-			});
+		let ntt = SingleThreadedNTT::<F>::new(LOG_DIM + log_inv_rate)
+			.unwrap()
+			.precompute_twiddles();
+		group.bench_function(BenchmarkId::new("single-thread/precompute", &params), |b| {
+			b.iter(|| transform(&mut data, LOG_DIM, LOG_BATCH_SIZE, log_inv_rate, &ntt, false));
+		});
 
-			let ntt = SingleThreadedNTT::<F>::new(log_dim + log_inv_rate)
-				.unwrap()
-				.precompute_twiddles()
-				.multithreaded();
-			group.bench_function(BenchmarkId::new("multithread/precompute", &params), |b| {
-				let msgs_len = ((1 << log_dim) / P::WIDTH) << LOG_BATCH_SIZE;
-				b.iter(|| {
-					(0..(1 << log_inv_rate))
-						.into_par_iter()
-						.zip(data.par_chunks_exact_mut(msgs_len))
-						.try_for_each(|(i, data)| ntt.forward_transform(data, i, LOG_BATCH_SIZE))
-						.expect("Failed to run ntt")
-				});
-			});
-		}
+		let ntt = SingleThreadedNTT::<F>::new(LOG_DIM + log_inv_rate)
+			.unwrap()
+			.precompute_twiddles()
+			.multithreaded();
+		group.bench_function(BenchmarkId::new("multithread/precompute", &params), |b| {
+			b.iter(|| transform(&mut data, LOG_DIM, LOG_BATCH_SIZE, log_inv_rate, &ntt, true));
+		});
 	}
 }
 
 // We are ignoring the transposition associated with byte slicing
 fn bench_byte_sliced(c: &mut Criterion) {
-	type F = AESTowerField32b;
-	type PByteSliced = ByteSlicedAES16x32b;
-
-	bench_large_transform::<F, PByteSliced>(c, "bytesliced=ByteSlicedAES16x32b")
+	bench_large_transform::<AESTowerField32b, ByteSlicedAES16x32b>(
+		c,
+		"bytesliced=ByteSlicedAES16x32b",
+	);
+	bench_large_transform::<AESTowerField32b, ByteSlicedAES32x32b>(
+		c,
+		"bytesliced=ByteSlicedAES32x32b",
+	);
+	bench_large_transform::<AESTowerField32b, ByteSlicedAES64x32b>(
+		c,
+		"bytesliced=ByteSlicedAES64x32b",
+	);
 }
 
 fn bench_packed32(c: &mut Criterion) {


### PR DESCRIPTION
This small MR adds Bytesliced Additive NTT and comparable packed AES Benchmarks. Note that the ByteSliced benchmark does not take into account data transposition. Preliminary investigations indicate Bytesliced NTT to be faster than `AESTowerField` on non gfni machines and seems to perform worse on machines with gfni instructions.

## Benchmark results on M3 pro
```
slow/transform/single-thread/precompute/field=BinaryField32b/log_dim=16/log_inv_rate=1/log_b=6
                        time:   [524.57 ms 537.78 ms 553.70 ms]
                        thrpt:  [57.793 MiB/s 59.504 MiB/s 61.003 MiB/s]
                 change:
                        time:   [+0.8019% +3.2481% +6.1817%] (p = 0.04 < 0.05)
                        thrpt:  [-5.8218% -3.1459% -0.7955%]
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
slow/transform/multithread/precompute/field=BinaryField32b/log_dim=16/log_inv_rate=1/log_b=6
                        time:   [78.055 ms 78.609 ms 79.061 ms]
                        thrpt:  [404.75 MiB/s 407.08 MiB/s 409.97 MiB/s]
                 change:
                        time:   [-1.4246% +0.0546% +1.6152%] (p = 0.95 > 0.05)
                        thrpt:  [-1.5895% -0.0546% +1.4452%]
                        No change in performance detected.
Found 4 outliers among 10 measurements (40.00%)
  2 (20.00%) low mild
  2 (20.00%) high mild
slow/transform/single-thread/precompute/field=BinaryField32b/log_dim=16/log_inv_rate=2/log_b=6
                        time:   [1.1203 s 1.1300 s 1.1409 s]
                        thrpt:  [56.097 MiB/s 56.637 MiB/s 57.127 MiB/s]
                 change:
                        time:   [+1.4836% +2.5730% +3.8381%] (p = 0.00 < 0.05)
                        thrpt:  [-3.6962% -2.5084% -1.4619%]
                        Performance has regressed.

slow/transform/multithread/precompute/field=BinaryField32b/log_dim=16/log_inv_rate=2/log_b=6
                        time:   [152.81 ms 155.62 ms 157.72 ms]
                        thrpt:  [405.79 MiB/s 411.27 MiB/s 418.83 MiB/s]
                 change:
                        time:   [+0.8270% +2.8808% +4.9279%] (p = 0.02 < 0.05)
                        thrpt:  [-4.6964% -2.8001% -0.8203%]
                        Change within noise threshold.
slow/transform/single-thread/precompute/field=AESTowerField32b/log_dim=16/log_inv_rate=1/log_b=6
                        time:   [165.55 ms 167.10 ms 168.68 ms]
                        thrpt:  [189.71 MiB/s 191.50 MiB/s 193.29 MiB/s]
                 change:
                        time:   [+0.2218% +0.6577% +1.2384%] (p = 0.02 < 0.05)
                        thrpt:  [-1.2233% -0.6534% -0.2213%]
                        Change within noise threshold.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
slow/transform/multithread/precompute/field=AESTowerField32b/log_dim=16/log_inv_rate=1/log_b=6
                        time:   [25.716 ms 26.049 ms 26.274 ms]
                        thrpt:  [1.1894 GiB/s 1.1996 GiB/s 1.2152 GiB/s]
                 change:
                        time:   [+0.1690% +0.9865% +1.8303%] (p = 0.04 < 0.05)
                        thrpt:  [-1.7974% -0.9769% -0.1687%]
                        Change within noise threshold.
slow/transform/single-thread/precompute/field=AESTowerField32b/log_dim=16/log_inv_rate=2/log_b=6
                        time:   [331.18 ms 332.89 ms 336.08 ms]
                        thrpt:  [190.43 MiB/s 192.26 MiB/s 193.25 MiB/s]
                 change:
                        time:   [+0.0488% +0.5688% +1.5236%] (p = 0.20 > 0.05)
                        thrpt:  [-1.5008% -0.5656% -0.0488%]
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
slow/transform/multithread/precompute/field=AESTowerField32b/log_dim=16/log_inv_rate=2/log_b=6
                        time:   [48.129 ms 48.545 ms 49.180 ms]
                        thrpt:  [1.2708 GiB/s 1.2875 GiB/s 1.2986 GiB/s]
                 change:
                        time:   [-0.8361% +0.3730% +1.5808%] (p = 0.60 > 0.05)
                        thrpt:  [-1.5562% -0.3716% +0.8431%]
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild

slow/transform/single-thread/precompute/bytesliced=ByteSlicedAES16x32b/log_dim=16/log_inv_rate=1/log...
                        time:   [62.136 ms 62.567 ms 63.284 ms]
                        thrpt:  [505.65 MiB/s 511.45 MiB/s 515.00 MiB/s]
                 change:
                        time:   [-0.4191% +0.0884% +0.7655%] (p = 0.84 > 0.05)
                        thrpt:  [-0.7596% -0.0883% +0.4209%]
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
slow/transform/multithread/precompute/bytesliced=ByteSlicedAES16x32b/log_dim=16/log_inv_rate=1/log_b...
                        time:   [10.227 ms 10.435 ms 10.704 ms]
                        thrpt:  [2.9194 GiB/s 2.9948 GiB/s 3.0555 GiB/s]
                 change:
                        time:   [+2.7617% +5.2016% +8.1041%] (p = 0.00 < 0.05)
                        thrpt:  [-7.4966% -4.9444% -2.6874%]
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
slow/transform/single-thread/precompute/bytesliced=ByteSlicedAES16x32b/log_dim=16/log_inv_rate=2/log...
                        time:   [127.45 ms 129.08 ms 131.71 ms]
                        thrpt:  [485.90 MiB/s 495.81 MiB/s 502.17 MiB/s]
                 change:
                        time:   [+2.6732% +4.4078% +6.5110%] (p = 0.00 < 0.05)
                        thrpt:  [-6.1129% -4.2218% -2.6036%]
                        Performance has regressed.
slow/transform/multithread/precompute/bytesliced=ByteSlicedAES16x32b/log_dim=16/log_inv_rate=2/log_b...
                        time:   [18.986 ms 19.058 ms 19.142 ms]
                        thrpt:  [3.2650 GiB/s 3.2795 GiB/s 3.2919 GiB/s]
                 change:
                        time:   [+1.3901% +2.2093% +2.9635%] (p = 0.00 < 0.05)
                        thrpt:  [-2.8782% -2.1616% -1.3710%]
                        Performance has regressed.

slow/transform/single-thread/precompute/bytesliced=ByteSlicedAES32x32b/log_dim=16/log_inv_rate=1/log...
                        time:   [61.729 ms 61.825 ms 61.954 ms]
                        thrpt:  [516.51 MiB/s 517.59 MiB/s 518.39 MiB/s]
                 change:
                        time:   [-3.5487% -1.5040% -0.2825%] (p = 0.12 > 0.05)
                        thrpt:  [+0.2833% +1.5270% +3.6793%]
                        No change in performance detected.
slow/transform/multithread/precompute/bytesliced=ByteSlicedAES32x32b/log_dim=16/log_inv_rate=1/log_b...
                        time:   [10.274 ms 10.311 ms 10.383 ms]
                        thrpt:  [3.0097 GiB/s 3.0306 GiB/s 3.0416 GiB/s]
                 change:
                        time:   [+2.1492% +3.9779% +5.1676%] (p = 0.00 < 0.05)
                        thrpt:  [-4.9137% -3.8257% -2.1040%]
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
slow/transform/single-thread/precompute/bytesliced=ByteSlicedAES32x32b/log_dim=16/log_inv_rate=2/log...
                        time:   [123.18 ms 123.31 ms 123.50 ms]
                        thrpt:  [518.24 MiB/s 519.01 MiB/s 519.58 MiB/s]
                 change:
                        time:   [-1.9616% -0.9815% -0.4011%] (p = 0.02 < 0.05)
                        thrpt:  [+0.4027% +0.9912% +2.0009%]
                        Change within noise threshold.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
slow/transform/multithread/precompute/bytesliced=ByteSlicedAES32x32b/log_dim=16/log_inv_rate=2/log_b...
                        time:   [19.002 ms 19.192 ms 19.505 ms]
                        thrpt:  [3.2043 GiB/s 3.2566 GiB/s 3.2892 GiB/s]
                 change:
                        time:   [+2.3420% +3.8151% +5.2446%] (p = 0.00 < 0.05)
                        thrpt:  [-4.9832% -3.6749% -2.2884%]
                        Performance has regressed.

slow/transform/single-thread/precompute/bytesliced=ByteSlicedAES64x32b/log_dim=16/log_inv_rate=1/log...
                        time:   [68.083 ms 68.326 ms 68.850 ms]
                        thrpt:  [464.78 MiB/s 468.35 MiB/s 470.01 MiB/s]
                 change:
                        time:   [-0.6191% +0.4471% +2.2732%] (p = 0.74 > 0.05)
                        thrpt:  [-2.2226% -0.4452% +0.6230%]
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
slow/transform/multithread/precompute/bytesliced=ByteSlicedAES64x32b/log_dim=16/log_inv_rate=1/log_b...
                        time:   [11.186 ms 11.333 ms 11.496 ms]
                        thrpt:  [2.7184 GiB/s 2.7573 GiB/s 2.7937 GiB/s]
                 change:
                        time:   [+3.1109% +4.6239% +6.7137%] (p = 0.00 < 0.05)
                        thrpt:  [-6.2913% -4.4196% -3.0171%]
                        Performance has regressed.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
slow/transform/single-thread/precompute/bytesliced=ByteSlicedAES64x32b/log_dim=16/log_inv_rate=2/log...
                        time:   [136.01 ms 136.19 ms 136.38 ms]
                        thrpt:  [469.27 MiB/s 469.94 MiB/s 470.55 MiB/s]
                 change:
                        time:   [-0.8268% -0.5833% -0.3636%] (p = 0.00 < 0.05)
                        thrpt:  [+0.3650% +0.5867% +0.8337%]
                        Change within noise threshold.
slow/transform/multithread/precompute/bytesliced=ByteSlicedAES64x32b/log_dim=16/log_inv_rate=2/log_b...
                        time:   [20.702 ms 20.761 ms 20.813 ms]
                        thrpt:  [3.0029 GiB/s 3.0104 GiB/s 3.0190 GiB/s]
                 change:
                        time:   [-27.105% -12.610% -0.3641%] (p = 0.19 > 0.05)
                        thrpt:  [+0.3654% +14.430% +37.184%]
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low severe
  1 (10.00%) low mild

```

## Benchmark results on `c7a-2xlarge`
```
slow/transform/single-thread/precompute/field=BinaryField32b/log_dim=16/log_inv_rate=1/log_b=6
                        time:   [37.274 ms 37.295 ms 37.315 ms]
                        thrpt:  [857.56 MiB/s 858.02 MiB/s 858.50 MiB/s]
                 change:
                        time:   [-0.0169% +0.0204% +0.0625%] (p = 0.41 > 0.05)
                        thrpt:  [-0.0625% -0.0204% +0.0169%]
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
slow/transform/multithread/precompute/field=BinaryField32b/log_dim=16/log_inv_rate=1/log_b=6
                        time:   [4.7230 ms 4.7275 ms 4.7356 ms]
                        thrpt:  [6.5990 GiB/s 6.6102 GiB/s 6.6166 GiB/s]
                 change:
                        time:   [+0.3630% +1.8030% +4.4955%] (p = 0.17 > 0.05)
                        thrpt:  [-4.3021% -1.7711% -0.3617%]
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
slow/transform/single-thread/precompute/field=BinaryField32b/log_dim=16/log_inv_rate=2/log_b=6
                        time:   [74.567 ms 74.584 ms 74.610 ms]
                        thrpt:  [857.79 MiB/s 858.09 MiB/s 858.29 MiB/s]
                 change:
                        time:   [-0.1450% -0.0815% -0.0130%] (p = 0.04 < 0.05)
                        thrpt:  [+0.0130% +0.0816% +0.1452%]
                        Change within noise threshold.
slow/transform/multithread/precompute/field=BinaryField32b/log_dim=16/log_inv_rate=2/log_b=6
                        time:   [11.382 ms 11.409 ms 11.433 ms]
                        thrpt:  [5.4665 GiB/s 5.4779 GiB/s 5.4909 GiB/s]
                 change:
                        time:   [-0.4645% -0.0363% +0.4060%] (p = 0.88 > 0.05)
                        thrpt:  [-0.4044% +0.0363% +0.4666%]
                        No change in performance detected.

slow/transform/single-thread/precompute/field=AESTowerField32b/log_dim=16/log_inv_rate=1/log_b=6
                        time:   [37.019 ms 37.044 ms 37.062 ms]
                        thrpt:  [863.43 MiB/s 863.85 MiB/s 864.42 MiB/s]
                 change:
                        time:   [-0.1272% -0.0713% -0.0089%] (p = 0.04 < 0.05)
                        thrpt:  [+0.0089% +0.0713% +0.1274%]
                        Change within noise threshold.
slow/transform/multithread/precompute/field=AESTowerField32b/log_dim=16/log_inv_rate=1/log_b=6
                        time:   [4.6647 ms 4.6684 ms 4.6755 ms]
                        thrpt:  [6.6838 GiB/s 6.6940 GiB/s 6.6992 GiB/s]
                 change:
                        time:   [+0.0284% +0.1565% +0.2851%] (p = 0.03 < 0.05)
                        thrpt:  [-0.2843% -0.1563% -0.0284%]
                        Change within noise threshold.
slow/transform/single-thread/precompute/field=AESTowerField32b/log_dim=16/log_inv_rate=2/log_b=6
                        time:   [74.089 ms 74.106 ms 74.124 ms]
                        thrpt:  [863.41 MiB/s 863.62 MiB/s 863.82 MiB/s]
                 change:
                        time:   [-0.0885% -0.0256% +0.0346%] (p = 0.46 > 0.05)
                        thrpt:  [-0.0346% +0.0256% +0.0886%]
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
slow/transform/multithread/precompute/field=AESTowerField32b/log_dim=16/log_inv_rate=2/log_b=6
                        time:   [11.357 ms 11.380 ms 11.401 ms]
                        thrpt:  [5.4820 GiB/s 5.4919 GiB/s 5.5031 GiB/s]
                 change:
                        time:   [+0.1161% +0.3225% +0.5382%] (p = 0.01 < 0.05)
                        thrpt:  [-0.5353% -0.3215% -0.1159%]
                        Change within noise threshold.

slow/transform/single-thread/precompute/bytesliced=ByteSlicedAES16x32b/log_dim=16/log_inv_rate=1/log...
                        time:   [53.370 ms 53.392 ms 53.416 ms]
                        thrpt:  [599.07 MiB/s 599.34 MiB/s 599.59 MiB/s]
                 change:
                        time:   [+0.0494% +0.1116% +0.1770%] (p = 0.00 < 0.05)
                        thrpt:  [-0.1767% -0.1115% -0.0494%]
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
slow/transform/multithread/precompute/bytesliced=ByteSlicedAES16x32b/log_dim=16/log_inv_rate=1/log_b...
                        time:   [7.5607 ms 7.5638 ms 7.5695 ms]
                        thrpt:  [4.1284 GiB/s 4.1315 GiB/s 4.1332 GiB/s]
                 change:
                        time:   [+0.9012% +1.0613% +1.2469%] (p = 0.00 < 0.05)
                        thrpt:  [-1.2315% -1.0502% -0.8932%]
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
slow/transform/single-thread/precompute/bytesliced=ByteSlicedAES16x32b/log_dim=16/log_inv_rate=2/log...
                        time:   [106.67 ms 106.69 ms 106.75 ms]
                        thrpt:  [599.56 MiB/s 599.87 MiB/s 600.00 MiB/s]
                 change:
                        time:   [-0.2142% -0.0774% +0.0802%] (p = 0.34 > 0.05)
                        thrpt:  [-0.0801% +0.0775% +0.2147%]
                        No change in performance detected.
slow/transform/multithread/precompute/bytesliced=ByteSlicedAES16x32b/log_dim=16/log_inv_rate=2/log_b...
                        time:   [16.548 ms 16.641 ms 16.756 ms]
                        thrpt:  [3.7299 GiB/s 3.7557 GiB/s 3.7770 GiB/s]
                 change:
                        time:   [+1.7754% +2.2865% +2.8243%] (p = 0.00 < 0.05)
                        thrpt:  [-2.7467% -2.2354% -1.7444%]
                        Performance has regressed.

slow/transform/single-thread/precompute/bytesliced=ByteSlicedAES32x32b/log_dim=16/log_inv_rate=1/log...
                        time:   [15.862 ms 16.044 ms 16.210 ms]
                        thrpt:  [1.9279 GiB/s 1.9478 GiB/s 1.9701 GiB/s]
                 change:
                        time:   [-8.6562% -7.8899% -7.0596%] (p = 0.00 < 0.05)
                        thrpt:  [+7.5958% +8.5657% +9.4766%]
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
slow/transform/multithread/precompute/bytesliced=ByteSlicedAES32x32b/log_dim=16/log_inv_rate=1/log_b...
                        time:   [2.1828 ms 2.1865 ms 2.1903 ms]
                        thrpt:  [14.268 GiB/s 14.292 GiB/s 14.316 GiB/s]
                 change:
                        time:   [-4.2770% -4.1334% -3.9925%] (p = 0.00 < 0.05)
                        thrpt:  [+4.1585% +4.3117% +4.4681%]
                        Performance has improved.
slow/transform/single-thread/precompute/bytesliced=ByteSlicedAES32x32b/log_dim=16/log_inv_rate=2/log...
                        time:   [31.424 ms 31.447 ms 31.473 ms]
                        thrpt:  [1.9859 GiB/s 1.9875 GiB/s 1.9890 GiB/s]
                 change:
                        time:   [-4.2053% -4.0866% -3.9719%] (p = 0.00 < 0.05)
                        thrpt:  [+4.1362% +4.2607% +4.3899%]
                        Performance has improved.
slow/transform/multithread/precompute/bytesliced=ByteSlicedAES32x32b/log_dim=16/log_inv_rate=2/log_b...
                        time:   [7.1541 ms 7.1749 ms 7.1964 ms]
                        thrpt:  [8.6849 GiB/s 8.7110 GiB/s 8.7362 GiB/s]
                 change:
                        time:   [-0.9455% -0.6144% -0.1966%] (p = 0.01 < 0.05)
                        thrpt:  [+0.1970% +0.6182% +0.9545%]
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
slow/transform/single-thread/precompute/bytesliced=ByteSlicedAES64x32b/log_dim=16/log_inv_rate=1/log...
                        time:   [14.673 ms 14.682 ms 14.696 ms]
                        thrpt:  [2.1264 GiB/s 2.1285 GiB/s 2.1298 GiB/s]
                 change:
                        time:   [-8.2167% -7.9806% -7.7416%] (p = 0.00 < 0.05)
                        thrpt:  [+8.3913% +8.6728% +8.9523%]
                        Performance has improved.
slow/transform/multithread/precompute/bytesliced=ByteSlicedAES64x32b/log_dim=16/log_inv_rate=1/log_b...
                        time:   [2.0655 ms 2.0692 ms 2.0711 ms]
                        thrpt:  [15.088 GiB/s 15.103 GiB/s 15.129 GiB/s]
                 change:
                        time:   [-3.2315% -2.3590% -1.8229%] (p = 0.00 < 0.05)
                        thrpt:  [+1.8567% +2.4160% +3.3395%]
                        Performance has improved.
slow/transform/single-thread/precompute/bytesliced=ByteSlicedAES64x32b/log_dim=16/log_inv_rate=2/log...
                        time:   [29.503 ms 29.527 ms 29.560 ms]
                        thrpt:  [2.1143 GiB/s 2.1167 GiB/s 2.1184 GiB/s]
                 change:
                        time:   [-1.2361% -1.1401% -1.0405%] (p = 0.00 < 0.05)
                        thrpt:  [+1.0514% +1.1532% +1.2516%]
                        Performance has improved.
slow/transform/multithread/precompute/bytesliced=ByteSlicedAES64x32b/log_dim=16/log_inv_rate=2/log_b...
                        time:   [6.1502 ms 6.1781 ms 6.2014 ms]
                        thrpt:  [10.078 GiB/s 10.116 GiB/s 10.162 GiB/s]
                 change:
                        time:   [-1.8572% -1.4670% -1.0906%] (p = 0.00 < 0.05)
                        thrpt:  [+1.1026% +1.4889% +1.8923%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild

```