### PR TITLE
[m3] Add utility method to witness index for evaluating expressions

### DIFF
--- a/crates/m3/Cargo.toml
+++ b/crates/m3/Cargo.toml
@@ -15,7 +15,6 @@ bumpalo.workspace = true
 bytemuck.workspace = true
 getset.workspace = true
 thiserror.workspace = true
-log = "0.4.26"
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/crates/m3/Cargo.toml
+++ b/crates/m3/Cargo.toml
@@ -15,6 +15,7 @@ bumpalo.workspace = true
 bytemuck.workspace = true
 getset.workspace = true
 thiserror.workspace = true
+log = "0.4.26"
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/crates/m3/src/builder/column.rs
+++ b/crates/m3/src/builder/column.rs
@@ -10,6 +10,9 @@ use super::{table::TableId, types::B128};
 /// An index of a column within a table.
 pub type ColumnIndex = usize;
 
+/// An index of a column within a table.
+pub type ColumnPartitionIndex = usize;
+
 /// A typed identifier for a column in a table.
 ///
 /// The column has entries that are elements of `F`. In practice, the fields used will always be
@@ -18,15 +21,21 @@ pub type ColumnIndex = usize;
 /// `Col<B1, 32>` will have 2^5 = 32 elements of `B1` packed into a single row.
 #[derive(Debug, Clone, Copy)]
 pub struct Col<F: TowerField, const VALUES_PER_ROW: usize = 1> {
-	pub id: ColumnId,
+	pub table_id: TableId,
+	pub table_index: TableId,
+	// Denormalized partition index so that we can use it to construct arithmetic expressions over
+	// the partition columns.
+	pub partition_index: ColumnPartitionIndex,
 	_marker: PhantomData<F>,
 }
 
 impl<F: TowerField, const VALUES_PER_ROW: usize> Col<F, VALUES_PER_ROW> {
-	pub fn new(id: ColumnId) -> Self {
+	pub fn new(id: ColumnId, partition_index: ColumnPartitionIndex) -> Self {
 		assert!(VALUES_PER_ROW.is_power_of_two());
 		Self {
-			id,
+			table_id: id.table_id,
+			table_index: id.table_index,
+			partition_index,
 			_marker: PhantomData,
 		}
 	}
@@ -34,12 +43,15 @@ impl<F: TowerField, const VALUES_PER_ROW: usize> Col<F, VALUES_PER_ROW> {
 	pub fn shape(&self) -> ColumnShape {
 		ColumnShape {
 			tower_height: F::TOWER_LEVEL,
-			values_per_row: VALUES_PER_ROW,
+			log_values_per_row: VALUES_PER_ROW.ilog2() as usize,
 		}
 	}
 
 	pub fn id(&self) -> ColumnId {
-		self.id
+		ColumnId {
+			table_id: self.table_id,
+			table_index: self.table_index,
+		}
 	}
 }
 
@@ -51,9 +63,17 @@ where
 	FSub: TowerField,
 	F: TowerField + ExtensionField<FSub>,
 {
+	let Col {
+		table_id,
+		table_index,
+		partition_index,
+		_marker: _,
+	} = col;
 	// REVIEW: Maybe this should retain the info of the smallest tower level
 	Col {
-		id: col.id,
+		table_id,
+		table_index,
+		partition_index,
 		_marker: PhantomData,
 	}
 }
@@ -74,8 +94,8 @@ pub struct ColumnInfo<F: TowerField = B128> {
 pub struct ColumnShape {
 	/// The tower height of the field elements.
 	pub tower_height: usize,
-	/// The number of elements packed vertically per event row.
-	pub values_per_row: usize,
+	/// The binary logarithm of the number of elements packed vertically per event row.
+	pub log_values_per_row: usize,
 }
 
 /// Unique identifier for a column within a constraint system.
@@ -86,10 +106,6 @@ pub struct ColumnShape {
 pub struct ColumnId {
 	pub table_id: TableId,
 	pub table_index: ColumnIndex,
-	// REVIEW: Does this strictly correspond to the packing factor?
-	// Should it be here or on columnInfo?
-	pub partition_id: usize,
-	pub partition_index: ColumnIndex,
 }
 
 /// A definition of a column in a table.

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -83,7 +83,7 @@ impl<F: TowerField> std::fmt::Display for ConstraintSystem<F> {
 
 			for col in table.columns.iter() {
 				let name = col.name.clone();
-				let values_per_row = col.shape.values_per_row;
+				let log_values_per_row = col.shape.log_values_per_row;
 				let field = match col.shape.tower_height {
 					0 => "B1",
 					1 => "B2",
@@ -94,7 +94,8 @@ impl<F: TowerField> std::fmt::Display for ConstraintSystem<F> {
 					6 => "B64",
 					_ => "B128",
 				};
-				let type_str = if values_per_row > 1 {
+				let type_str = if log_values_per_row > 0 {
+					let values_per_row = 1 << log_values_per_row;
 					format!("{field}x{values_per_row}")
 				} else {
 					field.to_string()
@@ -145,11 +146,11 @@ impl<F: TowerField> ConstraintSystem<F> {
 	/// The statement includes information about the tables sizes, which this requires in order to
 	/// allocate the column data correctly. The created witness index needs to be populated before
 	/// proving.
-	pub fn build_witness<'a, U: UnderlierType>(
-		&'a self,
-		allocator: &'a Bump,
+	pub fn build_witness<'cs, 'alloc, U: UnderlierType>(
+		&'cs self,
+		allocator: &'alloc Bump,
 		statement: &Statement,
-	) -> Result<WitnessIndex<'a, U, F>, Error> {
+	) -> Result<WitnessIndex<'cs, 'alloc, U, F>, Error> {
 		Ok(WitnessIndex {
 			tables: self
 				.tables
@@ -186,7 +187,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 
 			// Add multilinear oracles for all table columns.
 			for info in table.columns.iter() {
-				let n_vars = log2_ceil_usize(count) + log2_strict_usize(info.shape.values_per_row);
+				let n_vars = log2_ceil_usize(count) + info.shape.log_values_per_row;
 				let oracle_id = add_oracle_for_column(&mut oracles, &oracle_lookup, info, n_vars)?;
 				oracle_lookup.push(oracle_id);
 				if info.is_nonzero {
@@ -223,7 +224,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 				{
 					let flush_oracles = column_indices
 						.iter()
-						.map(|&column_index| partition_oracle_ids[column_index])
+						.map(|&column_index| oracle_lookup[column_index])
 						.collect::<Vec<_>>();
 					compiled_flushes.push(CompiledFlush {
 						oracles: flush_oracles,
@@ -278,7 +279,7 @@ fn add_oracle_for_column<F: TowerField>(
 	column_info: &ColumnInfo<F>,
 	n_vars: usize,
 ) -> Result<OracleId, Error> {
-	let ColumnInfo { id, col, name, .. } = column_info;
+	let ColumnInfo { col, name, .. } = column_info;
 	let addition = oracles.add_named(name.clone());
 	let oracle_id = match col {
 		ColumnDef::Committed { tower_level } => addition.committed(n_vars, *tower_level),
@@ -318,10 +319,11 @@ fn add_oracle_for_column<F: TowerField>(
 			log_block_size,
 			variant,
 		} => {
-			assert_eq!(col.partition_id, id.partition_id);
+			// TODO: debug assert column at col.table_index has the same values_per_row as col.id
 			addition.shifted(oracle_lookup[col.table_index], *offset, *log_block_size, *variant)?
 		}
 		ColumnDef::Packed { col, log_degree } => {
+			// TODO: debug assert column at col.table_index has the same values_per_row as col.id
 			addition.packed(oracle_lookup[col.table_index], *log_degree)?
 		}
 	};

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -146,11 +146,11 @@ impl<F: TowerField> ConstraintSystem<F> {
 	/// allocate the column data correctly. The created witness index needs to be populated before
 	/// proving.
 	pub fn build_witness<'a, U: UnderlierType>(
-		&self,
+		&'a self,
 		allocator: &'a Bump,
 		statement: &Statement,
-	) -> Result<WitnessIndex<'a, U>, Error> {
-		Ok(WitnessIndex::<U> {
+	) -> Result<WitnessIndex<'a, U, F>, Error> {
+		Ok(WitnessIndex {
 			tables: self
 				.tables
 				.iter()

--- a/crates/m3/src/builder/error.rs
+++ b/crates/m3/src/builder/error.rs
@@ -15,6 +15,11 @@ pub enum Error {
 	MissingTable { table_id: TableId },
 	#[error("missing column with ID: {0:?}")]
 	MissingColumn(ColumnId),
+	#[error("missing partition {partition_id} in table {table_id}")]
+	MissingPartition {
+		table_id: TableId,
+		partition_id: usize,
+	},
 	#[error("column is not in table; column table ID: {column_table_id}, witness table ID: {witness_table_id}")]
 	TableMismatch {
 		column_table_id: TableId,

--- a/crates/m3/src/builder/error.rs
+++ b/crates/m3/src/builder/error.rs
@@ -15,10 +15,10 @@ pub enum Error {
 	MissingTable { table_id: TableId },
 	#[error("missing column with ID: {0:?}")]
 	MissingColumn(ColumnId),
-	#[error("missing partition {partition_id} in table {table_id}")]
+	#[error("missing partition with log_vals_per_row={log_vals_per_row} in table {table_id}")]
 	MissingPartition {
 		table_id: TableId,
-		partition_id: usize,
+		log_vals_per_row: usize,
 	},
 	#[error("column is not in table; column table ID: {column_table_id}, witness table ID: {witness_table_id}")]
 	TableMismatch {

--- a/crates/m3/src/builder/expr.rs
+++ b/crates/m3/src/builder/expr.rs
@@ -20,6 +20,7 @@ pub struct ZeroConstraint<F: Field> {
 pub struct Expr<F: TowerField, const VALUES_PER_ROW: usize> {
 	#[get_copy = "pub"]
 	table_id: TableId,
+	// REVIEW: Shouldn't this always be V?
 	#[get_copy = "pub"]
 	partition_id: usize,
 	#[get = "pub"]

--- a/crates/m3/src/builder/expr.rs
+++ b/crates/m3/src/builder/expr.rs
@@ -20,225 +20,182 @@ pub struct ZeroConstraint<F: Field> {
 pub struct Expr<F: TowerField, const VALUES_PER_ROW: usize> {
 	#[get_copy = "pub"]
 	table_id: TableId,
-	// REVIEW: Shouldn't this always be V?
-	#[get_copy = "pub"]
-	partition_id: usize,
 	#[get = "pub"]
 	expr: ArithExpr<F>,
 }
 
-impl<F: TowerField, const VALUES_PER_ROW: usize> Expr<F, VALUES_PER_ROW> {
+impl<F: TowerField, const V: usize> Expr<F, V> {
 	/// Polynomial degree of the arithmetic expression.
 	pub fn degree(&self) -> usize {
 		self.expr.degree()
 	}
 }
 
-impl<F: TowerField, const VALUES_PER_ROW: usize> From<Col<F, VALUES_PER_ROW>>
-	for Expr<F, VALUES_PER_ROW>
-{
-	fn from(value: Col<F, VALUES_PER_ROW>) -> Self {
+impl<F: TowerField, const V: usize> From<Col<F, V>> for Expr<F, V> {
+	fn from(value: Col<F, V>) -> Self {
 		Expr {
-			table_id: value.id.table_id,
-			partition_id: value.id.partition_id,
-			expr: ArithExpr::Var(value.id.partition_index),
+			table_id: value.table_id,
+			expr: ArithExpr::Var(value.partition_index),
 		}
 	}
 }
 
-impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Add<Self> for Col<F, VALUES_PER_ROW> {
-	type Output = Expr<F, VALUES_PER_ROW>;
+impl<F: TowerField, const V: usize> std::ops::Add<Self> for Col<F, V> {
+	type Output = Expr<F, V>;
 
 	fn add(self, rhs: Self) -> Self::Output {
-		assert_eq!(self.id.table_id, rhs.id.table_id);
-		assert_eq!(self.id.partition_id, rhs.id.partition_id);
+		assert_eq!(self.table_id, rhs.table_id);
 
-		let lhs_expr = ArithExpr::Var(self.id.partition_index);
-		let rhs_expr = ArithExpr::Var(rhs.id.partition_index);
+		let lhs_expr = ArithExpr::Var(self.partition_index);
+		let rhs_expr = ArithExpr::Var(rhs.partition_index);
 
 		Expr {
-			table_id: self.id.table_id,
-			partition_id: self.id.partition_id,
+			table_id: self.table_id,
 			expr: lhs_expr + rhs_expr,
 		}
 	}
 }
 
-impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Add<Col<F, VALUES_PER_ROW>>
-	for Expr<F, VALUES_PER_ROW>
-{
-	type Output = Expr<F, VALUES_PER_ROW>;
+impl<F: TowerField, const V: usize> std::ops::Add<Col<F, V>> for Expr<F, V> {
+	type Output = Expr<F, V>;
 
-	fn add(self, rhs: Col<F, VALUES_PER_ROW>) -> Self::Output {
-		assert_eq!(self.table_id, rhs.id.table_id);
-		assert_eq!(self.partition_id, rhs.id.partition_id);
+	fn add(self, rhs: Col<F, V>) -> Self::Output {
+		assert_eq!(self.table_id, rhs.table_id);
 
-		let rhs_expr = ArithExpr::Var(rhs.id.partition_index);
-
+		let rhs_expr = ArithExpr::Var(rhs.partition_index);
 		Expr {
 			table_id: self.table_id,
-			partition_id: self.partition_id,
 			expr: self.expr + rhs_expr,
 		}
 	}
 }
 
-impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Add<Expr<F, VALUES_PER_ROW>>
-	for Expr<F, VALUES_PER_ROW>
-{
-	type Output = Expr<F, VALUES_PER_ROW>;
+impl<F: TowerField, const V: usize> std::ops::Add<Expr<F, V>> for Expr<F, V> {
+	type Output = Expr<F, V>;
 
-	fn add(self, rhs: Expr<F, VALUES_PER_ROW>) -> Self::Output {
+	fn add(self, rhs: Expr<F, V>) -> Self::Output {
 		assert_eq!(self.table_id, rhs.table_id);
-		assert_eq!(self.partition_id, rhs.partition_id);
 		Expr {
 			table_id: self.table_id,
-			partition_id: self.partition_id,
 			expr: self.expr + rhs.expr,
 		}
 	}
 }
 
-impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Add<F> for Expr<F, VALUES_PER_ROW> {
-	type Output = Expr<F, VALUES_PER_ROW>;
+impl<F: TowerField, const V: usize> std::ops::Add<F> for Expr<F, V> {
+	type Output = Expr<F, V>;
 
 	fn add(self, rhs: F) -> Self::Output {
 		Expr {
 			table_id: self.table_id,
-			partition_id: self.partition_id,
 			expr: self.expr + ArithExpr::Const(rhs),
 		}
 	}
 }
 
-impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Add<F> for Col<F, VALUES_PER_ROW> {
-	type Output = Expr<F, VALUES_PER_ROW>;
+impl<F: TowerField, const V: usize> std::ops::Add<F> for Col<F, V> {
+	type Output = Expr<F, V>;
 
 	fn add(self, rhs: F) -> Self::Output {
 		Expr::from(self) + rhs
 	}
 }
 
-impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Sub<Self> for Col<F, VALUES_PER_ROW> {
-	type Output = Expr<F, VALUES_PER_ROW>;
+impl<F: TowerField, const V: usize> std::ops::Sub<Self> for Col<F, V> {
+	type Output = Expr<F, V>;
 
 	fn sub(self, rhs: Self) -> Self::Output {
-		assert_eq!(self.id.table_id, rhs.id.table_id);
-		assert_eq!(self.id.partition_id, rhs.id.partition_id);
-		let lhs_expr = ArithExpr::Var(self.id.partition_index);
-		let rhs_expr = ArithExpr::Var(rhs.id.partition_index);
+		assert_eq!(self.table_id, rhs.table_id);
+		let lhs_expr = ArithExpr::Var(self.partition_index);
+		let rhs_expr = ArithExpr::Var(rhs.partition_index);
 
 		Expr {
-			table_id: self.id.table_id,
-			partition_id: self.id.partition_id,
+			table_id: self.table_id,
 			expr: lhs_expr - rhs_expr,
 		}
 	}
 }
 
-impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Sub<Col<F, VALUES_PER_ROW>>
-	for Expr<F, VALUES_PER_ROW>
-{
-	type Output = Expr<F, VALUES_PER_ROW>;
+impl<F: TowerField, const V: usize> std::ops::Sub<Col<F, V>> for Expr<F, V> {
+	type Output = Expr<F, V>;
 
-	fn sub(self, rhs: Col<F, VALUES_PER_ROW>) -> Self::Output {
+	fn sub(self, rhs: Col<F, V>) -> Self::Output {
 		self - Expr::from(rhs)
 	}
 }
 
-impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Sub<Expr<F, VALUES_PER_ROW>>
-	for Expr<F, VALUES_PER_ROW>
-{
-	type Output = Expr<F, VALUES_PER_ROW>;
+impl<F: TowerField, const V: usize> std::ops::Sub<Expr<F, V>> for Expr<F, V> {
+	type Output = Expr<F, V>;
 
-	fn sub(self, rhs: Expr<F, VALUES_PER_ROW>) -> Self::Output {
+	fn sub(self, rhs: Expr<F, V>) -> Self::Output {
 		assert_eq!(self.table_id, rhs.table_id);
-		assert_eq!(self.partition_id, rhs.partition_id);
 		Expr {
 			table_id: self.table_id,
-			partition_id: self.partition_id,
 			expr: self.expr - rhs.expr,
 		}
 	}
 }
 
-impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Sub<F> for Expr<F, VALUES_PER_ROW> {
-	type Output = Expr<F, VALUES_PER_ROW>;
+impl<F: TowerField, const V: usize> std::ops::Sub<F> for Expr<F, V> {
+	type Output = Expr<F, V>;
 
 	fn sub(self, rhs: F) -> Self::Output {
 		Expr {
 			table_id: self.table_id,
-			partition_id: self.partition_id,
 			expr: self.expr - ArithExpr::Const(rhs),
 		}
 	}
 }
 
-impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Sub<F> for Col<F, VALUES_PER_ROW> {
-	type Output = Expr<F, VALUES_PER_ROW>;
+impl<F: TowerField, const V: usize> std::ops::Sub<F> for Col<F, V> {
+	type Output = Expr<F, V>;
 
 	fn sub(self, rhs: F) -> Self::Output {
 		Expr::from(self) - rhs
 	}
 }
 
-impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Mul<Self> for Col<F, VALUES_PER_ROW> {
-	type Output = Expr<F, VALUES_PER_ROW>;
+impl<F: TowerField, const V: usize> std::ops::Mul<Self> for Col<F, V> {
+	type Output = Expr<F, V>;
 
 	fn mul(self, rhs: Self) -> Self::Output {
-		assert_eq!(self.id.table_id, rhs.id.table_id);
-		assert_eq!(self.id.partition_id, rhs.id.partition_id);
-		let lhs_expr = ArithExpr::Var(self.id.partition_index);
-		let rhs_expr = ArithExpr::Var(rhs.id.partition_index);
-
-		Expr {
-			table_id: self.id.table_id,
-			partition_id: self.id.partition_id,
-			expr: lhs_expr * rhs_expr,
-		}
+		Expr::from(self) * Expr::from(rhs)
 	}
 }
 
-impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Mul<Col<F, VALUES_PER_ROW>>
-	for Expr<F, VALUES_PER_ROW>
-{
-	type Output = Expr<F, VALUES_PER_ROW>;
+impl<F: TowerField, const V: usize> std::ops::Mul<Col<F, V>> for Expr<F, V> {
+	type Output = Expr<F, V>;
 
-	fn mul(self, rhs: Col<F, VALUES_PER_ROW>) -> Self::Output {
+	fn mul(self, rhs: Col<F, V>) -> Self::Output {
 		self * Expr::from(rhs)
 	}
 }
 
-impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Mul<Expr<F, VALUES_PER_ROW>>
-	for Expr<F, VALUES_PER_ROW>
-{
-	type Output = Expr<F, VALUES_PER_ROW>;
+impl<F: TowerField, const V: usize> std::ops::Mul<Expr<F, V>> for Expr<F, V> {
+	type Output = Expr<F, V>;
 
-	fn mul(self, rhs: Expr<F, VALUES_PER_ROW>) -> Self::Output {
+	fn mul(self, rhs: Expr<F, V>) -> Self::Output {
 		assert_eq!(self.table_id, rhs.table_id);
-		assert_eq!(self.partition_id, rhs.partition_id);
 		Expr {
 			table_id: self.table_id,
-			partition_id: self.partition_id,
 			expr: self.expr * rhs.expr,
 		}
 	}
 }
 
-impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Mul<F> for Expr<F, VALUES_PER_ROW> {
-	type Output = Expr<F, VALUES_PER_ROW>;
+impl<F: TowerField, const V: usize> std::ops::Mul<F> for Expr<F, V> {
+	type Output = Expr<F, V>;
 
 	fn mul(self, rhs: F) -> Self::Output {
 		Expr {
 			table_id: self.table_id,
-			partition_id: self.partition_id,
 			expr: self.expr * ArithExpr::Const(rhs),
 		}
 	}
 }
 
-impl<F: TowerField, const VALUES_PER_ROW: usize> std::ops::Mul<F> for Col<F, VALUES_PER_ROW> {
-	type Output = Expr<F, VALUES_PER_ROW>;
+impl<F: TowerField, const V: usize> std::ops::Mul<F> for Col<F, V> {
+	type Output = Expr<F, V>;
 
 	fn mul(self, rhs: F) -> Self::Output {
 		Expr::from(self) * rhs

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -660,9 +660,9 @@ mod tests {
 			assert_eq!(col0.len(), expected_slice_len);
 
 			for i in 0..expected_slice_len * <PackedType<OptimalUnderlier128b, B8>>::WIDTH {
-				set_packed_slice(&mut *col0, i, B8::new(i as u8) + B8::new(0x00));
-				set_packed_slice(&mut *col1, i, B8::new(i as u8) + B8::new(0x40));
-				set_packed_slice(&mut *col2, i, B8::new(i as u8) + B8::new(0x80));
+				set_packed_slice(&mut col0, i, B8::new(i as u8) + B8::new(0x00));
+				set_packed_slice(&mut col1, i, B8::new(i as u8) + B8::new(0x40));
+				set_packed_slice(&mut col2, i, B8::new(i as u8) + B8::new(0x80));
 			}
 		}
 

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -469,6 +469,10 @@ impl<U: UnderlierType, F: TowerField> TableWitnessIndexSegment<'_, U, F> {
 			.map(|col| col.as_ref().map(|col_ref| &**col_ref).unwrap_or(&dummy_col))
 			.collect::<Vec<_>>();
 
+		// REVIEW: This could be inefficient with very large segments because batch evaluation
+		// allocates more memory, proportional to the size of the segment. Because of how segments
+		// get split up in practice, it's not a problem yet. If we see stack overflows, we should
+		// split up the evaluation into multiple batches.
 		let mut evals = zeroed_vec(1 << log_packed_elems);
 		ArithCircuitPoly::new(expr.expr().clone()).batch_evaluate(&cols, &mut evals)?;
 		Ok(evals.into_iter())

--- a/crates/m3/tests/collatz.rs
+++ b/crates/m3/tests/collatz.rs
@@ -347,7 +347,7 @@ mod arithmetization {
 
 		Instance {
 			constraint_system: cs.compile(&statement).unwrap(),
-			witness: witness.into_multilinear_extension_index::<B128>(&statement),
+			witness: witness.into_multilinear_extension_index(&statement),
 			statement,
 		}
 	}

--- a/crates/m3/tests/fibonacci.rs
+++ b/crates/m3/tests/fibonacci.rs
@@ -124,7 +124,7 @@ mod arithmetization {
 	{
 		type Event = model::FibEvent;
 
-		fn id(&self) -> binius_m3::builder::TableId {
+		fn id(&self) -> TableId {
 			self.id
 		}
 
@@ -186,7 +186,7 @@ mod arithmetization {
 			.unwrap();
 
 		let compiled_cs = cs.compile(&statement).unwrap();
-		let witness = witness.into_multilinear_extension_index::<B128>(&statement);
+		let witness = witness.into_multilinear_extension_index(&statement);
 
 		binius_core::constraint_system::validate::validate_witness(
 			&compiled_cs,

--- a/crates/macros/src/composition_poly.rs
+++ b/crates/macros/src/composition_poly.rs
@@ -79,9 +79,14 @@ impl ToTokens for CompositionPolyItem {
 						return Err(binius_math::Error::IncorrectQuerySize { expected: #n_vars });
 					}
 
-					for col in 1..batch_query.len() {
-						if batch_query[col].len() != batch_query[0].len() {
-							return Err(binius_math::Error::BatchEvaluateSizeMismatch);
+					let row_len = evals.len();
+					for (i, row) in batch_query.iter().enumerate() {
+						if row.len() != row_len {
+							return Err(binius_math::Error::BatchEvaluateSizeMismatch {
+								index: i,
+								expected: row_len,
+								actual: row.len(),
+							});
 						}
 					}
 

--- a/crates/math/src/arith_expr.rs
+++ b/crates/math/src/arith_expr.rs
@@ -266,6 +266,28 @@ impl<F: Field> ArithExpr<F> {
 			Self::Pow(base, exp) => base.evaluate(vars).pow(*exp),
 		}
 	}
+
+	/// Returns a vector of booleans indicating which variables are used in the expression.
+	///
+	/// The vector is indexed by variable index, and the value at index `i` is `true` if and only
+	/// if the variable is used in the expression.
+	pub fn vars_usage(&self) -> Vec<bool> {
+		let mut usage = vec![false; self.n_vars()];
+		self.mark_vars_usage(&mut usage);
+		usage
+	}
+
+	fn mark_vars_usage(&self, usage: &mut [bool]) {
+		match self {
+			Self::Const(_) => (),
+			Self::Var(index) => usage[*index] = true,
+			Self::Add(left, right) | Self::Mul(left, right) => {
+				left.mark_vars_usage(usage);
+				right.mark_vars_usage(usage);
+			}
+			Self::Pow(base, _) => base.mark_vars_usage(usage),
+		}
+	}
 }
 
 impl<F: TowerField> ArithExpr<F> {

--- a/crates/math/src/composition_poly.rs
+++ b/crates/math/src/composition_poly.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 
 use auto_impl::auto_impl;
 use binius_field::PackedField;
+use binius_utils::bail;
 use stackalloc::stackalloc_with_default;
 
 use crate::{ArithExpr, Error};
@@ -47,8 +48,14 @@ where
 	/// This method has a default implementation.
 	fn batch_evaluate(&self, batch_query: &[&[P]], evals: &mut [P]) -> Result<(), Error> {
 		let row_len = evals.len();
-		if batch_query.iter().any(|row| row.len() != row_len) {
-			return Err(Error::BatchEvaluateSizeMismatch);
+		for (i, row) in batch_query.iter().enumerate() {
+			if row.len() != row_len {
+				bail!(Error::BatchEvaluateSizeMismatch {
+					index: i,
+					expected: row_len,
+					actual: row.len(),
+				});
+			}
 		}
 
 		stackalloc_with_default(batch_query.len(), |query| {

--- a/crates/math/src/error.rs
+++ b/crates/math/src/error.rs
@@ -24,8 +24,15 @@ pub enum Error {
 	ExtrapolateNumberOfEvaluations,
 	#[error("{0}")]
 	FieldError(#[from] binius_field::Error),
-	#[error("batch size mismatch - non-rectangular query shape or evals of wrong length")]
-	BatchEvaluateSizeMismatch,
+	#[error(
+		"batch evaluation expects all input slices to have the same length as the output slice;
+		at index {index}, expected length {expected}, got length {actual}"
+	)]
+	BatchEvaluateSizeMismatch {
+		index: usize,
+		expected: usize,
+		actual: usize,
+	},
 	#[error("the query must have size {expected}")]
 	IncorrectQuerySize { expected: usize },
 	#[error("Polynomial error: {0}")]


### PR DESCRIPTION
The main feature here is the `TableWitnessIndexSegment::eval_expr` method. This showed up as a useful method as I was implementing the Groestl circuit.

The implementation of this method could be optimized more, but it's probably OK for now. It uses `ArithCircuitPoly` batch evaluation. If the witness segments are really large, this could be problematic. I left a comment to explain that.

I also did some refactors to the M3 crate to

* reduce duplicated information in the `ColumnId` struct,
* rename `VALUES_PER_ROW` to `V` in most cases (it's common throughout the whole crate, we only need to explain it once and then use the shorthand)
* make the `WitnessIndex` hold a reference to the constraint system to make it easier for the witness index methods to query information from it