### PR TITLE
Add log size parameter to AdditiveNTT methods

### DIFF
--- a/crates/core/src/reed_solomon/reed_solomon.rs
+++ b/crates/core/src/reed_solomon/reed_solomon.rs
@@ -138,11 +138,17 @@ where
 			(0..(1 << self.log_inv_rate))
 				.into_par_iter()
 				.zip(code.par_chunks_exact_mut(msgs_len))
-				.try_for_each(|(i, data)| self.ntt.forward_transform(data, i, log_batch_size))
+				.try_for_each(|(i, data)| {
+					self.ntt
+						.forward_transform(data, i, log_batch_size, self.log_dim())
+				})
 		} else {
 			(0..(1 << self.log_inv_rate))
 				.zip(code.chunks_exact_mut(msgs_len))
-				.try_for_each(|(i, data)| self.ntt.forward_transform(data, i, log_batch_size))
+				.try_for_each(|(i, data)| {
+					self.ntt
+						.forward_transform(data, i, log_batch_size, self.log_dim())
+				})
 		}
 	}
 

--- a/crates/ntt/benches/additive_ntt.rs
+++ b/crates/ntt/benches/additive_ntt.rs
@@ -114,8 +114,9 @@ fn bench_forward_transform(c: &mut Criterion) {
 			F: BinaryField,
 			P: PackedField<Scalar = F>,
 		{
+			let log_n = data.len().ilog2() as usize + P::LOG_WIDTH - log_batch_size;
 			group.bench_function(BenchmarkId::new(name, param), |b| {
-				b.iter(|| ntt.forward_transform(data, 0, log_batch_size));
+				b.iter(|| ntt.forward_transform(data, 0, log_batch_size, log_n));
 			});
 		}
 	}
@@ -138,8 +139,9 @@ fn bench_inverse_transform(c: &mut Criterion) {
 			F: BinaryField,
 			P: PackedField<Scalar = F>,
 		{
+			let log_n = data.len().ilog2() as usize + P::LOG_WIDTH - log_batch_size;
 			group.bench_function(BenchmarkId::new(name, param), |b| {
-				b.iter(|| ntt.inverse_transform(data, 0, log_batch_size));
+				b.iter(|| ntt.inverse_transform(data, 0, log_batch_size, log_n));
 			});
 		}
 	}

--- a/crates/ntt/benches/large_transform.rs
+++ b/crates/ntt/benches/large_transform.rs
@@ -25,12 +25,12 @@ fn transform<P: PackedField<Scalar: BinaryField>>(
 		(0..(1 << log_inv_rate))
 			.into_par_iter()
 			.zip(data.par_chunks_exact_mut(msgs_len))
-			.try_for_each(|(i, data)| ntt.forward_transform(data, i, log_batch_size))
+			.try_for_each(|(i, data)| ntt.forward_transform(data, i, log_batch_size, log_dim))
 			.expect("Failed to run ntt")
 	} else {
 		(0..(1 << log_inv_rate))
 			.zip(data.chunks_exact_mut(msgs_len))
-			.try_for_each(|(i, data)| ntt.forward_transform(data, i, log_batch_size))
+			.try_for_each(|(i, data)| ntt.forward_transform(data, i, log_batch_size, log_dim))
 			.expect("Failed to run ntt")
 	}
 }

--- a/crates/ntt/src/additive_ntt.rs
+++ b/crates/ntt/src/additive_ntt.rs
@@ -55,6 +55,7 @@ pub trait AdditiveNTT<F: BinaryField> {
 		data: &mut [P],
 		coset: u32,
 		log_batch_size: usize,
+		log_n: usize,
 	) -> Result<(), Error>;
 
 	/// Inverse transformation defined in [LCH14] on a batch of inputs.
@@ -68,21 +69,24 @@ pub trait AdditiveNTT<F: BinaryField> {
 		data: &mut [P],
 		coset: u32,
 		log_batch_size: usize,
+		log_n: usize,
 	) -> Result<(), Error>;
 
 	fn forward_transform_ext<PE: PackedExtension<F>>(
 		&self,
 		data: &mut [PE],
 		coset: u32,
+		log_n: usize,
 	) -> Result<(), Error> {
-		self.forward_transform(PE::cast_bases_mut(data), coset, PE::Scalar::LOG_DEGREE)
+		self.forward_transform(PE::cast_bases_mut(data), coset, PE::Scalar::LOG_DEGREE, log_n)
 	}
 
 	fn inverse_transform_ext<PE: PackedExtension<F>>(
 		&self,
 		data: &mut [PE],
 		coset: u32,
+		log_n: usize,
 	) -> Result<(), Error> {
-		self.inverse_transform(PE::cast_bases_mut(data), coset, PE::Scalar::LOG_DEGREE)
+		self.inverse_transform(PE::cast_bases_mut(data), coset, PE::Scalar::LOG_DEGREE, log_n)
 	}
 }

--- a/crates/ntt/src/dynamic_dispatch.rs
+++ b/crates/ntt/src/dynamic_dispatch.rs
@@ -113,15 +113,16 @@ impl<F: BinaryField> AdditiveNTT<F> for DynamicDispatchNTT<F> {
 		data: &mut [P],
 		coset: u32,
 		log_batch_size: usize,
+		log_n: usize,
 	) -> Result<(), Error> {
 		match self {
-			Self::SingleThreaded(ntt) => ntt.forward_transform(data, coset, log_batch_size),
+			Self::SingleThreaded(ntt) => ntt.forward_transform(data, coset, log_batch_size, log_n),
 			Self::SingleThreadedPrecompute(ntt) => {
-				ntt.forward_transform(data, coset, log_batch_size)
+				ntt.forward_transform(data, coset, log_batch_size, log_n)
 			}
-			Self::MultiThreaded(ntt) => ntt.forward_transform(data, coset, log_batch_size),
+			Self::MultiThreaded(ntt) => ntt.forward_transform(data, coset, log_batch_size, log_n),
 			Self::MultiThreadedPrecompute(ntt) => {
-				ntt.forward_transform(data, coset, log_batch_size)
+				ntt.forward_transform(data, coset, log_batch_size, log_n)
 			}
 		}
 	}
@@ -131,15 +132,16 @@ impl<F: BinaryField> AdditiveNTT<F> for DynamicDispatchNTT<F> {
 		data: &mut [P],
 		coset: u32,
 		log_batch_size: usize,
+		log_n: usize,
 	) -> Result<(), Error> {
 		match self {
-			Self::SingleThreaded(ntt) => ntt.inverse_transform(data, coset, log_batch_size),
+			Self::SingleThreaded(ntt) => ntt.inverse_transform(data, coset, log_batch_size, log_n),
 			Self::SingleThreadedPrecompute(ntt) => {
-				ntt.inverse_transform(data, coset, log_batch_size)
+				ntt.inverse_transform(data, coset, log_batch_size, log_n)
 			}
-			Self::MultiThreaded(ntt) => ntt.inverse_transform(data, coset, log_batch_size),
+			Self::MultiThreaded(ntt) => ntt.inverse_transform(data, coset, log_batch_size, log_n),
 			Self::MultiThreadedPrecompute(ntt) => {
-				ntt.inverse_transform(data, coset, log_batch_size)
+				ntt.inverse_transform(data, coset, log_batch_size, log_n)
 			}
 		}
 	}

--- a/crates/ntt/src/multithreaded.rs
+++ b/crates/ntt/src/multithreaded.rs
@@ -115,7 +115,7 @@ fn forward_transform<F: BinaryField, P: PackedField<Scalar = F>>(
 					data,
 					coset,
 					log_batch_size,
-					P::LOG_WIDTH - log_batch_size,
+					log_n,
 				),
 			};
 		}
@@ -209,7 +209,7 @@ fn inverse_transform<F: BinaryField, P: PackedField<Scalar = F>>(
 					data,
 					coset,
 					log_batch_size,
-					log_n.saturating_sub(log_batch_size),
+					log_n,
 				),
 			};
 		}

--- a/crates/ntt/src/multithreaded.rs
+++ b/crates/ntt/src/multithreaded.rs
@@ -277,11 +277,5 @@ fn inverse_transform<F: BinaryField, P: PackedField<Scalar = F>>(
 			}
 		});
 
-	if log_n + log_b < log_w {
-		for i in 1 << (log_n + log_b)..P::WIDTH {
-			data[0].set(i, F::ZERO);
-		}
-	}
-
 	Ok(())
 }

--- a/crates/ntt/src/odd_interpolate.rs
+++ b/crates/ntt/src/odd_interpolate.rs
@@ -67,7 +67,7 @@ impl<F: BinaryField> OddInterpolate<F> {
 		}
 
 		for (i, chunk) in data.chunks_exact_mut(1 << ell).enumerate() {
-			ntt.inverse_transform(chunk, i as u32, 0, chunk.len().ilog2() as usize)?;
+			ntt.inverse_transform(chunk, i as u32, 0, ell)?;
 		}
 
 		// Given M and a vector v, do the "strided product" M v. In more detail: we assume matrix is $d\times d$,

--- a/crates/ntt/src/odd_interpolate.rs
+++ b/crates/ntt/src/odd_interpolate.rs
@@ -67,7 +67,7 @@ impl<F: BinaryField> OddInterpolate<F> {
 		}
 
 		for (i, chunk) in data.chunks_exact_mut(1 << ell).enumerate() {
-			ntt.inverse_transform(chunk, i as u32, 0)?;
+			ntt.inverse_transform(chunk, i as u32, 0, chunk.len().ilog2() as usize)?;
 		}
 
 		// Given M and a vector v, do the "strided product" M v. In more detail: we assume matrix is $d\times d$,
@@ -161,10 +161,11 @@ mod tests {
 
 				let mut ntt_evals = expected_novel.clone();
 				// zero-pad to the next power of two to apply the forward transform.
-				let next_power_of_two = 1 << log2_ceil_usize(expected_novel.len());
-				ntt_evals.resize(next_power_of_two, F::ZERO);
+				let next_log_n = log2_ceil_usize(expected_novel.len());
+				ntt_evals.resize(1 << next_log_n, F::ZERO);
 				// apply forward transform and then run our odd interpolation routine.
-				ntt.forward_transform(&mut ntt_evals, 0, 0).unwrap();
+				ntt.forward_transform(&mut ntt_evals, 0, 0, next_log_n)
+					.unwrap();
 
 				let odd_interpolate = OddInterpolate::new(d, ell, &ntt.s_evals).unwrap();
 				odd_interpolate

--- a/crates/ntt/src/single_threaded.rs
+++ b/crates/ntt/src/single_threaded.rs
@@ -310,9 +310,11 @@ pub fn check_batch_transform_inputs_and_params<PB: PackedField>(
 
 	// The domain size should be at least large enough to represent the given coset;
 	// on the lower end, there is a fallback for data.len() == 1 which reduces to
-	// a forward/inverse NTT on the [PB; 2], which demands log_domain_size of at least
-	// PB::LOG_WIDTH + 1. Not enforcing this bound makes some twiddle values unavailable.
-	let log_required_domain_size = (log_n + coset_bits).max(PB::LOG_WIDTH + 1);
+	// a forward/inverse NTT on the [PB; 2], which demands log_domain_size of
+	// at least min(PB::LOG_WIDTH + 1 - log_batch_size, 0).
+	// Not enforcing this bound makes some twiddle values unavailable.
+	let log_required_domain_size =
+		(log_n + coset_bits).max((PB::LOG_WIDTH + 1).saturating_sub(log_batch_size));
 	if log_required_domain_size > log_domain_size {
 		return Err(Error::DomainTooSmall {
 			log_required_domain_size,

--- a/crates/ntt/src/tests/ntt_tests.rs
+++ b/crates/ntt/src/tests/ntt_tests.rs
@@ -10,8 +10,8 @@ use binius_field::{
 		packed_8::PackedBinaryField1x8b,
 	},
 	underlier::{NumCast, WithUnderlier},
-	AESTowerField8b, BinaryField, BinaryField8b, PackedBinaryField16x32b, PackedBinaryField8x32b,
-	PackedExtension, PackedField, RepackedExtension,
+	AESTowerField8b, BinaryField, BinaryField8b, PackedBinaryField16x32b, PackedBinaryField32x16b,
+	PackedBinaryField8x32b, PackedExtension, PackedField, RepackedExtension,
 };
 use rand::{rngs::StdRng, SeedableRng};
 
@@ -22,34 +22,50 @@ use crate::{dynamic_dispatch::DynamicDispatchNTT, AdditiveNTT, SingleThreadedNTT
 fn check_roundtrip_with_reference<F, P>(
 	reference_ntt: &impl AdditiveNTT<F>,
 	ntt: &impl AdditiveNTT<F>,
-	data: &mut [P],
+	data: &[P],
 	cosets: Range<u32>,
 	log_batch_size: usize,
 ) where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 {
-	let log_n = data.len().ilog2() as usize + P::LOG_WIDTH - log_batch_size;
-	let data_copy = data.to_vec();
-	let mut data_copy_2 = data.to_vec();
+	let log_n_range = if data.len() > 1 {
+		let single_log_n = data.len().ilog2() as usize + P::LOG_WIDTH - log_batch_size;
+		single_log_n..single_log_n + 1
+	} else {
+		0..P::LOG_WIDTH - log_batch_size
+	};
 
-	for coset in cosets {
-		ntt.forward_transform(data, coset, log_batch_size, log_n)
-			.unwrap();
-		reference_ntt
-			.forward_transform(&mut data_copy_2, coset, log_batch_size, log_n)
-			.unwrap();
+	for log_n in log_n_range {
+		let mut orig_data = data.to_vec();
 
-		assert_eq!(data, &data_copy_2);
+		if log_n + log_batch_size < P::LOG_WIDTH {
+			for i in 1 << (log_n + log_batch_size)..P::WIDTH {
+				orig_data[0].set(i, F::ZERO);
+			}
+		}
 
-		ntt.inverse_transform(data, coset, log_batch_size, log_n)
-			.unwrap();
-		reference_ntt
-			.inverse_transform(&mut data_copy_2, coset, log_batch_size, log_n)
-			.unwrap();
+		let mut data_copy_impl = orig_data.clone();
+		let mut data_copy_ref = orig_data.clone();
 
-		assert_eq!(data, &data_copy);
-		assert_eq!(data, &data_copy_2);
+		for coset in cosets.clone() {
+			ntt.forward_transform(&mut data_copy_impl, coset, log_batch_size, log_n)
+				.unwrap();
+			reference_ntt
+				.forward_transform(&mut data_copy_ref, coset, log_batch_size, log_n)
+				.unwrap();
+
+			assert_eq!(&data_copy_impl, &data_copy_ref);
+
+			ntt.inverse_transform(&mut data_copy_impl, coset, log_batch_size, log_n)
+				.unwrap();
+			reference_ntt
+				.inverse_transform(&mut data_copy_ref, coset, log_batch_size, log_n)
+				.unwrap();
+
+			assert_eq!(&orig_data, &data_copy_impl);
+			assert_eq!(&orig_data, &data_copy_ref);
+		}
 	}
 }
 
@@ -81,7 +97,7 @@ fn check_roundtrip_all_ntts<P>(
 	);
 
 	let mut rng = StdRng::seed_from_u64(0);
-	let mut data = (0..1u128 << log_data_size)
+	let data = (0..1u128 << log_data_size)
 		.map(|_| P::random(&mut rng))
 		.collect::<Vec<_>>();
 
@@ -90,35 +106,35 @@ fn check_roundtrip_all_ntts<P>(
 		check_roundtrip_with_reference(
 			&simple_ntt,
 			&single_threaded_ntt,
-			&mut data,
+			&data,
 			cosets.clone(),
 			log_batch_size,
 		);
 		check_roundtrip_with_reference(
 			&simple_ntt,
 			&single_threaded_precompute_ntt,
-			&mut data,
+			&data,
 			cosets.clone(),
 			log_batch_size,
 		);
 		check_roundtrip_with_reference(
 			&simple_ntt,
 			&multithreaded_ntt,
-			&mut data,
+			&data,
 			cosets.clone(),
 			log_batch_size,
 		);
 		check_roundtrip_with_reference(
 			&simple_ntt,
 			&multithreaded_precompute_ntt,
-			&mut data,
+			&data,
 			cosets.clone(),
 			log_batch_size,
 		);
 		check_roundtrip_with_reference(
 			&simple_ntt,
 			&dynamic_dispatch_ntt,
-			&mut data,
+			&data,
 			cosets.clone(),
 			log_batch_size,
 		);
@@ -148,6 +164,11 @@ fn tests_field_256_bits() {
 #[test]
 fn tests_field_512_bits() {
 	check_roundtrip_all_ntts::<PackedBinaryField16x32b>(12, 6, 4, 0);
+}
+
+#[test]
+fn test_sub_packing_width() {
+	check_roundtrip_all_ntts::<PackedBinaryField32x16b>(12, 0, 2, 1);
 }
 
 fn check_packed_extension_roundtrip_with_reference<F, PE>(

--- a/crates/ntt/src/tests/reference.rs
+++ b/crates/ntt/src/tests/reference.rs
@@ -73,15 +73,12 @@ fn forward_transform_simple<F, FF>(
 	s_evals: &[impl TwiddleAccess<F>],
 	data: &mut impl DataAccess<FF>,
 	coset: u32,
+	log_n: usize,
 ) -> Result<(), Error>
 where
 	F: BinaryField,
 	FF: ExtensionField<F>,
 {
-	let n = data.len();
-	assert!(n.is_power_of_two());
-
-	let log_n = n.trailing_zeros() as usize;
 	let coset_bits = 32 - coset.leading_zeros() as usize;
 	if log_n + coset_bits > log_domain_size {
 		return Err(Error::DomainTooSmall {
@@ -108,6 +105,10 @@ where
 		}
 	}
 
+	for i in 1 << log_n..data.len() {
+		data.set(i, FF::ZERO);
+	}
+
 	Ok(())
 }
 
@@ -117,15 +118,12 @@ fn inverse_transform_simple<F, FF>(
 	s_evals: &[impl TwiddleAccess<F>],
 	data: &mut impl DataAccess<FF>,
 	coset: u32,
+	log_n: usize,
 ) -> Result<(), Error>
 where
 	F: BinaryField,
 	FF: ExtensionField<F>,
 {
-	let n = data.len();
-	assert!(n.is_power_of_two());
-
-	let log_n = n.trailing_zeros() as usize;
 	let coset_bits = 32 - coset.leading_zeros() as usize;
 	if log_n + coset_bits > log_domain_size {
 		return Err(Error::DomainTooSmall {
@@ -184,10 +182,15 @@ impl<F: BinaryField, TA: TwiddleAccess<F>> AdditiveNTT<F> for SimpleAdditiveNTT<
 		log_batch_size: usize,
 		log_n: usize,
 	) -> Result<(), Error> {
-		assert_eq!(log_n, data.len().ilog2() as usize + P::LOG_WIDTH - log_batch_size);
 		for batch_index in 0..1 << log_batch_size {
 			let mut batch = BatchedPackedFieldSlice::new(data, log_batch_size, batch_index);
-			forward_transform_simple(self.log_domain_size(), &self.s_evals, &mut batch, coset)?;
+			forward_transform_simple(
+				self.log_domain_size(),
+				&self.s_evals,
+				&mut batch,
+				coset,
+				log_n,
+			)?;
 		}
 
 		Ok(())
@@ -200,10 +203,15 @@ impl<F: BinaryField, TA: TwiddleAccess<F>> AdditiveNTT<F> for SimpleAdditiveNTT<
 		log_batch_size: usize,
 		log_n: usize,
 	) -> Result<(), Error> {
-		assert_eq!(log_n, data.len().ilog2() as usize + P::LOG_WIDTH - log_batch_size);
 		for batch_index in 0..1 << log_batch_size {
 			let mut batch = BatchedPackedFieldSlice::new(data, log_batch_size, batch_index);
-			inverse_transform_simple(self.log_domain_size(), &self.s_evals, &mut batch, coset)?;
+			inverse_transform_simple(
+				self.log_domain_size(),
+				&self.s_evals,
+				&mut batch,
+				coset,
+				log_n,
+			)?;
 		}
 
 		Ok(())

--- a/crates/ntt/src/tests/reference.rs
+++ b/crates/ntt/src/tests/reference.rs
@@ -182,7 +182,9 @@ impl<F: BinaryField, TA: TwiddleAccess<F>> AdditiveNTT<F> for SimpleAdditiveNTT<
 		data: &mut [P],
 		coset: u32,
 		log_batch_size: usize,
+		log_n: usize,
 	) -> Result<(), Error> {
+		assert_eq!(log_n, data.len().ilog2() as usize + P::LOG_WIDTH - log_batch_size);
 		for batch_index in 0..1 << log_batch_size {
 			let mut batch = BatchedPackedFieldSlice::new(data, log_batch_size, batch_index);
 			forward_transform_simple(self.log_domain_size(), &self.s_evals, &mut batch, coset)?;
@@ -196,7 +198,9 @@ impl<F: BinaryField, TA: TwiddleAccess<F>> AdditiveNTT<F> for SimpleAdditiveNTT<
 		data: &mut [P],
 		coset: u32,
 		log_batch_size: usize,
+		log_n: usize,
 	) -> Result<(), Error> {
+		assert_eq!(log_n, data.len().ilog2() as usize + P::LOG_WIDTH - log_batch_size);
 		for batch_index in 0..1 << log_batch_size {
 			let mut batch = BatchedPackedFieldSlice::new(data, log_batch_size, batch_index);
 			inverse_transform_simple(self.log_domain_size(), &self.s_evals, &mut batch, coset)?;


### PR DESCRIPTION
Previously there was no way to specify an NTT forward/inverse transform narrower than a packing width, which incurred unneeded `PackedFieldIndexable` constraints in univariate skip. This PR adds `log_n` as the fourth parameter to `AdditiveNTT` methods and updates usage sites accordingly.