### PR TITLE
Fix stack overflow errors for unit tests

### DIFF
--- a/crates/core/src/protocols/gkr_exp/tests.rs
+++ b/crates/core/src/protocols/gkr_exp/tests.rs
@@ -157,7 +157,6 @@ fn generate_mul_witnesses_claims_with_different_log_size<'a>(
 }
 
 #[test]
-#[allow(clippy::large_stack_frames)]
 fn witness_gen_happens_correctly() {
 	const LOG_SIZE: usize = 13usize;
 	const COLUMN_LEN: usize = 1usize << LOG_SIZE;


### PR DESCRIPTION
When running tests locally with the standard stack size I found that some of the tests are failing due to stack overflow on initialization which is pretty confusing. The reason is big arrays of test data allocated on the stack. I'm not against having big stack size setting by default, but here it seems that we are doing it for now reason and better just use dynamic-allocated memory.