### PR TITLE
[m3] Fix underconstained Collatz example

### DIFF
--- a/crates/m3/src/builder/column.rs
+++ b/crates/m3/src/builder/column.rs
@@ -4,7 +4,6 @@ use std::marker::PhantomData;
 
 use binius_core::oracle::ShiftVariant;
 use binius_field::{ExtensionField, TowerField};
-use binius_math::LinearNormalForm;
 
 use super::{table::TableId, types::B128};
 
@@ -91,15 +90,16 @@ pub struct ColumnId {
 	pub partition_index: ColumnIndex,
 }
 
-// TODO: TableBuilder needs namespacing
-
 /// A definition of a column in a table.
 #[derive(Debug)]
 pub enum ColumnDef<F: TowerField = B128> {
 	Committed {
 		tower_level: usize,
 	},
-	LinearCombination(LinearNormalForm<F>),
+	LinearCombination {
+		offset: F,
+		col_scalars: Vec<(ColumnIndex, F)>,
+	},
 	Selected {
 		col: ColumnId,
 		index: usize,

--- a/crates/m3/src/builder/column.rs
+++ b/crates/m3/src/builder/column.rs
@@ -100,6 +100,11 @@ pub enum ColumnDef<F: TowerField = B128> {
 		tower_level: usize,
 	},
 	LinearCombination(LinearNormalForm<F>),
+	Selected {
+		col: ColumnId,
+		index: usize,
+		index_bits: usize,
+	},
 	Shifted {
 		col: ColumnId,
 		offset: usize,

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -55,11 +55,7 @@ impl<F: TowerField> std::fmt::Display for ConstraintSystem<F> {
 					let columns = flush
 						.column_indices
 						.iter()
-						.map(|i| {
-							table.columns[partition.columns[*i].table_index]
-								.name
-								.clone()
-						})
+						.map(|i| table.columns[partition.columns[*i]].name.clone())
 						.collect::<Vec<_>>()
 						.join(", ");
 					match flush.direction {
@@ -75,7 +71,7 @@ impl<F: TowerField> std::fmt::Display for ConstraintSystem<F> {
 				let names = partition
 					.columns
 					.iter()
-					.map(|id| table.columns[id.table_index].name.clone())
+					.map(|&index| table.columns[index].name.clone())
 					.collect::<Vec<_>>();
 
 				for constraint in partition.zero_constraints.iter() {
@@ -210,7 +206,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 
 				let partition_oracle_ids = columns
 					.iter()
-					.map(|id| oracle_lookup[id.table_index])
+					.map(|&index| oracle_lookup[index])
 					.collect::<Vec<_>>();
 
 				// StepDown witness data is populated in WitnessIndex::into_multilinear_extension_index

--- a/crates/m3/src/builder/expr.rs
+++ b/crates/m3/src/builder/expr.rs
@@ -37,7 +37,8 @@ impl<F: TowerField, const V: usize> From<Col<F, V>> for Expr<F, V> {
 	fn from(value: Col<F, V>) -> Self {
 		Expr {
 			table_id: value.id.table_id,
-			expr: ArithExpr::Var(value.id.index),
+			partition_id: value.id.partition_id,
+			expr: ArithExpr::Var(value.id.partition_index),
 		}
 	}
 }
@@ -97,6 +98,7 @@ impl<F: TowerField, const V: usize> std::ops::Add<F> for Expr<F, V> {
 	fn add(self, rhs: F) -> Self::Output {
 		Expr {
 			table_id: self.table_id,
+			partition_id: self.partition_id,
 			expr: self.expr + ArithExpr::Const(rhs),
 		}
 	}
@@ -155,6 +157,7 @@ impl<F: TowerField, const V: usize> std::ops::Sub<F> for Expr<F, V> {
 	fn sub(self, rhs: F) -> Self::Output {
 		Expr {
 			table_id: self.table_id,
+			partition_id: self.partition_id,
 			expr: self.expr - ArithExpr::Const(rhs),
 		}
 	}
@@ -213,6 +216,7 @@ impl<F: TowerField, const V: usize> std::ops::Mul<F> for Expr<F, V> {
 	fn mul(self, rhs: F) -> Self::Output {
 		Expr {
 			table_id: self.table_id,
+			partition_id: self.partition_id,
 			expr: self.expr * ArithExpr::Const(rhs),
 		}
 	}

--- a/crates/m3/src/builder/expr.rs
+++ b/crates/m3/src/builder/expr.rs
@@ -33,6 +33,15 @@ impl<F: TowerField, const V: usize> Expr<F, V> {
 	}
 }
 
+impl<F: TowerField, const V: usize> From<Col<F, V>> for Expr<F, V> {
+	fn from(value: Col<F, V>) -> Self {
+		Expr {
+			table_id: value.id.table_id,
+			expr: ArithExpr::Var(value.id.index),
+		}
+	}
+}
+
 impl<F: TowerField, const V: usize> std::ops::Add<Self> for Col<F, V> {
 	type Output = Expr<F, V>;
 
@@ -82,6 +91,25 @@ impl<F: TowerField, const V: usize> std::ops::Add<Expr<F, V>> for Expr<F, V> {
 	}
 }
 
+impl<F: TowerField, const V: usize> std::ops::Add<F> for Expr<F, V> {
+	type Output = Expr<F, V>;
+
+	fn add(self, rhs: F) -> Self::Output {
+		Expr {
+			table_id: self.table_id,
+			expr: self.expr + ArithExpr::Const(rhs),
+		}
+	}
+}
+
+impl<F: TowerField, const V: usize> std::ops::Add<F> for Col<F, V> {
+	type Output = Expr<F, V>;
+
+	fn add(self, rhs: F) -> Self::Output {
+		Expr::from(self) + rhs
+	}
+}
+
 impl<F: TowerField, const V: usize> std::ops::Sub<Self> for Col<F, V> {
 	type Output = Expr<F, V>;
 
@@ -103,15 +131,7 @@ impl<F: TowerField, const V: usize> std::ops::Sub<Col<F, V>> for Expr<F, V> {
 	type Output = Expr<F, V>;
 
 	fn sub(self, rhs: Col<F, V>) -> Self::Output {
-		assert_eq!(self.table_id, rhs.id.table_id);
-		assert_eq!(self.partition_id, rhs.id.partition_id);
-		let rhs_expr = ArithExpr::Var(rhs.id.partition_index);
-
-		Expr {
-			table_id: self.table_id,
-			partition_id: self.partition_id,
-			expr: self.expr - rhs_expr,
-		}
+		self - Expr::from(rhs)
 	}
 }
 
@@ -126,6 +146,25 @@ impl<F: TowerField, const V: usize> std::ops::Sub<Expr<F, V>> for Expr<F, V> {
 			partition_id: self.partition_id,
 			expr: self.expr - rhs.expr,
 		}
+	}
+}
+
+impl<F: TowerField, const V: usize> std::ops::Sub<F> for Expr<F, V> {
+	type Output = Expr<F, V>;
+
+	fn sub(self, rhs: F) -> Self::Output {
+		Expr {
+			table_id: self.table_id,
+			expr: self.expr - ArithExpr::Const(rhs),
+		}
+	}
+}
+
+impl<F: TowerField, const V: usize> std::ops::Sub<F> for Col<F, V> {
+	type Output = Expr<F, V>;
+
+	fn sub(self, rhs: F) -> Self::Output {
+		Expr::from(self) - rhs
 	}
 }
 
@@ -150,16 +189,7 @@ impl<F: TowerField, const V: usize> std::ops::Mul<Col<F, V>> for Expr<F, V> {
 	type Output = Expr<F, V>;
 
 	fn mul(self, rhs: Col<F, V>) -> Self::Output {
-		assert_eq!(self.table_id, rhs.id.table_id);
-		assert_eq!(self.partition_id, rhs.id.partition_id);
-
-		let rhs_expr = ArithExpr::Var(rhs.id.partition_index);
-
-		Expr {
-			table_id: self.table_id,
-			partition_id: self.partition_id,
-			expr: self.expr * rhs_expr,
-		}
+		self * Expr::from(rhs)
 	}
 }
 
@@ -174,6 +204,25 @@ impl<F: TowerField, const V: usize> std::ops::Mul<Expr<F, V>> for Expr<F, V> {
 			partition_id: self.partition_id,
 			expr: self.expr * rhs.expr,
 		}
+	}
+}
+
+impl<F: TowerField, const V: usize> std::ops::Mul<F> for Expr<F, V> {
+	type Output = Expr<F, V>;
+
+	fn mul(self, rhs: F) -> Self::Output {
+		Expr {
+			table_id: self.table_id,
+			expr: self.expr * ArithExpr::Const(rhs),
+		}
+	}
+}
+
+impl<F: TowerField, const V: usize> std::ops::Mul<F> for Col<F, V> {
+	type Output = Expr<F, V>;
+
+	fn mul(self, rhs: F) -> Self::Output {
+		Expr::from(self) * rhs
 	}
 }
 

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -13,6 +13,7 @@ use super::{
 	column::{upcast_col, Col, ColumnDef, ColumnInfo, ColumnShape},
 	expr::{Expr, ZeroConstraint},
 	types::B128,
+	ColumnIndex,
 };
 use crate::builder::column::ColumnId;
 
@@ -117,8 +118,7 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 			.filter_map(|(partition_index, coeff)| {
 				if coeff != F::ZERO {
 					let partition = &self.table.partitions[expr.partition_id()];
-					let col_index = partition.columns[partition_index].table_index;
-					Some((col_index, coeff))
+					Some((partition.columns[partition_index], coeff))
 				} else {
 					None
 				}
@@ -237,8 +237,7 @@ pub(super) struct TablePartition<F: TowerField = B128> {
 	pub table_id: TableId,
 	pub pack_factor: usize,
 	pub flushes: Vec<Flush>,
-	// TODO: Swap this to ColumnIndex
-	pub columns: Vec<ColumnId>,
+	pub columns: Vec<ColumnIndex>,
 	pub zero_constraints: Vec<ZeroConstraint<F>>,
 }
 
@@ -361,7 +360,7 @@ impl<F: TowerField> Table<F> {
 			},
 			is_nonzero: false,
 		};
-		partition.columns.push(id);
+		partition.columns.push(table_index);
 		self.columns.push(info);
 		Col::new(id)
 	}

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -130,17 +130,36 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		)
 	}
 
-	pub fn add_selected<FSub, const LOG_VALS_PER_ROW: usize>(
+	pub fn add_selected<FSub, const V: usize>(
 		&mut self,
-		_name: impl ToString,
-		_original: Col<FSub, LOG_VALS_PER_ROW>,
-		_index: usize,
+		name: impl ToString,
+		original: Col<FSub, V>,
+		index: usize,
 	) -> Col<FSub, 0>
 	where
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
 	{
-		todo!()
+		assert!(index < (1 << V));
+		let index = self.column_info.len();
+		self.column_info.push(ColumnInfo {
+			id: self.column_id(index),
+			col: ColumnDef::Selected {
+				col: col.id(),
+				index,
+				index_bits: col.shape().pack_factor,
+			},
+			name: name.to_string(),
+			shape: ColumnShape {
+				pack_factor: 0,
+				tower_height: FSub::TOWER_LEVEL,
+			},
+			is_nonzero: false,
+		});
+		Col {
+			id: self.column_id(index),
+			_marker: PhantomData,
+		}
 	}
 
 	pub fn assert_zero<FSub, const V: usize>(&mut self, name: impl ToString, expr: Expr<FSub, V>)

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -129,7 +129,7 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 			self.namespaced_name(name),
 			ColumnDef::LinearCombination {
 				offset,
-				col_scalars: col_scalars,
+				col_scalars,
 			},
 		)
 	}


### PR DESCRIPTION
The Collatz example was underconstrained and didn't check the evenness of values in the evens table and oddness of values in the odds table. This requires a few features and bug fixes:

* Handling of selected columns
* Bug fix for LinearCombination oracles indexing improperly into the table
* Ability to add constants to expressions