### PR TITLE
Expose computed columns from the M3 Table interface

### DIFF
--- a/crates/m3/src/builder/column.rs
+++ b/crates/m3/src/builder/column.rs
@@ -4,6 +4,7 @@ use std::marker::PhantomData;
 
 use binius_core::oracle::ShiftVariant;
 use binius_field::{ExtensionField, TowerField};
+use binius_math::ArithExpr;
 
 use super::{table::TableId, types::B128};
 
@@ -132,5 +133,9 @@ pub enum ColumnDef<F: TowerField = B128> {
 	Packed {
 		col: ColumnId,
 		log_degree: usize,
+	},
+	Computed {
+		cols: Vec<ColumnIndex>,
+		expr: ArithExpr<F>,
 	},
 }

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -326,6 +326,13 @@ fn add_oracle_for_column<F: TowerField>(
 			// TODO: debug assert column at col.table_index has the same values_per_row as col.id
 			addition.packed(oracle_lookup[col.table_index], *log_degree)?
 		}
+		ColumnDef::Computed { cols, expr } => {
+			let inner_oracles = cols
+				.iter()
+				.map(|&col_index| oracle_lookup[col_index])
+				.collect::<Vec<_>>();
+			addition.composite_mle(n_vars, inner_oracles, expr.clone())?
+		}
 	};
 	Ok(oracle_id)
 }

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -173,7 +173,14 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
 	{
-		let partition_indexes = expr.expr().used_vars();
+		let partition_indexes = expr
+			.expr()
+			.vars_usage()
+			.iter()
+			.enumerate()
+			.filter(|(_, &used)| used)
+			.map(|(i, _)| i)
+			.collect::<Vec<_>>();
 		let cols = partition_indexes
 			.iter()
 			.map(|&partition_index| {

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -164,11 +164,11 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		)
 	}
 
-	pub fn add_computed<FSub, const VALUES_PER_ROW: usize>(
+	pub fn add_computed<FSub, const V: usize>(
 		&mut self,
 		name: impl ToString,
-		expr: Expr<FSub, VALUES_PER_ROW>,
-	) -> Col<FSub, VALUES_PER_ROW>
+		expr: Expr<FSub, V>,
+	) -> Col<FSub, V>
 	where
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
@@ -177,7 +177,7 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		let cols = partition_indexes
 			.iter()
 			.map(|&partition_index| {
-				let partition = &self.table.partitions[expr.partition_id()];
+				let partition = &self.table.partitions[partition_id::<V>()];
 				partition.columns[partition_index]
 			})
 			.collect::<Vec<_>>();

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -173,7 +173,7 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
 	{
-		let partition_indexes = expr.expr().vars_sorted();
+		let partition_indexes = expr.expr().used_vars();
 		let cols = partition_indexes
 			.iter()
 			.map(|&partition_index| {

--- a/crates/m3/tests/computed.rs
+++ b/crates/m3/tests/computed.rs
@@ -105,7 +105,7 @@ fn test_m3_computed_col() {
 		.unwrap();
 
 	let constraint_system = cs.compile(&statement).unwrap();
-	let witness = witness.into_multilinear_extension_index::<B128>(&statement);
+	let witness = witness.into_multilinear_extension_index(&statement);
 
 	binius_core::constraint_system::validate::validate_witness(
 		&constraint_system,

--- a/crates/m3/tests/computed.rs
+++ b/crates/m3/tests/computed.rs
@@ -1,0 +1,132 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_core::{fiat_shamir::HasherChallenger, tower::CanonicalTowerFamily};
+use binius_field::{arch::OptimalUnderlier128b, as_packed_field::PackScalar, Field};
+use binius_hash::compress::Groestl256ByteCompression;
+use binius_m3::builder::{
+	Col, ConstraintSystem, Statement, TableFiller, TableId, TableWitnessIndexSegment, B1, B128, B64,
+};
+use binius_math::DefaultEvaluationDomainFactory;
+use bumpalo::Bump;
+use bytemuck::Pod;
+use groestl_crypto::Groestl256;
+
+pub struct MyTable {
+	id: TableId,
+	committed_1: Col<B128, 32>,
+	committed_2: Col<B128, 32>,
+	_zeros_1: [Col<B64, 16>; 10],
+	_zeros_2: [Col<B64, 32>; 10],
+	computed: Col<B128, 32>,
+}
+
+impl<U> TableFiller<U> for MyTable
+where
+	U: Pod + PackScalar<B1>,
+{
+	type Event = (u128, u128);
+
+	fn id(&self) -> TableId {
+		self.id
+	}
+
+	fn fill<'a>(
+		&'a self,
+		mut rows: impl Iterator<Item = &'a Self::Event>,
+		witness: &'a mut TableWitnessIndexSegment<U>,
+	) -> Result<(), anyhow::Error> {
+		let mut committed_1 = witness.get_mut_as(self.committed_1)?;
+		let mut committed_2 = witness.get_mut_as(self.committed_2)?;
+		let mut computed = witness.get_mut_as(self.computed)?;
+
+		let &(com1, com2) = rows.next().unwrap();
+		assert!(rows.next().is_none());
+
+		for i in 0..32 {
+			committed_1[i] = com1;
+			committed_2[i] = com2;
+			computed[i] = (B128::from(com1) + B128::from(com2)) * B128::from(com1) * B128::from(10)
+				+ B128::ONE;
+		}
+		Ok(())
+	}
+}
+
+#[test]
+fn test_m3_computed_col() {
+	let allocator = Bump::new();
+	let mut cs = ConstraintSystem::<B128>::new();
+	let mut table = cs.add_table("table_1");
+	let committed_1 = table.add_committed::<B128, 32>("committed_2");
+	let zeros_1 = table.add_committed_multiple::<B64, 16, 10>("zeros");
+	let committed_2 = table.add_committed::<B128, 32>("committed_2");
+	let zeros_2 = table.add_committed_multiple::<B64, 32, 10>("zeros");
+	let expr = (committed_1 + committed_2) * committed_1 * B128::from(10) + B128::ONE;
+	let computed = table.add_computed("computed", expr);
+	for col in &zeros_1 {
+		table.assert_zero("z", (*col).into());
+	}
+	for col in &zeros_2 {
+		table.assert_zero("z", (*col).into());
+	}
+	let table = MyTable {
+		id: table.id(),
+		committed_1,
+		committed_2,
+		_zeros_1: zeros_1,
+		_zeros_2: zeros_2,
+		computed,
+	};
+
+	let statement = Statement {
+		boundaries: vec![],
+		table_sizes: vec![8],
+	};
+	let mut witness = cs
+		.build_witness::<OptimalUnderlier128b>(&allocator, &statement)
+		.unwrap();
+	witness
+		.fill_table_sequential(&table, &(0..8).map(|i| (i, i + 10_u128)).collect::<Vec<_>>())
+		.unwrap();
+
+	let constraint_system = cs.compile(&statement).unwrap();
+	let witness = witness.into_multilinear_extension_index::<B128>(&statement);
+
+	binius_core::constraint_system::validate::validate_witness(
+		&constraint_system,
+		&statement.boundaries,
+		&witness,
+	)
+	.unwrap();
+
+	const LOG_INV_RATE: usize = 1;
+	const SECURITY_BITS: usize = 30;
+
+	let proof = binius_core::constraint_system::prove::<
+		_,
+		CanonicalTowerFamily,
+		_,
+		Groestl256,
+		Groestl256ByteCompression,
+		HasherChallenger<Groestl256>,
+		_,
+	>(
+		&constraint_system,
+		LOG_INV_RATE,
+		SECURITY_BITS,
+		&statement.boundaries,
+		witness,
+		&DefaultEvaluationDomainFactory::default(),
+		&binius_hal::make_portable_backend(),
+	)
+	.unwrap();
+
+	binius_core::constraint_system::verify::<
+		OptimalUnderlier128b,
+		CanonicalTowerFamily,
+		Groestl256,
+		Groestl256ByteCompression,
+		HasherChallenger<Groestl256>,
+	>(&constraint_system, LOG_INV_RATE, SECURITY_BITS, &statement.boundaries, proof)
+	.unwrap();
+}

--- a/crates/m3/tests/computed.rs
+++ b/crates/m3/tests/computed.rs
@@ -11,13 +11,44 @@ use bumpalo::Bump;
 use bytemuck::Pod;
 use groestl_crypto::Groestl256;
 
+const VALUES_PER_ROW: usize = 32;
+const N_ROWS: usize = 8;
+const LOG_INV_RATE: usize = 1;
+const SECURITY_BITS: usize = 30;
+
 pub struct MyTable {
 	id: TableId,
-	committed_1: Col<B128, 32>,
-	committed_2: Col<B128, 32>,
+	committed_1: Col<B128, VALUES_PER_ROW>,
+	committed_2: Col<B128, VALUES_PER_ROW>,
 	_zeros_1: [Col<B64, 16>; 10],
-	_zeros_2: [Col<B64, 32>; 10],
-	computed: Col<B128, 32>,
+	_zeros_2: [Col<B64, 64>; 10],
+	computed: Col<B128, VALUES_PER_ROW>,
+}
+
+impl MyTable {
+	pub fn new(cs: &mut ConstraintSystem) -> Self {
+		let mut table = cs.add_table("table_1");
+		let committed_1 = table.add_committed::<B128, VALUES_PER_ROW>("committed_2");
+		let zeros_1 = table.add_committed_multiple::<B64, 16, 10>("col_zeros_1");
+		let committed_2 = table.add_committed::<B128, VALUES_PER_ROW>("committed_2");
+		let zeros_2 = table.add_committed_multiple::<B64, 64, 10>("col_zeros_2");
+		let expr = (committed_1 + committed_2) * committed_1 * B128::from(10) + B128::ONE;
+		let computed = table.add_computed("computed", expr);
+		for col in &zeros_1 {
+			table.assert_zero("zeros_1", (*col).into());
+		}
+		for col in &zeros_2 {
+			table.assert_zero("zeros_2", (*col).into());
+		}
+		Self {
+			id: table.id(),
+			committed_1,
+			committed_2,
+			computed,
+			_zeros_1: zeros_1,
+			_zeros_2: zeros_2,
+		}
+	}
 }
 
 impl<U> TableFiller<U> for MyTable
@@ -42,7 +73,7 @@ where
 		let &(com1, com2) = rows.next().unwrap();
 		assert!(rows.next().is_none());
 
-		for i in 0..32 {
+		for i in 0..VALUES_PER_ROW {
 			committed_1[i] = com1;
 			committed_2[i] = com2;
 			computed[i] = (B128::from(com1) + B128::from(com2)) * B128::from(com1) * B128::from(10)
@@ -56,37 +87,21 @@ where
 fn test_m3_computed_col() {
 	let allocator = Bump::new();
 	let mut cs = ConstraintSystem::<B128>::new();
-	let mut table = cs.add_table("table_1");
-	let committed_1 = table.add_committed::<B128, 32>("committed_2");
-	let zeros_1 = table.add_committed_multiple::<B64, 16, 10>("zeros");
-	let committed_2 = table.add_committed::<B128, 32>("committed_2");
-	let zeros_2 = table.add_committed_multiple::<B64, 32, 10>("zeros");
-	let expr = (committed_1 + committed_2) * committed_1 * B128::from(10) + B128::ONE;
-	let computed = table.add_computed("computed", expr);
-	for col in &zeros_1 {
-		table.assert_zero("z", (*col).into());
-	}
-	for col in &zeros_2 {
-		table.assert_zero("z", (*col).into());
-	}
-	let table = MyTable {
-		id: table.id(),
-		committed_1,
-		committed_2,
-		_zeros_1: zeros_1,
-		_zeros_2: zeros_2,
-		computed,
-	};
-
+	let table = MyTable::new(&mut cs);
 	let statement = Statement {
 		boundaries: vec![],
-		table_sizes: vec![8],
+		table_sizes: vec![N_ROWS],
 	};
 	let mut witness = cs
 		.build_witness::<OptimalUnderlier128b>(&allocator, &statement)
 		.unwrap();
 	witness
-		.fill_table_sequential(&table, &(0..8).map(|i| (i, i + 10_u128)).collect::<Vec<_>>())
+		.fill_table_sequential(
+			&table,
+			&(0..N_ROWS as u128)
+				.map(|i| (i, i + 10_u128))
+				.collect::<Vec<_>>(),
+		)
 		.unwrap();
 
 	let constraint_system = cs.compile(&statement).unwrap();
@@ -98,9 +113,6 @@ fn test_m3_computed_col() {
 		&witness,
 	)
 	.unwrap();
-
-	const LOG_INV_RATE: usize = 1;
-	const SECURITY_BITS: usize = 30;
 
 	let proof = binius_core::constraint_system::prove::<
 		_,

--- a/crates/math/src/arith_expr.rs
+++ b/crates/math/src/arith_expr.rs
@@ -2,7 +2,6 @@
 
 use std::{
 	cmp::Ordering,
-	collections::HashSet,
 	fmt::{self, Display},
 	iter::{Product, Sum},
 	ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
@@ -50,25 +49,19 @@ impl<F: Field> ArithExpr<F> {
 		}
 	}
 
-	/// The set of variable indices the expression contains.
-	pub fn vars(&self) -> HashSet<usize> {
-		match self {
-			Self::Const(_) => HashSet::new(),
-			Self::Var(index) => std::iter::once(*index).collect(),
-			Self::Add(left, right) | Self::Mul(left, right) => {
-				let mut set = left.vars();
-				set.extend(right.vars());
-				set
-			}
-			Self::Pow(base, _) => base.vars(),
-		}
-	}
-
 	/// The variable indices the expression contains, sorted and deduplicated.
-	pub fn vars_sorted(&self) -> Vec<usize> {
-		let mut vars = self.vars().into_iter().collect::<Vec<_>>();
-		vars.sort();
-		vars
+	pub fn used_vars(&self) -> Vec<usize> {
+		match self {
+			Self::Const(_) => Vec::new(),
+			Self::Var(index) => vec![*index],
+			Self::Add(left, right) | Self::Mul(left, right) => {
+				let mut res = [left.used_vars(), right.used_vars()].concat();
+				res.sort();
+				res.dedup();
+				res
+			}
+			Self::Pow(base, _) => base.used_vars(),
+		}
 	}
 
 	/// The total degree of the polynomial the expression represents.

--- a/crates/math/src/arith_expr.rs
+++ b/crates/math/src/arith_expr.rs
@@ -2,6 +2,7 @@
 
 use std::{
 	cmp::Ordering,
+	collections::HashSet,
 	fmt::{self, Display},
 	iter::{Product, Sum},
 	ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
@@ -47,6 +48,27 @@ impl<F: Field> ArithExpr<F> {
 			Self::Add(left, right) | Self::Mul(left, right) => left.n_vars().max(right.n_vars()),
 			Self::Pow(id, _) => id.n_vars(),
 		}
+	}
+
+	/// The set of variable indices the expression contains.
+	pub fn vars(&self) -> HashSet<usize> {
+		match self {
+			Self::Const(_) => HashSet::new(),
+			Self::Var(index) => std::iter::once(*index).collect(),
+			Self::Add(left, right) | Self::Mul(left, right) => {
+				let mut set = left.vars();
+				set.extend(right.vars());
+				set
+			}
+			Self::Pow(base, _) => base.vars(),
+		}
+	}
+
+	/// The variable indices the expression contains, sorted and deduplicated.
+	pub fn vars_sorted(&self) -> Vec<usize> {
+		let mut vars = self.vars().into_iter().collect::<Vec<_>>();
+		vars.sort();
+		vars
 	}
 
 	/// The total degree of the polynomial the expression represents.

--- a/crates/math/src/arith_expr.rs
+++ b/crates/math/src/arith_expr.rs
@@ -49,21 +49,6 @@ impl<F: Field> ArithExpr<F> {
 		}
 	}
 
-	/// The variable indices the expression contains, sorted and deduplicated.
-	pub fn used_vars(&self) -> Vec<usize> {
-		match self {
-			Self::Const(_) => Vec::new(),
-			Self::Var(index) => vec![*index],
-			Self::Add(left, right) | Self::Mul(left, right) => {
-				let mut res = [left.used_vars(), right.used_vars()].concat();
-				res.sort();
-				res.dedup();
-				res
-			}
-			Self::Pow(base, _) => base.used_vars(),
-		}
-	}
-
 	/// The total degree of the polynomial the expression represents.
 	pub fn degree(&self) -> usize {
 		match self {


### PR DESCRIPTION
Attempt to fix #104

The test I wrote is quite ugly, I only did it to ensure I wasn’t missing something trivial. Unless contraindicated, I think it's better to remove it. (Otherwise I should improve it)

As for the PR itself, it seems pretty straightforward, I hope I don't miss anything. 2 remarks:
- I introduced 2 new functions for `ArithExpr`: `vars()` and `vars_sorted()`, and there may be confusion because `arithm_circuit.n_vars()` returns the max variable index + 1, which is different in general from `arithm_circuit.vars.len()` (`Var(0) * Var(5)` -> `n_vars()` = 6 but `vars().len()` = 2). Maybe we should rename ?
- While writing the test, I could not create an m3 `Expr` based on columns / field elements with different tower heights. Is there a raison not to allow this ?
