### PR TITLE
[m3] Add TableBuilder with namespacing

### DIFF
--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -189,7 +189,7 @@ pub struct Table<F: TowerField = B128> {
 	pub id: TableId,
 	pub name: String,
 	pub columns: Vec<ColumnInfo<F>>,
-	pub partitions: SparseIndex<TablePartition<F>>,
+	pub(super) partitions: SparseIndex<TablePartition<F>>,
 	/// This indicates whether a table is fixed for constraint system or part of the dynamic trace.
 	///
 	/// Fixed tables are either entirely transparent or committed during a preprocessing step that
@@ -202,7 +202,7 @@ pub struct Table<F: TowerField = B128> {
 ///
 /// Zerocheck constraints can only be defined within table partitions.
 #[derive(Debug)]
-pub struct TablePartition<F: TowerField = B128> {
+pub(super) struct TablePartition<F: TowerField = B128> {
 	pub table_id: TableId,
 	pub pack_factor: usize,
 	pub flushes: Vec<Flush>,

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -471,7 +471,8 @@ mod tests {
 	#[test]
 	fn test_table_witness_borrows() {
 		let table_id = 0;
-		let mut table = TableBuilder::<B128>::new(table_id, "table".to_string());
+		let mut inner_table = Table::<B128>::new(table_id, "table".to_string());
+		let mut table = TableBuilder::new(&mut inner_table);
 		let col0 = table.add_committed::<B1, 3>("col0");
 		let col1 = table.add_committed::<B1, 5>("col1");
 		let col2 = table.add_committed::<B8, 0>("col2");
@@ -480,7 +481,7 @@ mod tests {
 		let allocator = bumpalo::Bump::new();
 		let table_size = 64;
 		let mut index =
-			TableWitnessIndex::<OptimalUnderlier128b>::new(&allocator, &table.table(), table_size);
+			TableWitnessIndex::<OptimalUnderlier128b>::new(&allocator, &inner_table, table_size);
 		let segment = index.full_segment();
 
 		{
@@ -503,7 +504,8 @@ mod tests {
 	#[test]
 	fn test_table_witness_segments() {
 		let table_id = 0;
-		let mut table = TableBuilder::<B128>::new(table_id, "table".to_string());
+		let mut inner_table = Table::<B128>::new(table_id, "table".to_string());
+		let mut table = TableBuilder::new(&mut inner_table);
 		let col0 = table.add_committed::<B1, 3>("col0");
 		let col1 = table.add_committed::<B1, 5>("col1");
 		let col2 = table.add_committed::<B8, 0>("col2");
@@ -512,7 +514,7 @@ mod tests {
 		let allocator = bumpalo::Bump::new();
 		let table_size = 64;
 		let mut index =
-			TableWitnessIndex::<OptimalUnderlier128b>::new(&allocator, &table.table(), table_size);
+			TableWitnessIndex::<OptimalUnderlier128b>::new(&allocator, &inner_table, table_size);
 
 		assert_eq!(index.min_log_segment_size(), 4);
 		let mut iter = index.segments(5);

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -463,12 +463,15 @@ mod tests {
 	use binius_field::{arch::OptimalUnderlier128b, packed::len_packed_slice};
 
 	use super::*;
-	use crate::builder::types::{B1, B32, B8};
+	use crate::builder::{
+		types::{B1, B32, B8},
+		TableBuilder,
+	};
 
 	#[test]
 	fn test_table_witness_borrows() {
 		let table_id = 0;
-		let mut table = Table::<B128>::new(table_id, "table".to_string());
+		let mut table = TableBuilder::<B128>::new(table_id, "table".to_string());
 		let col0 = table.add_committed::<B1, 3>("col0");
 		let col1 = table.add_committed::<B1, 5>("col1");
 		let col2 = table.add_committed::<B8, 0>("col2");
@@ -477,7 +480,7 @@ mod tests {
 		let allocator = bumpalo::Bump::new();
 		let table_size = 64;
 		let mut index =
-			TableWitnessIndex::<OptimalUnderlier128b>::new(&allocator, &table, table_size);
+			TableWitnessIndex::<OptimalUnderlier128b>::new(&allocator, &table.table(), table_size);
 		let segment = index.full_segment();
 
 		{
@@ -500,7 +503,7 @@ mod tests {
 	#[test]
 	fn test_table_witness_segments() {
 		let table_id = 0;
-		let mut table = Table::<B128>::new(table_id, "table".to_string());
+		let mut table = TableBuilder::<B128>::new(table_id, "table".to_string());
 		let col0 = table.add_committed::<B1, 3>("col0");
 		let col1 = table.add_committed::<B1, 5>("col1");
 		let col2 = table.add_committed::<B8, 0>("col2");
@@ -509,7 +512,7 @@ mod tests {
 		let allocator = bumpalo::Bump::new();
 		let table_size = 64;
 		let mut index =
-			TableWitnessIndex::<OptimalUnderlier128b>::new(&allocator, &table, table_size);
+			TableWitnessIndex::<OptimalUnderlier128b>::new(&allocator, &table.table(), table_size);
 
 		assert_eq!(index.min_log_segment_size(), 4);
 		let mut iter = index.segments(5);

--- a/crates/m3/src/gadgets/u32.rs
+++ b/crates/m3/src/gadgets/u32.rs
@@ -4,7 +4,7 @@ use binius_core::oracle::ShiftVariant;
 use binius_field::{as_packed_field::PackScalar, packed::set_packed_slice, Field};
 use bytemuck::Pod;
 
-use crate::builder::{column::Col, table::Table, types::B1, witness::TableWitnessIndexSegment};
+use crate::builder::{column::Col, types::B1, witness::TableWitnessIndexSegment, TableBuilder};
 
 /// A gadget for performing 32-bit integer addition on vertically-packed bit columns.
 ///
@@ -42,7 +42,12 @@ pub struct U32AddFlags {
 }
 
 impl U32Add {
-	pub fn new(table: &mut Table, xin: Col<B1, 5>, yin: Col<B1, 5>, flags: U32AddFlags) -> Self {
+	pub fn new(
+		table: &mut TableBuilder,
+		xin: Col<B1, 5>,
+		yin: Col<B1, 5>,
+		flags: U32AddFlags,
+	) -> Self {
 		let cout = table.add_committed::<B1, 5>("cout");
 		let cout_shl = table.add_shifted("cout_shl", cout, 5, 1, ShiftVariant::LogicalLeft);
 

--- a/crates/m3/tests/collatz.rs
+++ b/crates/m3/tests/collatz.rs
@@ -129,7 +129,7 @@ mod arithmetization {
 
 	impl EvensTable {
 		pub fn new(cs: &mut ConstraintSystem, seq_chan: ChannelId) -> Self {
-			let table = cs.add_table("evens");
+			let mut table = cs.add_table("evens");
 
 			let even = table.add_committed::<B1, 5>("even");
 
@@ -200,7 +200,7 @@ mod arithmetization {
 
 	impl OddsTable {
 		pub fn new(cs: &mut ConstraintSystem, seq_chan: ChannelId) -> Self {
-			let table = cs.add_table("odds");
+			let mut table = cs.add_table("odds");
 
 			let odd = table.add_committed::<B1, 5>("odd_bits");
 

--- a/crates/m3/tests/collatz.rs
+++ b/crates/m3/tests/collatz.rs
@@ -218,7 +218,7 @@ mod arithmetization {
 
 			// Input times 3 + 1
 			let triple_plus_one = U32Add::new(
-				&mut table.with_namespace("u32add"),
+				&mut table.with_namespace("triple_plus_one"),
 				double,
 				odd,
 				U32AddFlags {

--- a/crates/m3/tests/collatz.rs
+++ b/crates/m3/tests/collatz.rs
@@ -218,7 +218,7 @@ mod arithmetization {
 
 			// Input times 3 + 1
 			let triple_plus_one = U32Add::new(
-				table,
+				&mut table.with_namespace("u32add"),
 				double,
 				odd,
 				U32AddFlags {


### PR DESCRIPTION
Moves `Table::add_*` methods to `TableBuilder::add_*`, which also supports namespacing.

To add a namespace before passing the TableBuilder to a gadget, you can do something like:
```rs
let inner_table = Table::new(..)
let table = TableBuilder::new(&mut inner_table)
U32Add::new(
  &mut table.with_namespace("u32add"),
  ..
)
```
