### PR TITLE
[m3] Add support for repeating constants

### DIFF
--- a/crates/core/src/polynomial/multivariate.rs
+++ b/crates/core/src/polynomial/multivariate.rs
@@ -2,6 +2,7 @@
 
 use std::{borrow::Borrow, fmt::Debug, iter::repeat_with, marker::PhantomData, sync::Arc};
 
+use auto_impl::auto_impl;
 use binius_field::{Field, PackedField};
 use binius_math::{
 	ArithExpr, CompositionPoly, MLEDirectAdapter, MultilinearPoly, MultilinearQueryRef,
@@ -17,6 +18,7 @@ use super::error::Error;
 ///
 /// The definition `MultivariatePoly` is nearly identical to that of [`CompositionPoly`], except that
 /// `MultivariatePoly` is _object safe_, whereas `CompositionPoly` is not.
+#[auto_impl(Arc)]
 pub trait MultivariatePoly<P>: Debug + Send + Sync {
 	/// The number of variables.
 	fn n_vars(&self) -> usize;

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -397,13 +397,10 @@ pub fn mul_by_subfield_scalar<P: PackedExtension<FS>, FS: Field>(val: P, multipl
 }
 
 pub fn pack_slice<P: PackedField>(scalars: &[P::Scalar]) -> Vec<P> {
-	let log_width = binius_utils::checked_arithmetics::log2_ceil_usize(scalars.len())
-		.saturating_sub(P::LOG_WIDTH);
-	let mut packed_slice = vec![P::default(); 1 << log_width];
-	for (i, scalar) in scalars.iter().enumerate() {
-		set_packed_slice(&mut packed_slice, i, *scalar);
-	}
-	packed_slice
+	scalars
+		.chunks(P::WIDTH)
+		.map(|chunk| P::from_scalars(chunk.iter().copied()))
+		.collect()
 }
 
 impl<F: Field> Broadcast<F> for F {

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -397,7 +397,9 @@ pub fn mul_by_subfield_scalar<P: PackedExtension<FS>, FS: Field>(val: P, multipl
 }
 
 pub fn pack_slice<P: PackedField>(scalars: &[P::Scalar]) -> Vec<P> {
-	let mut packed_slice = vec![P::default(); scalars.len() / P::WIDTH];
+	let log_width = binius_utils::checked_arithmetics::log2_ceil_usize(scalars.len())
+		.saturating_sub(P::LOG_WIDTH);
+	let mut packed_slice = vec![P::default(); 1 << log_width];
 	for (i, scalar) in scalars.iter().enumerate() {
 		set_packed_slice(&mut packed_slice, i, *scalar);
 	}

--- a/crates/m3/src/builder/column.rs
+++ b/crates/m3/src/builder/column.rs
@@ -1,8 +1,8 @@
 // Copyright 2025 Irreducible Inc.
 
-use std::marker::PhantomData;
+use std::{marker::PhantomData, sync::Arc};
 
-use binius_core::oracle::ShiftVariant;
+use binius_core::{oracle::ShiftVariant, polynomial::MultivariatePoly};
 use binius_field::{ExtensionField, TowerField};
 use binius_math::ArithExpr;
 
@@ -88,6 +88,8 @@ pub struct ColumnInfo<F: TowerField = B128> {
 	pub shape: ColumnShape,
 	/// Whether the column is constrained to be non-zero.
 	pub is_nonzero: bool,
+	/// Whether the column is transparent and only contains a single row.
+	pub is_single_row: bool,
 }
 
 /// The shape of each cell in a column.
@@ -137,5 +139,11 @@ pub enum ColumnDef<F: TowerField = B128> {
 	Computed {
 		cols: Vec<ColumnIndex>,
 		expr: ArithExpr<F>,
+	},
+	Transparent {
+		poly: Arc<dyn MultivariatePoly<F>>,
+	},
+	RepeatingTransparent {
+		col: ColumnId,
 	},
 }

--- a/crates/m3/src/builder/column.rs
+++ b/crates/m3/src/builder/column.rs
@@ -99,6 +99,12 @@ pub struct ColumnShape {
 	pub log_values_per_row: usize,
 }
 
+impl ColumnShape {
+	pub fn log_cell_size(&self) -> usize {
+		self.tower_height + self.log_values_per_row
+	}
+}
+
 /// Unique identifier for a column within a constraint system.
 ///
 /// IDs are assigned when columns are added to the constraint system and remain stable when more
@@ -138,7 +144,7 @@ pub enum ColumnDef<F: TowerField = B128> {
 		cols: Vec<ColumnIndex>,
 		expr: ArithExpr<F>,
 	},
-	RepeatingTransparent {
+	Transparent {
 		poly: Arc<dyn MultivariatePoly<F>>,
 	},
 }

--- a/crates/m3/src/builder/column.rs
+++ b/crates/m3/src/builder/column.rs
@@ -88,8 +88,6 @@ pub struct ColumnInfo<F: TowerField = B128> {
 	pub shape: ColumnShape,
 	/// Whether the column is constrained to be non-zero.
 	pub is_nonzero: bool,
-	/// Whether the column is transparent and only contains a single row.
-	pub is_single_row: bool,
 }
 
 /// The shape of each cell in a column.
@@ -140,10 +138,7 @@ pub enum ColumnDef<F: TowerField = B128> {
 		cols: Vec<ColumnIndex>,
 		expr: ArithExpr<F>,
 	},
-	Transparent {
-		poly: Arc<dyn MultivariatePoly<F>>,
-	},
 	RepeatingTransparent {
-		col: ColumnId,
+		poly: Arc<dyn MultivariatePoly<F>>,
 	},
 }

--- a/crates/m3/src/builder/column.rs
+++ b/crates/m3/src/builder/column.rs
@@ -144,7 +144,7 @@ pub enum ColumnDef<F: TowerField = B128> {
 		cols: Vec<ColumnIndex>,
 		expr: ArithExpr<F>,
 	},
-	Transparent {
+	Constant {
 		poly: Arc<dyn MultivariatePoly<F>>,
 	},
 }

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -82,7 +82,7 @@ impl<F: TowerField> std::fmt::Display for ConstraintSystem<F> {
 			}
 
 			for col in table.columns.iter() {
-				if matches!(col.col, ColumnDef::Transparent { .. }) {
+				if matches!(col.col, ColumnDef::Constant { .. }) {
 					oracle_id += 1;
 				}
 			}
@@ -193,7 +193,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 
 			let mut transparent_single = vec![None; table.columns.len()];
 			for (table_index, info) in table.columns.iter().enumerate() {
-				if let ColumnDef::Transparent { poly } = &info.col {
+				if let ColumnDef::Constant { poly } = &info.col {
 					let oracle_id = oracles
 						.add_named(format!("{}_single", info.name))
 						.transparent(poly.clone())?;
@@ -362,7 +362,7 @@ fn add_oracle_for_column<F: TowerField>(
 				.collect::<Vec<_>>();
 			addition.composite_mle(n_vars, inner_oracles, expr.clone())?
 		}
-		ColumnDef::Transparent { .. } => addition.repeating(
+		ColumnDef::Constant { .. } => addition.repeating(
 			transparent_single[id.table_index].unwrap(),
 			n_vars - shape.log_values_per_row,
 		)?,

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -258,7 +258,7 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		.unwrap();
 		self.table.new_column(
 			namespaced_name,
-			ColumnDef::RepeatingTransparent {
+			ColumnDef::Transparent {
 				poly: Arc::new(mle),
 			},
 		)

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -237,7 +237,7 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		)
 	}
 
-	pub fn add_repeating_constants<FSub, const VALUES_PER_ROW: usize>(
+	pub fn add_constant<FSub, const VALUES_PER_ROW: usize>(
 		&mut self,
 		name: impl ToString,
 		constants: [FSub; VALUES_PER_ROW],

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -258,7 +258,7 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		.unwrap();
 		self.table.new_column(
 			namespaced_name,
-			ColumnDef::Transparent {
+			ColumnDef::Constant {
 				poly: Arc::new(mle),
 			},
 		)

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -8,7 +8,7 @@ use std::{
 
 use anyhow::ensure;
 use binius_core::{
-	polynomial::ArithCircuitPoly, transparent::step_down::StepDown,
+	oracle::OracleId, polynomial::ArithCircuitPoly, transparent::step_down::StepDown,
 	witness::MultilinearExtensionIndex,
 };
 use binius_field::{
@@ -78,8 +78,8 @@ impl<'cs, 'alloc, U: UnderlierType, F: TowerField> WitnessIndex<'cs, 'alloc, U, 
 			let cols = immutable_witness_index_columns(table.cols);
 
 			let mut count = 0;
-			for col in cols {
-				let oracle_id = first_oracle_id_in_table + col.id.table_index;
+			for (oracle_id_offset, col) in cols.into_iter().enumerate() {
+				let oracle_id = first_oracle_id_in_table + oracle_id_offset;
 				let log_capacity = if col.is_single_row {
 					0
 				} else {
@@ -160,6 +160,7 @@ where
 pub struct TableWitnessIndex<'cs, 'alloc, U: UnderlierType = OptimalUnderlier, F: TowerField = B128>
 {
 	table: &'cs Table<F>,
+	oracle_offset_lookup: Vec<OracleId>,
 	selector_log_values_per_rows: Vec<usize>,
 	cols: Vec<WitnessIndexColumn<'alloc, U>>,
 	#[get_copy = "pub"]
@@ -174,7 +175,6 @@ pub struct TableWitnessIndex<'cs, 'alloc, U: UnderlierType = OptimalUnderlier, F
 
 #[derive(Debug)]
 pub struct WitnessIndexColumn<'a, U: UnderlierType> {
-	pub id: ColumnId,
 	pub shape: ColumnShape,
 	pub data: WitnessDataMut<'a, U>,
 	pub is_single_row: bool,
@@ -183,18 +183,17 @@ pub struct WitnessIndexColumn<'a, U: UnderlierType> {
 #[derive(Debug)]
 pub enum WitnessDataMut<'alloc, U: UnderlierType> {
 	Owned(&'alloc mut [U]),
-	SameAsTableIndex(ColumnIndex),
+	SameAsOracleIndex(usize),
 }
 
 #[derive(Debug)]
 pub enum RefCellData<'alloc, U: UnderlierType> {
 	Owned(RefCell<&'alloc mut [U]>),
-	SameAsTableIndex(ColumnIndex),
+	SameAsOracleIndex(usize),
 }
 
 #[derive(Debug)]
 pub struct ImmutableWitnessIndexColumn<'a, U: UnderlierType> {
-	pub id: ColumnId,
 	pub shape: ColumnShape,
 	pub data: &'a [U],
 	pub is_single_row: bool,
@@ -206,11 +205,10 @@ fn immutable_witness_index_columns<'a, U: UnderlierType>(
 	let mut result: Vec<ImmutableWitnessIndexColumn<'a, U>> = Vec::with_capacity(cols.len());
 	for col in cols {
 		result.push(ImmutableWitnessIndexColumn {
-			id: col.id,
 			shape: col.shape,
 			data: match col.data {
 				WitnessDataMut::Owned(data) => data,
-				WitnessDataMut::SameAsTableIndex(index) => result[index].data,
+				WitnessDataMut::SameAsOracleIndex(index) => result[index].data,
 			},
 			is_single_row: col.is_single_row,
 		});
@@ -225,42 +223,53 @@ impl<'cs, 'alloc, U: UnderlierType, F: TowerField> TableWitnessIndex<'cs, 'alloc
 
 		let mut min_log_cell_bits = U::LOG_BITS;
 
-		let cols = table
-			.columns
-			.iter()
-			.map(|col| {
-				let data = match col.col {
-					ColumnDef::Packed { col: inner_col, .. } => {
-						WitnessDataMut::SameAsTableIndex(inner_col.table_index)
-					}
-					ColumnDef::RepeatingTransparent { col: inner_col } => {
-						WitnessDataMut::SameAsTableIndex(inner_col.table_index)
-					}
-					_ => {
-						let log_cell_bits = col.shape.tower_height + col.shape.log_values_per_row;
-						min_log_cell_bits = min_log_cell_bits.min(log_cell_bits);
-						let log_col_bits = log_cell_bits + log_capacity;
+		let mut next_oracle_index = 0;
+		let mut cols = Vec::new();
+		let mut oracle_offset_lookup = Vec::with_capacity(table.columns.len());
 
-						// TODO: Error instead of panic
-						if log_col_bits < U::LOG_BITS {
-							panic!("capacity is too low");
-						}
-
-						// TODO: Allocate uninitialized memory and avoid filling. That should be OK because
-						// Underlier is Pod.
-						WitnessDataMut::Owned(
-							allocator.alloc_slice_fill_default(1 << (log_col_bits - U::LOG_BITS)),
-						)
-					}
-				};
-				WitnessIndexColumn {
-					id: col.id,
-					shape: col.shape,
-					data,
-					is_single_row: col.is_single_row,
+		for col in &table.columns {
+			let shape = col.shape;
+			let data = match col.col {
+				ColumnDef::Packed { col: inner_col, .. } => {
+					WitnessDataMut::SameAsOracleIndex(oracle_offset_lookup[inner_col.table_index])
 				}
-			})
-			.collect();
+				_ => {
+					let log_cell_bits = col.shape.tower_height + col.shape.log_values_per_row;
+					min_log_cell_bits = min_log_cell_bits.min(log_cell_bits);
+					let log_col_bits = log_cell_bits + log_capacity;
+
+					// TODO: Error instead of panic
+					if log_col_bits < U::LOG_BITS {
+						panic!("capacity is too low");
+					}
+
+					// TODO: Allocate uninitialized memory and avoid filling. That should be OK because
+					// Underlier is Pod.
+					WitnessDataMut::Owned(
+						allocator.alloc_slice_fill_default(1 << (log_col_bits - U::LOG_BITS)),
+					)
+				}
+			};
+			cols.push(WitnessIndexColumn {
+				shape,
+				data,
+				is_single_row: matches!(col.col, ColumnDef::RepeatingTransparent { .. }),
+			});
+
+			if matches!(col.col, ColumnDef::RepeatingTransparent { .. }) {
+				cols.push(WitnessIndexColumn {
+					shape,
+					data: WitnessDataMut::SameAsOracleIndex(next_oracle_index),
+					is_single_row: false,
+				});
+				next_oracle_index += 1;
+				oracle_offset_lookup.push(next_oracle_index);
+				next_oracle_index += 1;
+			} else {
+				oracle_offset_lookup.push(next_oracle_index);
+				next_oracle_index += 1;
+			}
+		}
 
 		Self {
 			table,
@@ -268,6 +277,7 @@ impl<'cs, 'alloc, U: UnderlierType, F: TowerField> TableWitnessIndex<'cs, 'alloc
 			cols,
 			log_capacity,
 			min_log_segment_size: U::LOG_BITS - min_log_cell_bits,
+			oracle_offset_lookup,
 		}
 	}
 
@@ -285,14 +295,15 @@ impl<'cs, 'alloc, U: UnderlierType, F: TowerField> TableWitnessIndex<'cs, 'alloc
 			.cols
 			.iter_mut()
 			.map(|col| match &mut col.data {
+				WitnessDataMut::SameAsOracleIndex(index) => RefCellData::SameAsOracleIndex(*index),
 				WitnessDataMut::Owned(data) => RefCellData::Owned(RefCell::new(data)),
-				WitnessDataMut::SameAsTableIndex(index) => RefCellData::SameAsTableIndex(*index),
 			})
 			.collect();
 		TableWitnessIndexSegment {
 			table: self.table,
 			cols,
 			log_size: self.log_capacity,
+			oracle_offset_lookup: &self.oracle_offset_lookup,
 		}
 	}
 
@@ -311,8 +322,8 @@ impl<'cs, 'alloc, U: UnderlierType, F: TowerField> TableWitnessIndex<'cs, 'alloc
 				.cols
 				.iter()
 				.map(|col| match &col.data {
-					WitnessDataMut::SameAsTableIndex(index) => {
-						RefCellData::SameAsTableIndex(*index)
+					WitnessDataMut::SameAsOracleIndex(index) => {
+						RefCellData::SameAsOracleIndex(*index)
 					}
 					WitnessDataMut::Owned(data) => {
 						let log_cell_bits = col.shape.tower_height + col.shape.log_values_per_row;
@@ -331,6 +342,7 @@ impl<'cs, 'alloc, U: UnderlierType, F: TowerField> TableWitnessIndex<'cs, 'alloc
 				table,
 				cols: col_strides,
 				log_size,
+				oracle_offset_lookup: &self_ref.oracle_offset_lookup,
 			}
 		})
 	}
@@ -353,8 +365,8 @@ impl<'cs, 'alloc, U: UnderlierType, F: TowerField> TableWitnessIndex<'cs, 'alloc
 					.cols
 					.iter()
 					.map(|col| match &col.data {
-						WitnessDataMut::SameAsTableIndex(index) => {
-							RefCellData::SameAsTableIndex(*index)
+						WitnessDataMut::SameAsOracleIndex(index) => {
+							RefCellData::SameAsOracleIndex(*index)
 						}
 						WitnessDataMut::Owned(data) => {
 							let log_cell_bits =
@@ -376,6 +388,7 @@ impl<'cs, 'alloc, U: UnderlierType, F: TowerField> TableWitnessIndex<'cs, 'alloc
 					table,
 					cols: col_strides,
 					log_size,
+					oracle_offset_lookup: &self_ref.oracle_offset_lookup,
 				}
 			})
 	}
@@ -391,6 +404,7 @@ pub struct TableWitnessIndexSegment<
 	U: UnderlierType = OptimalUnderlier,
 	F: TowerField = B128,
 > {
+	oracle_offset_lookup: &'alloc [ColumnIndex],
 	table: &'alloc Table<F>,
 	cols: Vec<RefCellData<'alloc, U>>,
 	#[get_copy = "pub"]
@@ -548,10 +562,17 @@ impl<'alloc, U: UnderlierType, F: TowerField> TableWitnessIndexSegment<'alloc, U
 		1 << self.log_size
 	}
 
-	fn get_col_data(&self, table_index: usize) -> Option<&RefCell<&'alloc mut [U]>> {
-		match self.cols.get(table_index) {
-			Some(RefCellData::Owned(data)) => Some(data),
-			Some(RefCellData::SameAsTableIndex(table_index)) => self.get_col_data(*table_index),
+	fn get_col_data(&self, table_index: ColumnIndex) -> Option<&RefCell<&'alloc mut [U]>> {
+		self.get_col_data_by_oracle_offset(self.oracle_offset_lookup[table_index])
+	}
+
+	fn get_col_data_by_oracle_offset(
+		&self,
+		oracle_id: OracleId,
+	) -> Option<&RefCell<&'alloc mut [U]>> {
+		match self.cols.get(oracle_id) {
+			Some(RefCellData::Owned(data)) => Some(&*data),
+			Some(RefCellData::SameAsOracleIndex(id)) => self.get_col_data_by_oracle_offset(*id),
 			None => None,
 		}
 	}

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -234,7 +234,7 @@ impl<'cs, 'alloc, U: UnderlierType, F: TowerField> TableWitnessIndex<'cs, 'alloc
 		let mut transparent_single_backing = vec![None; table.columns.len()];
 
 		for col in &table.columns {
-			if matches!(col.col, ColumnDef::Transparent { .. }) {
+			if matches!(col.col, ColumnDef::Constant { .. }) {
 				transparent_single_backing[col.id.table_index] = Some(oracle_offset);
 				cols.push(WitnessIndexColumn {
 					shape: col.shape,
@@ -254,7 +254,7 @@ impl<'cs, 'alloc, U: UnderlierType, F: TowerField> TableWitnessIndex<'cs, 'alloc
 				ColumnDef::Packed { col: inner_col, .. } => {
 					WitnessDataMut::SameAsOracleIndex(oracle_offset + inner_col.table_index)
 				}
-				ColumnDef::Transparent { .. } => WitnessDataMut::SameAsOracleIndex(
+				ColumnDef::Constant { .. } => WitnessDataMut::SameAsOracleIndex(
 					transparent_single_backing[col.id.table_index].unwrap(),
 				),
 				_ => WitnessDataMut::new_owned(

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -571,7 +571,7 @@ impl<'alloc, U: UnderlierType, F: TowerField> TableWitnessIndexSegment<'alloc, U
 		oracle_id: OracleId,
 	) -> Option<&RefCell<&'alloc mut [U]>> {
 		match self.cols.get(oracle_id) {
-			Some(RefCellData::Owned(data)) => Some(&*data),
+			Some(RefCellData::Owned(data)) => Some(data),
 			Some(RefCellData::SameAsOracleIndex(id)) => self.get_col_data_by_oracle_offset(*id),
 			None => None,
 		}

--- a/crates/m3/tests/collatz.rs
+++ b/crates/m3/tests/collatz.rs
@@ -108,7 +108,7 @@ mod arithmetization {
 	use binius_field::{
 		arch::OptimalUnderlier128b,
 		as_packed_field::{PackScalar, PackedType},
-		underlier::UnderlierType,
+		underlier::{SmallU, UnderlierType},
 		Field, PackedField,
 	};
 	use binius_hash::compress::Groestl256ByteCompression;
@@ -222,10 +222,7 @@ mod arithmetization {
 			let double =
 				table.add_shifted::<B1, 32>("double_bits", odd, 5, 1, ShiftVariant::LogicalLeft);
 
-			// TODO: Figure out how to add repeating constants (repeating transparents). Basically a
-			// multilinear extension of some constant vector, repeating for the number of rows.
-			// This shouldn't actually be committed. It should be the carry bit, repeated for each row.
-			let carry_bit = table.add_committed::<B1, 32>("carry_bit");
+			let carry_bit = table.add_repeating_constants("carry_bit", decomposed_u32_bits(1));
 
 			// Input times 3 + 1
 			let triple_plus_one = U32Add::new(
@@ -256,6 +253,10 @@ mod arithmetization {
 				_triple_plus_one_packed: triple_plus_one_packed,
 			}
 		}
+	}
+
+	fn decomposed_u32_bits(bits: u32) -> [B1; 32] {
+		std::array::from_fn(|i| B1::new(SmallU::new(((bits >> i) & 1) as u8)))
 	}
 
 	impl<U: UnderlierType> TableFiller<U> for OddsTable

--- a/crates/m3/tests/collatz.rs
+++ b/crates/m3/tests/collatz.rs
@@ -222,7 +222,7 @@ mod arithmetization {
 			let double =
 				table.add_shifted::<B1, 32>("double_bits", odd, 5, 1, ShiftVariant::LogicalLeft);
 
-			let carry_bit = table.add_repeating_constants("carry_bit", decomposed_u32_bits(1));
+			let carry_bit = table.add_constant("carry_bit", decomposed_u32_bits(1));
 
 			// Input times 3 + 1
 			let triple_plus_one = U32Add::new(


### PR DESCRIPTION
Adding a repeating constant actually creates 2 oracles:
- transparent
- a repeating version of the transparent poly

We get around needing to fill the transparent witness, or even returning an id for it by having it alias the same underlying data as the repeating transparent (but with a different length value).
