### PR TITLE
[m3] Switch from LOG_VALS_PER_ROW to VALUES_PER_ROW

### DIFF
--- a/crates/m3/src/builder/expr.rs
+++ b/crates/m3/src/builder/expr.rs
@@ -17,7 +17,7 @@ pub struct ZeroConstraint<F: Field> {
 ///
 /// If the expression degree is 1, then it is a linear expression.
 #[derive(Debug, Getters, CopyGetters)]
-pub struct Expr<F: TowerField, const V: usize> {
+pub struct Expr<F: TowerField, const VALUES_PER_ROW: usize> {
 	#[get_copy = "pub"]
 	table_id: TableId,
 	#[get_copy = "pub"]
@@ -26,15 +26,17 @@ pub struct Expr<F: TowerField, const V: usize> {
 	expr: ArithExpr<F>,
 }
 
-impl<F: TowerField, const V: usize> Expr<F, V> {
+impl<F: TowerField, const VALUES_PER_ROW: usize> Expr<F, VALUES_PER_ROW> {
 	/// Polynomial degree of the arithmetic expression.
 	pub fn degree(&self) -> usize {
 		self.expr.degree()
 	}
 }
 
-impl<F: TowerField, const V: usize> From<Col<F, V>> for Expr<F, V> {
-	fn from(value: Col<F, V>) -> Self {
+impl<F: TowerField, const VALUES_PER_ROW: usize> From<Col<F, VALUES_PER_ROW>>
+	for Expr<F, VALUES_PER_ROW>
+{
+	fn from(value: Col<F, VALUES_PER_ROW>) -> Self {
 		Expr {
 			table_id: value.id.table_id,
 			partition_id: value.id.partition_id,
@@ -43,8 +45,8 @@ impl<F: TowerField, const V: usize> From<Col<F, V>> for Expr<F, V> {
 	}
 }
 
-impl<F: TowerField, const V: usize> std::ops::Add<Self> for Col<F, V> {
-	type Output = Expr<F, V>;
+impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Add<Self> for Col<F, VALUES_PER_ROW> {
+	type Output = Expr<F, VALUES_PER_ROW>;
 
 	fn add(self, rhs: Self) -> Self::Output {
 		assert_eq!(self.id.table_id, rhs.id.table_id);
@@ -61,10 +63,12 @@ impl<F: TowerField, const V: usize> std::ops::Add<Self> for Col<F, V> {
 	}
 }
 
-impl<F: TowerField, const V: usize> std::ops::Add<Col<F, V>> for Expr<F, V> {
-	type Output = Expr<F, V>;
+impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Add<Col<F, VALUES_PER_ROW>>
+	for Expr<F, VALUES_PER_ROW>
+{
+	type Output = Expr<F, VALUES_PER_ROW>;
 
-	fn add(self, rhs: Col<F, V>) -> Self::Output {
+	fn add(self, rhs: Col<F, VALUES_PER_ROW>) -> Self::Output {
 		assert_eq!(self.table_id, rhs.id.table_id);
 		assert_eq!(self.partition_id, rhs.id.partition_id);
 
@@ -78,10 +82,12 @@ impl<F: TowerField, const V: usize> std::ops::Add<Col<F, V>> for Expr<F, V> {
 	}
 }
 
-impl<F: TowerField, const V: usize> std::ops::Add<Expr<F, V>> for Expr<F, V> {
-	type Output = Expr<F, V>;
+impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Add<Expr<F, VALUES_PER_ROW>>
+	for Expr<F, VALUES_PER_ROW>
+{
+	type Output = Expr<F, VALUES_PER_ROW>;
 
-	fn add(self, rhs: Expr<F, V>) -> Self::Output {
+	fn add(self, rhs: Expr<F, VALUES_PER_ROW>) -> Self::Output {
 		assert_eq!(self.table_id, rhs.table_id);
 		assert_eq!(self.partition_id, rhs.partition_id);
 		Expr {
@@ -92,8 +98,8 @@ impl<F: TowerField, const V: usize> std::ops::Add<Expr<F, V>> for Expr<F, V> {
 	}
 }
 
-impl<F: TowerField, const V: usize> std::ops::Add<F> for Expr<F, V> {
-	type Output = Expr<F, V>;
+impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Add<F> for Expr<F, VALUES_PER_ROW> {
+	type Output = Expr<F, VALUES_PER_ROW>;
 
 	fn add(self, rhs: F) -> Self::Output {
 		Expr {
@@ -104,16 +110,16 @@ impl<F: TowerField, const V: usize> std::ops::Add<F> for Expr<F, V> {
 	}
 }
 
-impl<F: TowerField, const V: usize> std::ops::Add<F> for Col<F, V> {
-	type Output = Expr<F, V>;
+impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Add<F> for Col<F, VALUES_PER_ROW> {
+	type Output = Expr<F, VALUES_PER_ROW>;
 
 	fn add(self, rhs: F) -> Self::Output {
 		Expr::from(self) + rhs
 	}
 }
 
-impl<F: TowerField, const V: usize> std::ops::Sub<Self> for Col<F, V> {
-	type Output = Expr<F, V>;
+impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Sub<Self> for Col<F, VALUES_PER_ROW> {
+	type Output = Expr<F, VALUES_PER_ROW>;
 
 	fn sub(self, rhs: Self) -> Self::Output {
 		assert_eq!(self.id.table_id, rhs.id.table_id);
@@ -129,18 +135,22 @@ impl<F: TowerField, const V: usize> std::ops::Sub<Self> for Col<F, V> {
 	}
 }
 
-impl<F: TowerField, const V: usize> std::ops::Sub<Col<F, V>> for Expr<F, V> {
-	type Output = Expr<F, V>;
+impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Sub<Col<F, VALUES_PER_ROW>>
+	for Expr<F, VALUES_PER_ROW>
+{
+	type Output = Expr<F, VALUES_PER_ROW>;
 
-	fn sub(self, rhs: Col<F, V>) -> Self::Output {
+	fn sub(self, rhs: Col<F, VALUES_PER_ROW>) -> Self::Output {
 		self - Expr::from(rhs)
 	}
 }
 
-impl<F: TowerField, const V: usize> std::ops::Sub<Expr<F, V>> for Expr<F, V> {
-	type Output = Expr<F, V>;
+impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Sub<Expr<F, VALUES_PER_ROW>>
+	for Expr<F, VALUES_PER_ROW>
+{
+	type Output = Expr<F, VALUES_PER_ROW>;
 
-	fn sub(self, rhs: Expr<F, V>) -> Self::Output {
+	fn sub(self, rhs: Expr<F, VALUES_PER_ROW>) -> Self::Output {
 		assert_eq!(self.table_id, rhs.table_id);
 		assert_eq!(self.partition_id, rhs.partition_id);
 		Expr {
@@ -151,8 +161,8 @@ impl<F: TowerField, const V: usize> std::ops::Sub<Expr<F, V>> for Expr<F, V> {
 	}
 }
 
-impl<F: TowerField, const V: usize> std::ops::Sub<F> for Expr<F, V> {
-	type Output = Expr<F, V>;
+impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Sub<F> for Expr<F, VALUES_PER_ROW> {
+	type Output = Expr<F, VALUES_PER_ROW>;
 
 	fn sub(self, rhs: F) -> Self::Output {
 		Expr {
@@ -163,16 +173,16 @@ impl<F: TowerField, const V: usize> std::ops::Sub<F> for Expr<F, V> {
 	}
 }
 
-impl<F: TowerField, const V: usize> std::ops::Sub<F> for Col<F, V> {
-	type Output = Expr<F, V>;
+impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Sub<F> for Col<F, VALUES_PER_ROW> {
+	type Output = Expr<F, VALUES_PER_ROW>;
 
 	fn sub(self, rhs: F) -> Self::Output {
 		Expr::from(self) - rhs
 	}
 }
 
-impl<F: TowerField, const V: usize> std::ops::Mul<Self> for Col<F, V> {
-	type Output = Expr<F, V>;
+impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Mul<Self> for Col<F, VALUES_PER_ROW> {
+	type Output = Expr<F, VALUES_PER_ROW>;
 
 	fn mul(self, rhs: Self) -> Self::Output {
 		assert_eq!(self.id.table_id, rhs.id.table_id);
@@ -188,18 +198,22 @@ impl<F: TowerField, const V: usize> std::ops::Mul<Self> for Col<F, V> {
 	}
 }
 
-impl<F: TowerField, const V: usize> std::ops::Mul<Col<F, V>> for Expr<F, V> {
-	type Output = Expr<F, V>;
+impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Mul<Col<F, VALUES_PER_ROW>>
+	for Expr<F, VALUES_PER_ROW>
+{
+	type Output = Expr<F, VALUES_PER_ROW>;
 
-	fn mul(self, rhs: Col<F, V>) -> Self::Output {
+	fn mul(self, rhs: Col<F, VALUES_PER_ROW>) -> Self::Output {
 		self * Expr::from(rhs)
 	}
 }
 
-impl<F: TowerField, const V: usize> std::ops::Mul<Expr<F, V>> for Expr<F, V> {
-	type Output = Expr<F, V>;
+impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Mul<Expr<F, VALUES_PER_ROW>>
+	for Expr<F, VALUES_PER_ROW>
+{
+	type Output = Expr<F, VALUES_PER_ROW>;
 
-	fn mul(self, rhs: Expr<F, V>) -> Self::Output {
+	fn mul(self, rhs: Expr<F, VALUES_PER_ROW>) -> Self::Output {
 		assert_eq!(self.table_id, rhs.table_id);
 		assert_eq!(self.partition_id, rhs.partition_id);
 		Expr {
@@ -210,8 +224,8 @@ impl<F: TowerField, const V: usize> std::ops::Mul<Expr<F, V>> for Expr<F, V> {
 	}
 }
 
-impl<F: TowerField, const V: usize> std::ops::Mul<F> for Expr<F, V> {
-	type Output = Expr<F, V>;
+impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Mul<F> for Expr<F, VALUES_PER_ROW> {
+	type Output = Expr<F, VALUES_PER_ROW>;
 
 	fn mul(self, rhs: F) -> Self::Output {
 		Expr {
@@ -222,8 +236,8 @@ impl<F: TowerField, const V: usize> std::ops::Mul<F> for Expr<F, V> {
 	}
 }
 
-impl<F: TowerField, const V: usize> std::ops::Mul<F> for Col<F, V> {
-	type Output = Expr<F, V>;
+impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Mul<F> for Col<F, VALUES_PER_ROW> {
+	type Output = Expr<F, VALUES_PER_ROW>;
 
 	fn mul(self, rhs: F) -> Self::Output {
 		Expr::from(self) * rhs

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -6,7 +6,7 @@ use binius_core::{
 };
 use binius_field::{ExtensionField, TowerField};
 use binius_math::LinearNormalForm;
-use binius_utils::sparse_index::SparseIndex;
+use binius_utils::{checked_arithmetics::log2_strict_usize, sparse_index::SparseIndex};
 
 use super::{
 	channel::Flush,
@@ -44,10 +44,10 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		self.table.id()
 	}
 
-	pub fn add_committed<FSub, const LOG_VALS_PER_ROW: usize>(
+	pub fn add_committed<FSub, const VALUES_PER_ROW: usize>(
 		&mut self,
 		name: impl ToString,
-	) -> Col<FSub, LOG_VALS_PER_ROW>
+	) -> Col<FSub, VALUES_PER_ROW>
 	where
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
@@ -60,10 +60,10 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		)
 	}
 
-	pub fn add_committed_multiple<FSub, const V: usize, const N: usize>(
+	pub fn add_committed_multiple<FSub, const VALUES_PER_ROW: usize, const N: usize>(
 		&mut self,
 		name: impl ToString,
-	) -> [Col<FSub, V>; N]
+	) -> [Col<FSub, VALUES_PER_ROW>; N]
 	where
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
@@ -71,19 +71,19 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		std::array::from_fn(|i| self.add_committed(format!("{}[{}]", name.to_string(), i)))
 	}
 
-	pub fn add_shifted<FSub, const LOG_VALS_PER_ROW: usize>(
+	pub fn add_shifted<FSub, const VALUES_PER_ROW: usize>(
 		&mut self,
 		name: impl ToString,
-		col: Col<FSub, LOG_VALS_PER_ROW>,
+		col: Col<FSub, VALUES_PER_ROW>,
 		log_block_size: usize,
 		offset: usize,
 		variant: ShiftVariant,
-	) -> Col<FSub, LOG_VALS_PER_ROW>
+	) -> Col<FSub, VALUES_PER_ROW>
 	where
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
 	{
-		assert!(log_block_size <= LOG_VALS_PER_ROW);
+		assert!(log_block_size <= log2_strict_usize(VALUES_PER_ROW));
 		assert!(offset <= 1 << log_block_size);
 		self.table.new_column(
 			self.namespaced_name(name),
@@ -96,11 +96,11 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		)
 	}
 
-	pub fn add_linear_combination<FSub, const V: usize>(
+	pub fn add_linear_combination<FSub, const VALUES_PER_ROW: usize>(
 		&mut self,
 		name: impl ToString,
-		expr: Expr<FSub, V>,
-	) -> Col<FSub, V>
+		expr: Expr<FSub, VALUES_PER_ROW>,
+	) -> Col<FSub, VALUES_PER_ROW>
 	where
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
@@ -136,19 +136,22 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		)
 	}
 
-	pub fn add_packed<FSubSub, const VSUB: usize, FSub, const V: usize>(
+	pub fn add_packed<FSubSub, const VALUES_PER_ROW_SUB: usize, FSub, const VALUES_PER_ROW: usize>(
 		&mut self,
 		name: impl ToString,
-		col: Col<FSubSub, VSUB>,
-	) -> Col<FSub, V>
+		col: Col<FSubSub, VALUES_PER_ROW_SUB>,
+	) -> Col<FSub, VALUES_PER_ROW>
 	where
 		FSub: TowerField + ExtensionField<FSubSub>,
 		FSubSub: TowerField,
 		F: ExtensionField<FSub>,
 	{
 		assert!(FSubSub::TOWER_LEVEL < FSub::TOWER_LEVEL);
-		assert!(VSUB > V);
-		assert_eq!(FSub::TOWER_LEVEL + V, FSubSub::TOWER_LEVEL + VSUB);
+		assert!(VALUES_PER_ROW_SUB > VALUES_PER_ROW);
+		assert_eq!(
+			FSub::TOWER_LEVEL + log2_strict_usize(VALUES_PER_ROW),
+			FSubSub::TOWER_LEVEL + log2_strict_usize(VALUES_PER_ROW_SUB)
+		);
 		self.table.new_column(
 			self.namespaced_name(name),
 			ColumnDef::Packed {
@@ -158,33 +161,38 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		)
 	}
 
-	pub fn add_selected<FSub, const V: usize>(
+	pub fn add_selected<FSub, const VALUES_PER_ROW: usize>(
 		&mut self,
 		name: impl ToString,
-		col: Col<FSub, V>,
+		col: Col<FSub, VALUES_PER_ROW>,
 		index: usize,
-	) -> Col<FSub, 0>
+	) -> Col<FSub, 1>
 	where
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
 	{
-		assert!(index < (1 << V));
+		assert!(index < VALUES_PER_ROW);
 		self.table.new_column(
 			self.namespaced_name(name),
 			ColumnDef::Selected {
 				col: col.id(),
 				index,
-				index_bits: V,
+				index_bits: log2_strict_usize(VALUES_PER_ROW),
 			},
 		)
 	}
 
-	pub fn assert_zero<FSub, const V: usize>(&mut self, name: impl ToString, expr: Expr<FSub, V>)
-	where
+	pub fn assert_zero<FSub, const VALUES_PER_ROW: usize>(
+		&mut self,
+		name: impl ToString,
+		expr: Expr<FSub, VALUES_PER_ROW>,
+	) where
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
 	{
-		self.table.partition_mut(V).assert_zero(name, expr)
+		self.table
+			.partition_mut(VALUES_PER_ROW)
+			.assert_zero(name, expr)
 	}
 
 	pub fn pull_one<FSub>(&mut self, channel: ChannelId, col: Col<FSub>)
@@ -192,7 +200,7 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
 	{
-		self.table.partition_mut(0).pull_one(channel, col)
+		self.table.partition_mut(1).pull_one(channel, col)
 	}
 
 	pub fn push_one<FSub>(&mut self, channel: ChannelId, col: Col<FSub>)
@@ -200,7 +208,7 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
 	{
-		self.table.partition_mut(0).push_one(channel, col)
+		self.table.partition_mut(1).push_one(channel, col)
 	}
 
 	fn namespaced_name(&self, name: impl ToString) -> String {
@@ -240,25 +248,28 @@ pub struct Table<F: TowerField = B128> {
 #[derive(Debug)]
 pub(super) struct TablePartition<F: TowerField = B128> {
 	pub table_id: TableId,
-	pub pack_factor: usize,
+	pub values_per_row: usize,
 	pub flushes: Vec<Flush>,
 	pub columns: Vec<ColumnIndex>,
 	pub zero_constraints: Vec<ZeroConstraint<F>>,
 }
 
 impl<F: TowerField> TablePartition<F> {
-	pub fn new(table_id: TableId, pack_factor: usize) -> Self {
+	pub fn new(table_id: TableId, values_per_row: usize) -> Self {
 		Self {
 			table_id,
-			pack_factor,
+			values_per_row,
 			flushes: Vec::new(),
 			columns: Vec::new(),
 			zero_constraints: Vec::new(),
 		}
 	}
 
-	pub fn assert_zero<FSub, const V: usize>(&mut self, name: impl ToString, expr: Expr<FSub, V>)
-	where
+	pub fn assert_zero<FSub, const VALUES_PER_ROW: usize>(
+		&mut self,
+		name: impl ToString,
+		expr: Expr<FSub, VALUES_PER_ROW>,
+	) where
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
 	{
@@ -298,13 +309,13 @@ impl<F: TowerField> TablePartition<F> {
 		&mut self,
 		channel_id: ChannelId,
 		direction: FlushDirection,
-		cols: impl IntoIterator<Item = Col<F, 0>>,
+		cols: impl IntoIterator<Item = Col<F, 1>>,
 	) {
 		let column_indices = cols
 			.into_iter()
 			.map(|col| {
 				assert_eq!(col.id.table_id, self.table_id);
-				assert_eq!(col.id.partition_id, self.pack_factor);
+				assert_eq!(col.id.partition_id, log2_strict_usize(self.values_per_row));
 				col.id.partition_index
 			})
 			.collect();
@@ -337,22 +348,22 @@ impl<F: TowerField> Table<F> {
 		self.id
 	}
 
-	fn new_column<FSub, const V: usize>(
+	fn new_column<FSub, const VALUES_PER_ROW: usize>(
 		&mut self,
 		name: impl ToString,
 		col: ColumnDef<F>,
-	) -> Col<FSub, V>
+	) -> Col<FSub, VALUES_PER_ROW>
 	where
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
 	{
 		let table_id = self.id;
 		let table_index = self.columns.len();
-		let partition = self.partition_mut(V);
+		let partition = self.partition_mut(VALUES_PER_ROW);
 		let id = ColumnId {
 			table_id,
 			table_index,
-			partition_id: partition.pack_factor,
+			partition_id: log2_strict_usize(partition.values_per_row),
 			partition_index: partition.columns.len(),
 		};
 		let info = ColumnInfo {
@@ -360,7 +371,7 @@ impl<F: TowerField> Table<F> {
 			col,
 			name: name.to_string(),
 			shape: ColumnShape {
-				pack_factor: V,
+				values_per_row: VALUES_PER_ROW,
 				tower_height: FSub::TOWER_LEVEL,
 			},
 			is_nonzero: false,
@@ -370,9 +381,9 @@ impl<F: TowerField> Table<F> {
 		Col::new(id)
 	}
 
-	fn partition_mut(&mut self, pack_factor: usize) -> &mut TablePartition<F> {
+	fn partition_mut(&mut self, values_per_row: usize) -> &mut TablePartition<F> {
 		self.partitions
-			.entry(pack_factor)
-			.or_insert_with(|| TablePartition::new(self.id, pack_factor))
+			.entry(log2_strict_usize(values_per_row))
+			.or_insert_with(|| TablePartition::new(self.id, values_per_row))
 	}
 }

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -15,7 +15,7 @@ use binius_field::{
 };
 use binius_math::MultilinearExtension;
 use binius_maybe_rayon::prelude::*;
-use binius_utils::checked_arithmetics::log2_ceil_usize;
+use binius_utils::checked_arithmetics::{log2_ceil_usize, log2_strict_usize};
 use bytemuck::{must_cast_slice, must_cast_slice_mut, Pod};
 use getset::CopyGetters;
 
@@ -79,7 +79,7 @@ impl<'a, U: UnderlierType> WitnessIndex<'a, U> {
 
 			for col in table.cols.into_iter() {
 				let oracle_id = first_oracle_id_in_table + col.id.table_index;
-				let n_vars = table.log_capacity + col.shape.pack_factor;
+				let n_vars = table.log_capacity + log2_strict_usize(col.shape.values_per_row);
 				let witness = match col.shape.tower_height {
 					0 => MultilinearExtension::new(
 						n_vars,
@@ -126,9 +126,9 @@ impl<'a, U: UnderlierType> WitnessIndex<'a, U> {
 			}
 
 			// Every table partition has a step_down appended to the end of the table to support non-power of two height tables
-			for pack_factor in table.selector_pack_factors.into_iter() {
+			for log_values_per_row in table.selector_log_values_per_rows.into_iter() {
 				let oracle_id = first_oracle_id_in_table + count;
-				let size = statement.table_sizes[table.table_id] << pack_factor;
+				let size = statement.table_sizes[table.table_id] << log_values_per_row;
 				let log_size = log2_ceil_usize(size);
 				let witness = StepDown::new(log_size, size)
 					.unwrap()
@@ -149,7 +149,7 @@ impl<'a, U: UnderlierType> WitnessIndex<'a, U> {
 #[derive(Debug, Default, CopyGetters)]
 pub struct TableWitnessIndex<'a, U: UnderlierType = OptimalUnderlier> {
 	table_id: TableId,
-	selector_pack_factors: Vec<usize>,
+	selector_log_values_per_rows: Vec<usize>,
 	cols: Vec<WitnessIndexColumn<'a, U>>,
 	#[get_copy = "pub"]
 	log_capacity: usize,
@@ -183,7 +183,8 @@ impl<'a, U: UnderlierType> TableWitnessIndex<'a, U> {
 			.columns
 			.iter()
 			.map(|col| {
-				let log_cell_bits = col.shape.tower_height + col.shape.pack_factor;
+				let log_cell_bits =
+					col.shape.tower_height + log2_strict_usize(col.shape.values_per_row);
 				min_log_cell_bits = min_log_cell_bits.min(log_cell_bits);
 				let log_col_bits = log_cell_bits + log_capacity;
 
@@ -207,7 +208,7 @@ impl<'a, U: UnderlierType> TableWitnessIndex<'a, U> {
 
 		Self {
 			table_id: table.id,
-			selector_pack_factors: table.partitions.keys().collect(),
+			selector_log_values_per_rows: table.partitions.keys().collect(),
 			cols,
 			log_capacity,
 			min_log_segment_size: U::LOG_BITS - min_log_cell_bits,
@@ -247,7 +248,8 @@ impl<'a, U: UnderlierType> TableWitnessIndex<'a, U> {
 				.cols
 				.iter()
 				.map(|col| {
-					let log_cell_bits = col.shape.tower_height + col.shape.pack_factor;
+					let log_cell_bits =
+						col.shape.tower_height + log2_strict_usize(col.shape.values_per_row);
 					let log_stride = log_size + log_cell_bits - U::LOG_BITS;
 					// Safety: The function borrows self mutably, so we have mutable access to
 					// all columns and thus none can be borrowed by anyone else. The loop is
@@ -285,7 +287,8 @@ impl<'a, U: UnderlierType> TableWitnessIndex<'a, U> {
 					.cols
 					.iter()
 					.map(|col| {
-						let log_cell_bits = col.shape.tower_height + col.shape.pack_factor;
+						let log_cell_bits =
+							col.shape.tower_height + log2_strict_usize(col.shape.values_per_row);
 						let log_stride = log_size + log_cell_bits - U::LOG_BITS;
 						// Safety: The function borrows self mutably, so we have mutable access to
 						// all columns and thus none can be borrowed by anyone else. The loop is
@@ -321,9 +324,9 @@ pub struct TableWitnessIndexSegment<'a, U: UnderlierType = OptimalUnderlier> {
 }
 
 impl<U: UnderlierType> TableWitnessIndexSegment<'_, U> {
-	pub fn get<F: TowerField, const V: usize>(
+	pub fn get<F: TowerField, const VALUES_PER_ROW: usize>(
 		&self,
-		col: Col<F, V>,
+		col: Col<F, VALUES_PER_ROW>,
 	) -> Result<Ref<[PackedType<U, F>]>, Error>
 	where
 		U: PackScalar<F>,
@@ -340,14 +343,14 @@ impl<U: UnderlierType> TableWitnessIndexSegment<'_, U> {
 		let col = self
 			.cols
 			.get(col.id.table_index)
-			.ok_or_else(|| Error::MissingColumn(col.id))?;
+			.ok_or_else(|| Error::MissingColumn(col.id()))?;
 		let col_ref = col.try_borrow().map_err(Error::WitnessBorrow)?;
 		Ok(Ref::map(col_ref, |x| <PackedType<U, F>>::from_underliers_ref(x)))
 	}
 
-	pub fn get_mut<F: TowerField, const V: usize>(
+	pub fn get_mut<F: TowerField, const VALUES_PER_ROW: usize>(
 		&self,
-		col: Col<F, V>,
+		col: Col<F, VALUES_PER_ROW>,
 	) -> Result<RefMut<[PackedType<U, F>]>, Error>
 	where
 		U: PackScalar<F>,
@@ -364,14 +367,14 @@ impl<U: UnderlierType> TableWitnessIndexSegment<'_, U> {
 		let col = self
 			.cols
 			.get(col.id.table_index)
-			.ok_or_else(|| Error::MissingColumn(col.id))?;
+			.ok_or_else(|| Error::MissingColumn(col.id()))?;
 		let col_ref = col.try_borrow_mut().map_err(Error::WitnessBorrowMut)?;
 		Ok(RefMut::map(col_ref, |x| <PackedType<U, F>>::from_underliers_ref_mut(x)))
 	}
 
-	pub fn get_as<T: Pod, F: TowerField, const V: usize>(
+	pub fn get_as<T: Pod, F: TowerField, const VALUES_PER_ROW: usize>(
 		&self,
-		col: Col<F, V>,
+		col: Col<F, VALUES_PER_ROW>,
 	) -> Result<Ref<[T]>, Error>
 	where
 		U: Pod,
@@ -379,14 +382,14 @@ impl<U: UnderlierType> TableWitnessIndexSegment<'_, U> {
 		let col = self
 			.cols
 			.get(col.id.table_index)
-			.ok_or_else(|| Error::MissingColumn(col.id))?;
+			.ok_or_else(|| Error::MissingColumn(col.id()))?;
 		let col_ref = col.try_borrow().map_err(Error::WitnessBorrow)?;
 		Ok(Ref::map(col_ref, |x| must_cast_slice(x)))
 	}
 
-	pub fn get_mut_as<T: Pod, F: TowerField, const V: usize>(
+	pub fn get_mut_as<T: Pod, F: TowerField, const VALUES_PER_ROW: usize>(
 		&self,
-		col: Col<F, V>,
+		col: Col<F, VALUES_PER_ROW>,
 	) -> Result<RefMut<[T]>, Error>
 	where
 		U: Pod,
@@ -401,7 +404,7 @@ impl<U: UnderlierType> TableWitnessIndexSegment<'_, U> {
 		let col = self
 			.cols
 			.get(col.id.table_index)
-			.ok_or_else(|| Error::MissingColumn(col.id))?;
+			.ok_or_else(|| Error::MissingColumn(col.id()))?;
 		let col_ref = col.try_borrow_mut().map_err(Error::WitnessBorrowMut)?;
 		Ok(RefMut::map(col_ref, |x| must_cast_slice_mut(x)))
 	}
@@ -495,10 +498,10 @@ mod tests {
 		let table_id = 0;
 		let mut inner_table = Table::<B128>::new(table_id, "table".to_string());
 		let mut table = TableBuilder::new(&mut inner_table);
-		let col0 = table.add_committed::<B1, 3>("col0");
-		let col1 = table.add_committed::<B1, 5>("col1");
-		let col2 = table.add_committed::<B8, 0>("col2");
-		let col3 = table.add_committed::<B32, 0>("col3");
+		let col0 = table.add_committed::<B1, 8>("col0");
+		let col1 = table.add_committed::<B1, 32>("col1");
+		let col2 = table.add_committed::<B8, 1>("col2");
+		let col3 = table.add_committed::<B32, 1>("col3");
 
 		let allocator = bumpalo::Bump::new();
 		let table_size = 64;
@@ -528,10 +531,10 @@ mod tests {
 		let table_id = 0;
 		let mut inner_table = Table::<B128>::new(table_id, "table".to_string());
 		let mut table = TableBuilder::new(&mut inner_table);
-		let col0 = table.add_committed::<B1, 3>("col0");
-		let col1 = table.add_committed::<B1, 5>("col1");
-		let col2 = table.add_committed::<B8, 0>("col2");
-		let col3 = table.add_committed::<B32, 0>("col3");
+		let col0 = table.add_committed::<B1, 8>("col0");
+		let col1 = table.add_committed::<B1, 32>("col1");
+		let col2 = table.add_committed::<B8, 1>("col2");
+		let col3 = table.add_committed::<B32, 1>("col3");
 
 		let allocator = bumpalo::Bump::new();
 		let table_size = 64;

--- a/crates/m3/src/gadgets/u32.rs
+++ b/crates/m3/src/gadgets/u32.rs
@@ -13,18 +13,18 @@ use crate::builder::{column::Col, types::B1, witness::TableWitnessIndexSegment, 
 #[derive(Debug)]
 pub struct U32Add {
 	// Inputs
-	pub xin: Col<B1, 5>,
-	pub yin: Col<B1, 5>,
+	pub xin: Col<B1, 32>,
+	pub yin: Col<B1, 32>,
 
 	// Private
-	cin: Col<B1, 5>,
-	cout: Col<B1, 5>,
-	cout_shl: Col<B1, 5>,
+	cin: Col<B1, 32>,
+	cout: Col<B1, 32>,
+	cout_shl: Col<B1, 32>,
 
 	// Outputs
 	/// The output column, either committed if `flags.commit_zout` is set, otherwise a linear
 	/// combination derived column.
-	pub zout: Col<B1, 5>,
+	pub zout: Col<B1, 32>,
 	/// This is `Some` if `flags.expose_final_carry` is set, otherwise it is `None`.
 	pub final_carry: Option<Col<B1>>,
 	/// Flags modifying the gadget's behavior.
@@ -36,7 +36,7 @@ pub struct U32Add {
 pub struct U32AddFlags {
 	// Optionally a column for a dynamic carry in bit. This *must* be zero in all bits except the
 	// 0th.
-	pub carry_in_bit: Option<Col<B1, 5>>,
+	pub carry_in_bit: Option<Col<B1, 32>>,
 	pub commit_zout: bool,
 	pub expose_final_carry: bool,
 }
@@ -44,11 +44,11 @@ pub struct U32AddFlags {
 impl U32Add {
 	pub fn new(
 		table: &mut TableBuilder,
-		xin: Col<B1, 5>,
-		yin: Col<B1, 5>,
+		xin: Col<B1, 32>,
+		yin: Col<B1, 32>,
 		flags: U32AddFlags,
 	) -> Self {
-		let cout = table.add_committed::<B1, 5>("cout");
+		let cout = table.add_committed::<B1, 32>("cout");
 		let cout_shl = table.add_shifted("cout_shl", cout, 5, 1, ShiftVariant::LogicalLeft);
 
 		let cin = if let Some(carry_in_bit) = flags.carry_in_bit {
@@ -64,7 +64,7 @@ impl U32Add {
 		table.assert_zero("carry_out", (xin + cin) * (yin + cin) + cin - cout);
 
 		let zout = if flags.commit_zout {
-			let zout = table.add_committed::<B1, 5>("zout");
+			let zout = table.add_committed::<B1, 32>("zout");
 			table.assert_zero("zout", xin + yin + cin - zout);
 			zout
 		} else {

--- a/crates/m3/tests/collatz.rs
+++ b/crates/m3/tests/collatz.rs
@@ -124,9 +124,9 @@ mod arithmetization {
 	#[derive(Debug)]
 	pub struct EvensTable {
 		id: TableId,
-		even: Col<B1, 5>,
+		even: Col<B1, 32>,
 		even_lsb: Col<B1>,
-		half: Col<B1, 5>,
+		half: Col<B1, 32>,
 		even_packed: Col<B32>,
 		half_packed: Col<B32>,
 	}
@@ -135,16 +135,16 @@ mod arithmetization {
 		pub fn new(cs: &mut ConstraintSystem, seq_chan: ChannelId) -> Self {
 			let mut table = cs.add_table("evens");
 
-			let even = table.add_committed::<B1, 5>("even");
+			let even = table.add_committed::<B1, 32>("even");
 			let even_lsb = table.add_selected("even_lsb", even, 0);
 
 			table.assert_zero("even_lsb is 0", even_lsb.into());
 
 			// Logical right shift is division by 2
-			let half = table.add_shifted::<B1, 5>("half", even, 5, 1, ShiftVariant::LogicalRight);
+			let half = table.add_shifted::<B1, 32>("half", even, 5, 1, ShiftVariant::LogicalRight);
 
-			let even_packed = table.add_packed::<_, 5, B32, 0>("even_packed", even);
-			let half_packed = table.add_packed::<_, 5, B32, 0>("half_packed", half);
+			let even_packed = table.add_packed::<_, 32, B32, 1>("even_packed", even);
+			let half_packed = table.add_packed::<_, 32, B32, 1>("half_packed", half);
 
 			table.pull_one(seq_chan, even_packed);
 			table.push_one(seq_chan, half_packed);
@@ -198,10 +198,10 @@ mod arithmetization {
 	#[derive(Debug)]
 	pub struct OddsTable {
 		id: TableId,
-		odd: Col<B1, 5>,
+		odd: Col<B1, 32>,
 		odd_lsb: Col<B1>,
-		double: Col<B1, 5>,
-		carry_bit: Col<B1, 5>,
+		double: Col<B1, 32>,
+		carry_bit: Col<B1, 32>,
 		triple_plus_one: U32Add,
 		odd_packed: Col<B32>,
 		triple_plus_one_packed: Col<B32>,
@@ -211,19 +211,19 @@ mod arithmetization {
 		pub fn new(cs: &mut ConstraintSystem, seq_chan: ChannelId) -> Self {
 			let mut table = cs.add_table("odds");
 
-			let odd = table.add_committed::<B1, 5>("odd_bits");
+			let odd = table.add_committed::<B1, 32>("odd_bits");
 			let odd_lsb = table.add_selected("odd_lsb", odd, 0);
 
 			table.assert_zero("odd_lsb is 1", odd_lsb - B1::ONE);
 
 			// Input times 2
 			let double =
-				table.add_shifted::<B1, 5>("double_bits", odd, 5, 1, ShiftVariant::LogicalLeft);
+				table.add_shifted::<B1, 32>("double_bits", odd, 5, 1, ShiftVariant::LogicalLeft);
 
 			// TODO: Figure out how to add repeating constants (repeating transparents). Basically a
 			// multilinear extension of some constant vector, repeating for the number of rows.
 			// This shouldn't actually be committed. It should be the carry bit, repeated for each row.
-			let carry_bit = table.add_committed::<B1, 5>("carry_bit");
+			let carry_bit = table.add_committed::<B1, 32>("carry_bit");
 
 			// Input times 3 + 1
 			let triple_plus_one = U32Add::new(
@@ -236,9 +236,9 @@ mod arithmetization {
 				},
 			);
 
-			let odd_packed = table.add_packed::<_, 5, B32, 0>("odd_packed", odd);
+			let odd_packed = table.add_packed::<_, 32, B32, 1>("odd_packed", odd);
 			let triple_plus_one_packed =
-				table.add_packed::<_, 5, B32, 0>("triple_plus_one_packed", triple_plus_one.zout);
+				table.add_packed::<_, 32, B32, 1>("triple_plus_one_packed", triple_plus_one.zout);
 
 			table.pull_one(seq_chan, odd_packed);
 			table.push_one(seq_chan, triple_plus_one_packed);


### PR DESCRIPTION
Also removes any mention of pack_factor, which can be confusing name-wise, since we also have packed virtuals/packed fields.

This is nice because `Col<B1, 32>` generally feels more familiar than `Col<B1, 5>`, and pairs more reads more nicely together with `Col<B32, 1>`