### PR TITLE
Specialized left lerp fold for P==PE

### DIFF
--- a/crates/math/src/fold.rs
+++ b/crates/math/src/fold.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use core::slice;
-use std::{any::TypeId, cmp::min, iter, mem::MaybeUninit};
+use std::{any::TypeId, cmp::min, mem::MaybeUninit};
 
 use binius_field::{
 	arch::{ArchOptimal, OptimalUnderlier},
@@ -16,6 +16,7 @@ use binius_field::{
 };
 use binius_utils::bail;
 use bytemuck::fill_zeroes;
+use itertools::izip;
 use lazy_static::lazy_static;
 use stackalloc::helpers::slice_assume_init_mut;
 
@@ -91,7 +92,25 @@ where
 		return Ok(());
 	}
 
-	fold_left_fallback(evals, log_evals_size, query, log_query_size, out);
+	// Use linear interpolation for single variable multilinear queries.
+	// Unlike right folds, left folds are often used with packed fields which are not indexable
+	// and have quite slow scalar indexing methods. For now, we specialize the practically important
+	// case of single variable fold when PE == P.
+	let is_lerp = log_query_size == 1
+		&& get_packed_slice(query, 0) + get_packed_slice(query, 1) == PE::Scalar::ONE
+		&& TypeId::of::<P>() == TypeId::of::<PE>();
+
+	if is_lerp {
+		let lerp_query = get_packed_slice(query, 1);
+		// Safety: P == PE checked above.
+		let out_p =
+			unsafe { std::mem::transmute::<&mut [MaybeUninit<PE>], &mut [MaybeUninit<P>]>(out) };
+
+		let lerp_query_p = lerp_query.try_into().ok().expect("P == PE");
+		fold_left_lerp(evals, log_evals_size, lerp_query_p, out_p)?;
+	} else {
+		fold_left_fallback(evals, log_evals_size, query, log_query_size, out);
+	}
 
 	Ok(())
 }
@@ -138,10 +157,10 @@ where
 }
 
 #[inline]
-fn check_lerp_fold_arguments<P, PE>(
+fn check_lerp_fold_arguments<P, PE, POut>(
 	evals: &[P],
 	log_evals_size: usize,
-	out: &[PE],
+	out: &[POut],
 ) -> Result<(), Error>
 where
 	P: PackedField,
@@ -359,7 +378,7 @@ where
 	P: PackedField,
 	PE: PackedField<Scalar: ExtensionField<P::Scalar>>,
 {
-	check_lerp_fold_arguments(evals, log_evals_size, out)?;
+	check_lerp_fold_arguments::<_, PE, _>(evals, log_evals_size, out)?;
 
 	out.iter_mut()
 		.enumerate()
@@ -387,7 +406,53 @@ where
 	Ok(())
 }
 
-/// Inplace left fold
+/// Left linear interpolation (lerp, single variable) fold
+///
+/// Please note that this method is single threaded. Currently we always have some
+/// parallelism above this level, so it's not a problem. Having no parallelism inside allows us to
+/// use more efficient optimizations for special cases. If we ever need a parallel version of this
+/// function, we can implement it separately.
+///
+/// Also note that left folds are often intended to be used with non-indexable packed fields that
+/// have inefficient scalar access; fully generic handling of all interesting cases that can leverage
+/// spread multiplication requires dynamically checking the `PackedExtension` relations, so for now we
+/// just handle the simplest yet important case of a single variable left fold in packed field P with
+/// a lerp query of its scalar (and not a nontrivial extension field!).
+pub fn fold_left_lerp<P>(
+	evals: &[P],
+	log_evals_size: usize,
+	lerp_query: P::Scalar,
+	out: &mut [MaybeUninit<P>],
+) -> Result<(), Error>
+where
+	P: PackedField,
+{
+	check_lerp_fold_arguments::<_, P, _>(evals, log_evals_size, out)?;
+
+	if log_evals_size > P::LOG_WIDTH {
+		let packed_len = 1 << (log_evals_size - 1 - P::LOG_WIDTH);
+		let (evals_0, evals_1) = evals.split_at(packed_len);
+
+		for (out, eval_0, eval_1) in izip!(out, evals_0, evals_1) {
+			out.write(*eval_0 + (*eval_1 - *eval_0) * lerp_query);
+		}
+	} else {
+		let only_packed = *evals.first().expect("log_evals_size > 0");
+		let mut folded = P::zero();
+
+		for i in 0..1 << (log_evals_size - 1) {
+			let eval_0 = only_packed.get(i);
+			let eval_1 = only_packed.get(i | 1 << (log_evals_size - 1));
+			folded.set(i, eval_0 + lerp_query * (eval_1 - eval_0));
+		}
+
+		out.first_mut().expect("log_evals_size > 0").write(folded);
+	}
+
+	Ok(())
+}
+
+/// Inplace left linear interpolation (lerp, single variable) fold
 ///
 /// Please note that this method is single threaded. Currently we always have some
 /// parallelism above this level, so it's not a problem. Having no parallelism inside allows us to
@@ -401,13 +466,13 @@ pub fn fold_left_lerp_inplace<P>(
 where
 	P: PackedField,
 {
-	check_lerp_fold_arguments(evals, log_evals_size, evals)?;
+	check_lerp_fold_arguments::<_, P, _>(evals, log_evals_size, evals)?;
 
 	if log_evals_size > P::LOG_WIDTH {
 		let packed_len = 1 << (log_evals_size - 1 - P::LOG_WIDTH);
 		let (evals_0, evals_1) = evals.split_at_mut(packed_len);
 
-		for (eval_0, eval_1) in iter::zip(evals_0, evals_1) {
+		for (eval_0, eval_1) in izip!(evals_0, evals_1) {
 			*eval_0 += (*eval_1 - *eval_0) * lerp_query;
 		}
 
@@ -978,7 +1043,7 @@ mod tests {
 			fold_left(&evals, log_evals_size, &query, 1, &mut out).unwrap();
 			fold_left_lerp_inplace(&mut evals, log_evals_size, lerp_query).unwrap();
 
-			for (out, &inplace) in iter::zip(&out, &evals) {
+			for (out, &inplace) in izip!(&out, &evals) {
 				unsafe {
 					assert_eq!(out.assume_init(), inplace);
 				}


### PR DESCRIPTION
 The notorious `MultilinearExtension::evaluate_partial_high` is based on individual scalar access and thus works spectacularly bad with byte sliced fields. While high-to-low sumchecks perform folding using specialized inplace routine, the overhead of first transition from MLE to folded representation remains and needs to be optimized.

 Correctly performing this specialization cannot use individual scalar access like in low-to-high for the aforementioned reasons. Furthermore, for the generic case of `P != PE` we need to do spreads on either `P` or `PE` (depending on respective `LOG_WIDTH`), which requires dynamically checking for `PackedExtension` relation. Lacking that ability and being reluctant to propagate this bound across the whole codebase, the decision is to specialize the `P == PE` case which is practically important for immediate switchover as observed in GKR sumcheck.

 New benchmarks on SM:

```
gpa_polyval_128b/n_vars=12
                        time:   [36.599 ms 36.799 ms 36.998 ms]
                        thrpt:  [1.1071 Melem/s 1.1131 Melem/s 1.1192 Melem/s]
                 change:
                        time:   [-0.1557% +0.7580% +1.7717%] (p = 0.14 > 0.05)
                        thrpt:  [-1.7409% -0.7523% +0.1560%]

gpa_polyval_128b/n_vars=16
                        time:   [85.320 ms 86.328 ms 86.885 ms]
                        thrpt:  [7.5429 Melem/s 7.5915 Melem/s 7.6812 Melem/s]
                 change:
                        time:   [+1.5693% +3.1887% +4.6478%] (p = 0.00 < 0.05)
                        thrpt:  [-4.4414% -3.0902% -1.5451%]

gpa_polyval_128b/n_vars=20
                        time:   [278.15 ms 280.99 ms 283.95 ms]
                        thrpt:  [36.928 Melem/s 37.317 Melem/s 37.698 Melem/s]
                 change:
                        time:   [-1.7623% -0.3585% +1.0586%] (p = 0.64 > 0.05)
                        thrpt:  [-1.0475% +0.3598% +1.7939%]

gpa_polyval_128b/n_vars=24
                        time:   [2.6610 s 2.6966 s 2.7500 s]
                        thrpt:  [61.008 Melem/s 62.217 Melem/s 63.048 Melem/s]
                 change:
                        time:   [-1.1876% +0.4200% +2.5573%] (p = 0.74 > 0.05)
                        thrpt:  [-2.4935% -0.4182% +1.2019%]

====
        
gpa_polyval_128b_high_to_low/n_vars=12
                        time:   [35.498 ms 35.782 ms 36.261 ms]
                        thrpt:  [1.1296 Melem/s 1.1447 Melem/s 1.1539 Melem/s]
                 change:
                        time:   [+0.6626% +2.1093% +3.5667%] (p = 0.02 < 0.05)
                        thrpt:  [-3.4439% -2.0657% -0.6582%]

gpa_polyval_128b_high_to_low/n_vars=16
                        time:   [82.585 ms 83.337 ms 84.247 ms]
                        thrpt:  [7.7791 Melem/s 7.8640 Melem/s 7.9356 Melem/s]
                 change:
                        time:   [-1.8194% -0.1857% +1.2597%] (p = 0.81 > 0.05)
                        thrpt:  [-1.2440% +0.1860% +1.8532%]

gpa_polyval_128b_high_to_low/n_vars=20
                        time:   [275.08 ms 277.83 ms 280.25 ms]
                        thrpt:  [37.416 Melem/s 37.742 Melem/s 38.119 Melem/s]
                 change:
                        time:   [-9.1665% -7.7304% -6.2422%] (p = 0.00 < 0.05)
                        thrpt:  [+6.6578% +8.3781% +10.092%]

gpa_polyval_128b_high_to_low/n_vars=24
                        time:   [2.5913 s 2.6033 s 2.6147 s]
                        thrpt:  [64.165 Melem/s 64.446 Melem/s 64.745 Melem/s]
                 change:
                        time:   [-13.328% -12.812% -12.311%] (p = 0.00 < 0.05)
                        thrpt:  [+14.039% +14.695% +15.377%]

====
    
gpa_binary_128b/n_vars=12
                        time:   [65.552 ms 65.755 ms 66.065 ms]
                        thrpt:  [619.99 Kelem/s 622.92 Kelem/s 624.85 Kelem/s]
                 change:
                        time:   [-34.145% -33.711% -33.308%] (p = 0.00 < 0.05)
                        thrpt:  [+49.944% +50.856% +51.849%]

gpa_binary_128b/n_vars=16
                        time:   [179.77 ms 181.13 ms 182.41 ms]
                        thrpt:  [3.5927 Melem/s 3.6181 Melem/s 3.6456 Melem/s]
                 change:
                        time:   [-39.058% -38.343% -37.607%] (p = 0.00 < 0.05)
                        thrpt:  [+60.275% +62.186% +64.091%]

gpa_binary_128b/n_vars=20
                        time:   [862.29 ms 866.77 ms 871.45 ms]
                        thrpt:  [12.033 Melem/s 12.098 Melem/s 12.160 Melem/s]
                 change:
                        time:   [-41.985% -41.562% -41.128%] (p = 0.00 < 0.05)
                        thrpt:  [+69.860% +71.120% +72.369%]

gpa_binary_128b/n_vars=24
                        time:   [10.592 s 10.613 s 10.638 s]
                        thrpt:  [15.772 Melem/s 15.809 Melem/s 15.839 Melem/s]
                 change:
                        time:   [-42.186% -42.009% -41.796%] (p = 0.00 < 0.05)
                        thrpt:  [+71.811% +72.441% +72.969%]

====

gpa_byte_sliced_aes_128b/n_vars=12
                        time:   [42.735 ms 43.014 ms 43.408 ms]
                        thrpt:  [943.61 Kelem/s 952.24 Kelem/s 958.46 Kelem/s]
                 change:
                        time:   [-4.2821% -2.6473% -1.3754%] (p = 0.00 < 0.05)
                        thrpt:  [+1.3946% +2.7193% +4.4736%]

gpa_byte_sliced_aes_128b/n_vars=16
                        time:   [109.36 ms 109.80 ms 110.13 ms]
                        thrpt:  [5.9510 Melem/s 5.9687 Melem/s 5.9927 Melem/s]
                 change:
                        time:   [-4.7531% -3.7645% -2.8418%] (p = 0.00 < 0.05)
                        thrpt:  [+2.9249% +3.9118% +4.9903%]

gpa_byte_sliced_aes_128b/n_vars=20
                        time:   [550.69 ms 555.10 ms 559.72 ms]
                        thrpt:  [18.734 Melem/s 18.890 Melem/s 19.041 Melem/s]
                 change:
                        time:   [-12.093% -11.060% -10.102%] (p = 0.00 < 0.05)
                        thrpt:  [+11.237% +12.435% +13.756%]

gpa_byte_sliced_aes_128b/n_vars=24
                        time:   [7.0808 s 7.0943 s 7.1092 s]
                        thrpt:  [23.599 Melem/s 23.649 Melem/s 23.694 Melem/s]
                 change:
                        time:   [-12.456% -12.129% -11.816%] (p = 0.00 < 0.05)
                        thrpt:  [+13.400% +13.803% +14.228%]

====

gpa_byte_sliced_aes_256b/n_vars=12
                        time:   [47.824 ms 48.087 ms 48.397 ms]
                        thrpt:  [846.34 Kelem/s 851.79 Kelem/s 856.48 Kelem/s]
                 change:
                        time:   [+0.1610% +0.7866% +1.5224%] (p = 0.04 < 0.05)
                        thrpt:  [-1.4996% -0.7804% -0.1607%]

gpa_byte_sliced_aes_256b/n_vars=16
                        time:   [111.76 ms 112.18 ms 112.49 ms]
                        thrpt:  [5.8259 Melem/s 5.8419 Melem/s 5.8642 Melem/s]
                 change:
                        time:   [-5.9243% -5.4276% -4.8663%] (p = 0.00 < 0.05)
                        thrpt:  [+5.1152% +5.7391% +6.2973%]

gpa_byte_sliced_aes_256b/n_vars=20
                        time:   [558.60 ms 562.12 ms 565.21 ms]
                        thrpt:  [18.552 Melem/s 18.654 Melem/s 18.772 Melem/s]
                 change:
                        time:   [-10.349% -9.4514% -8.5662%] (p = 0.00 < 0.05)
                        thrpt:  [+9.3687% +10.438% +11.543%]

gpa_byte_sliced_aes_256b/n_vars=24
                        time:   [7.0446 s 7.0591 s 7.0742 s]
                        thrpt:  [23.716 Melem/s 23.767 Melem/s 23.816 Melem/s]
                 change:
                        time:   [-11.750% -11.374% -10.988%] (p = 0.00 < 0.05)
                        thrpt:  [+12.344% +12.833% +13.314%]

====

gpa_byte_sliced_aes_512b/n_vars=12
                        time:   [54.686 ms 54.982 ms 55.679 ms]
                        thrpt:  [735.64 Kelem/s 744.97 Kelem/s 749.00 Kelem/s]
                 change:
                        time:   [-0.9027% +0.5308% +2.1082%] (p = 0.52 > 0.05)
                        thrpt:  [-2.0647% -0.5280% +0.9109%]

gpa_byte_sliced_aes_512b/n_vars=16
                        time:   [121.24 ms 121.67 ms 122.06 ms]
                        thrpt:  [5.3691 Melem/s 5.3865 Melem/s 5.4055 Melem/s]
                 change:
                        time:   [-5.1687% -4.4835% -3.8087%] (p = 0.00 < 0.05)
                        thrpt:  [+3.9595% +4.6940% +5.4504%]

gpa_byte_sliced_aes_512b/n_vars=20
                        time:   [534.61 ms 537.80 ms 541.67 ms]
                        thrpt:  [19.358 Melem/s 19.497 Melem/s 19.614 Melem/s]
                 change:
                        time:   [-7.7146% -6.9270% -6.0631%] (p = 0.00 < 0.05)
                        thrpt:  [+6.4544% +7.4426% +8.3595%]

gpa_byte_sliced_aes_512b/n_vars=24
                        time:   [6.3220 s 6.3388 s 6.3554 s]
                        thrpt:  [26.398 Melem/s 26.468 Melem/s 26.538 Melem/s]
                 change:
                        time:   [-9.5054% -9.2120% -8.9141%] (p = 0.00 < 0.05)
                        thrpt:  [+9.7865% +10.147% +10.504%]

====

gpa_binary_128b_isomorphic/n_vars=12
                        time:   [39.140 ms 39.395 ms 39.552 ms]
                        thrpt:  [1.0356 Melem/s 1.0397 Melem/s 1.0465 Melem/s]
                 change:
                        time:   [-5.4263% -4.1340% -2.8197%] (p = 0.00 < 0.05)
                        thrpt:  [+2.9015% +4.3123% +5.7376%]

gpa_binary_128b_isomorphic/n_vars=16
                        time:   [144.94 ms 145.55 ms 146.47 ms]
                        thrpt:  [4.4745 Melem/s 4.5027 Melem/s 4.5216 Melem/s]
                 change:
                        time:   [-4.8545% -4.2499% -3.6485%] (p = 0.00 < 0.05)
                        thrpt:  [+3.7867% +4.4385% +5.1022%]

gpa_binary_128b_isomorphic/n_vars=20
                        time:   [1.3372 s 1.3720 s 1.4007 s]
                        thrpt:  [7.4860 Melem/s 7.6428 Melem/s 7.8418 Melem/s]
                 change:
                        time:   [-5.8350% -2.4812% +0.1932%] (p = 0.13 > 0.05)
                        thrpt:  [-0.1928% +2.5443% +6.1966%]

gpa_binary_128b_isomorphic/n_vars=24
                        time:   [19.256 s 19.567 s 19.993 s]
                        thrpt:  [8.3916 Melem/s 8.5742 Melem/s 8.7129 Melem/s]
                 change:
                        time:   [-5.8732% -4.2932% -2.0870%] (p = 0.00 < 0.05)
                        thrpt:  [+2.1315% +4.4858% +6.2397%]
```