### PR TITLE
[m3] Create gadget for the Rijndael S-box

### DIFF
--- a/crates/m3/Cargo.toml
+++ b/crates/m3/Cargo.toml
@@ -21,3 +21,4 @@ assert_matches.workspace = true
 binius_hal = { path = "../hal" }
 binius_hash = { path = "../hash" }
 groestl_crypto.workspace = true
+rand.workspace = true

--- a/crates/m3/src/builder/column.rs
+++ b/crates/m3/src/builder/column.rs
@@ -56,10 +56,8 @@ impl<F: TowerField, const VALUES_PER_ROW: usize> Col<F, VALUES_PER_ROW> {
 	}
 }
 
-/// Upcast a columns from a subfield to an extension field..
-pub fn upcast_col<F, FSub, const VALUES_PER_ROW: usize>(
-	col: Col<FSub, VALUES_PER_ROW>,
-) -> Col<F, VALUES_PER_ROW>
+/// Upcast a column from a subfield to an extension field..
+pub fn upcast_col<F, FSub, const V: usize>(col: Col<FSub, V>) -> Col<F, V>
 where
 	FSub: TowerField,
 	F: TowerField + ExtensionField<FSub>,

--- a/crates/m3/src/builder/expr.rs
+++ b/crates/m3/src/builder/expr.rs
@@ -34,7 +34,6 @@ impl<F: TowerField, const V: usize> Expr<F, V> {
 	pub fn pow(self, exp: u64) -> Self {
 		Self {
 			table_id: self.table_id,
-			partition_id: self.partition_id,
 			expr: self.expr.pow(exp),
 		}
 	}
@@ -235,20 +234,15 @@ impl<F: TowerField, const V: usize> std::ops::Mul<F> for Col<F, V> {
 	}
 }
 
-/// Upcast an expression from a subfield to an extension field..
+/// Upcast an expression from a subfield to an extension field.
 pub fn upcast_expr<F, FSub, const V: usize>(expr: Expr<FSub, V>) -> Expr<F, V>
 where
 	FSub: TowerField,
 	F: TowerField + ExtensionField<FSub>,
 {
-	let Expr {
-		table_id,
-		partition_id,
-		expr,
-	} = expr;
+	let Expr { table_id, expr } = expr;
 	Expr {
 		table_id,
-		partition_id,
 		expr: expr.convert_field(),
 	}
 }

--- a/crates/m3/src/builder/expr.rs
+++ b/crates/m3/src/builder/expr.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_field::{Field, TowerField};
+use binius_field::{ExtensionField, Field, TowerField};
 use binius_math::ArithExpr;
 use getset::{CopyGetters, Getters};
 
@@ -105,7 +105,7 @@ impl<F: TowerField, const V: usize> std::ops::Add<F> for Expr<F, V> {
 impl<F: TowerField, const V: usize> std::ops::Add<Expr<F, V>> for Col<F, V> {
 	type Output = Expr<F, V>;
 
-	fn add(self, rhs: F) -> Self::Output {
+	fn add(self, rhs: Expr<F, V>) -> Self::Output {
 		Expr::from(self) + rhs
 	}
 }
@@ -167,7 +167,7 @@ impl<F: TowerField, const V: usize> std::ops::Sub<F> for Expr<F, V> {
 impl<F: TowerField, const V: usize> std::ops::Sub<Expr<F, V>> for Col<F, V> {
 	type Output = Expr<F, V>;
 
-	fn sub(self, rhs: F) -> Self::Output {
+	fn sub(self, rhs: Expr<F, V>) -> Self::Output {
 		Expr::from(self) - rhs
 	}
 }
@@ -222,7 +222,7 @@ impl<F: TowerField, const V: usize> std::ops::Mul<F> for Expr<F, V> {
 impl<F: TowerField, const V: usize> std::ops::Mul<Expr<F, V>> for Col<F, V> {
 	type Output = Expr<F, V>;
 
-	fn mul(self, rhs: F) -> Self::Output {
+	fn mul(self, rhs: Expr<F, V>) -> Self::Output {
 		Expr::from(self) * rhs
 	}
 }
@@ -232,6 +232,24 @@ impl<F: TowerField, const V: usize> std::ops::Mul<F> for Col<F, V> {
 
 	fn mul(self, rhs: F) -> Self::Output {
 		Expr::from(self) * rhs
+	}
+}
+
+/// Upcast an expression from a subfield to an extension field..
+pub fn upcast_expr<F, FSub, const V: usize>(expr: Expr<FSub, V>) -> Expr<F, V>
+where
+	FSub: TowerField,
+	F: TowerField + ExtensionField<FSub>,
+{
+	let Expr {
+		table_id,
+		partition_id,
+		expr,
+	} = expr;
+	Expr {
+		table_id,
+		partition_id,
+		expr: expr.convert_field(),
 	}
 }
 

--- a/crates/m3/src/builder/expr.rs
+++ b/crates/m3/src/builder/expr.rs
@@ -29,6 +29,15 @@ impl<F: TowerField, const V: usize> Expr<F, V> {
 	pub fn degree(&self) -> usize {
 		self.expr.degree()
 	}
+
+	/// Exponentiate the expression by a constant power.
+	pub fn pow(self, exp: u64) -> Self {
+		Self {
+			table_id: self.table_id,
+			partition_id: self.partition_id,
+			expr: self.expr.pow(exp),
+		}
+	}
 }
 
 impl<F: TowerField, const V: usize> From<Col<F, V>> for Expr<F, V> {
@@ -93,6 +102,14 @@ impl<F: TowerField, const V: usize> std::ops::Add<F> for Expr<F, V> {
 	}
 }
 
+impl<F: TowerField, const V: usize> std::ops::Add<Expr<F, V>> for Col<F, V> {
+	type Output = Expr<F, V>;
+
+	fn add(self, rhs: F) -> Self::Output {
+		Expr::from(self) + rhs
+	}
+}
+
 impl<F: TowerField, const V: usize> std::ops::Add<F> for Col<F, V> {
 	type Output = Expr<F, V>;
 
@@ -147,6 +164,14 @@ impl<F: TowerField, const V: usize> std::ops::Sub<F> for Expr<F, V> {
 	}
 }
 
+impl<F: TowerField, const V: usize> std::ops::Sub<Expr<F, V>> for Col<F, V> {
+	type Output = Expr<F, V>;
+
+	fn sub(self, rhs: F) -> Self::Output {
+		Expr::from(self) - rhs
+	}
+}
+
 impl<F: TowerField, const V: usize> std::ops::Sub<F> for Col<F, V> {
 	type Output = Expr<F, V>;
 
@@ -191,6 +216,14 @@ impl<F: TowerField, const V: usize> std::ops::Mul<F> for Expr<F, V> {
 			table_id: self.table_id,
 			expr: self.expr * ArithExpr::Const(rhs),
 		}
+	}
+}
+
+impl<F: TowerField, const V: usize> std::ops::Mul<Expr<F, V>> for Col<F, V> {
+	type Output = Expr<F, V>;
+
+	fn mul(self, rhs: F) -> Self::Output {
+		Expr::from(self) * rhs
 	}
 }
 

--- a/crates/m3/src/builder/expr.rs
+++ b/crates/m3/src/builder/expr.rs
@@ -16,8 +16,8 @@ pub struct ZeroConstraint<F: Field> {
 /// A type representing an arithmetic expression composed over some table columns.
 ///
 /// If the expression degree is 1, then it is a linear expression.
-#[derive(Debug, Getters, CopyGetters)]
-pub struct Expr<F: TowerField, const VALUES_PER_ROW: usize> {
+#[derive(Debug, Clone, Getters, CopyGetters)]
+pub struct Expr<F: TowerField, const V: usize> {
 	#[get_copy = "pub"]
 	table_id: TableId,
 	#[get = "pub"]

--- a/crates/m3/src/gadgets/hash/groestl.rs
+++ b/crates/m3/src/gadgets/hash/groestl.rs
@@ -1,5 +1,9 @@
 // Copyright 2025 Irreducible Inc.
 
+//! Gadgets for verifying the [Grøstl] hash function.
+//!
+//! [Grøstl]: <https://www.groestl.info/>
+
 use std::{array, iter};
 
 use anyhow::Result;
@@ -23,10 +27,10 @@ const MIX_BYTES_VEC: [u8; 8] = [0x02, 0x02, 0x03, 0x04, 0x05, 0x03, 0x05, 0x07];
 
 /// The affine transformation matrix for the Rijndael S-box, isomorphically converted to the
 /// canonical tower basis.
-pub const S_BOX_TOWER_MATRIX: FieldLinearTransformation<B8> =
+const S_BOX_TOWER_MATRIX: FieldLinearTransformation<B8> =
 	FieldLinearTransformation::new_const(&S_BOX_TOWER_MATRIX_COLS);
 
-pub const S_BOX_TOWER_MATRIX_COLS: [B8; 8] = [
+const S_BOX_TOWER_MATRIX_COLS: [B8; 8] = [
 	B8::new(0x62),
 	B8::new(0xd2),
 	B8::new(0x79),
@@ -39,7 +43,7 @@ pub const S_BOX_TOWER_MATRIX_COLS: [B8; 8] = [
 
 /// The affine transformation offset for the Rijndael S-box, isomorphically converted to the
 /// canonical tower basis.
-pub const S_BOX_TOWER_OFFSET: B8 = B8::new(0x14);
+const S_BOX_TOWER_OFFSET: B8 = B8::new(0x14);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PermutationVariant {
@@ -119,6 +123,15 @@ impl PermutationRound {
 	}
 }
 
+/// A gadget for the [Rijndael S-box].
+///
+/// The Rijndael S-box, used in the AES block cipher, is a non-linear substitution box that is
+/// defined as a composition of field inversion and an $\mathbb{F}_2$-affine transformation on
+/// elements of $\mathbb{F}_{2^8}$. The S-box is typically defined over a univariate basis
+/// representation of $\mathbb{F}_{2^8}$, which is [`binius_field::AESTowerField8b`], thought we
+/// can translate the S-box to a transformation on [`B8`] elements, which are isomorphic.
+///
+/// [Rijndael S-box]: <https://en.wikipedia.org/wiki/Rijndael_S-box>
 #[derive(Debug)]
 pub struct SBox<const V: usize> {
 	input: Expr<B8, V>,

--- a/crates/m3/src/gadgets/hash/groestl.rs
+++ b/crates/m3/src/gadgets/hash/groestl.rs
@@ -1,20 +1,45 @@
 // Copyright 2025 Irreducible Inc.
 
-use std::{array, iter::zip};
+use std::{array, iter};
 
 use anyhow::Result;
 use binius_core::oracle::ShiftVariant;
 use binius_field::{
 	as_packed_field::{PackScalar, PackedType},
+	linear_transformation::{
+		FieldLinearTransformation, PackedTransformationFactory, Transformation,
+	},
 	packed::{get_packed_slice, set_packed_slice},
-	AESTowerField8b, ExtensionField, Field, PackedField, TowerField,
+	AESTowerField8b, ExtensionField, Field, PackedField,
 };
 use bytemuck::Pod;
 
-use crate::builder::{upcast_expr, Col, Expr, TableBuilder, TableWitnessIndexSegment, B1, B8};
+use crate::builder::{
+	upcast_col, upcast_expr, Col, Expr, TableBuilder, TableWitnessIndexSegment, B1, B8,
+};
 
 /// The first row of the circulant matrix defining the MixBytes step in Grøstl.
 const MIX_BYTES_VEC: [u8; 8] = [0x02, 0x02, 0x03, 0x04, 0x05, 0x03, 0x05, 0x07];
+
+/// The affine transformation matrix for the Rijndael S-box, isomorphically converted to the
+/// canonical tower basis.
+pub const S_BOX_TOWER_MATRIX: FieldLinearTransformation<B8> =
+	FieldLinearTransformation::new_const(&S_BOX_TOWER_MATRIX_COLS);
+
+pub const S_BOX_TOWER_MATRIX_COLS: [B8; 8] = [
+	B8::new(0x62),
+	B8::new(0xd2),
+	B8::new(0x79),
+	B8::new(0x41),
+	B8::new(0xf4),
+	B8::new(0xd5),
+	B8::new(0x81),
+	B8::new(0x4e),
+];
+
+/// The affine transformation offset for the Rijndael S-box, isomorphically converted to the
+/// canonical tower basis.
+pub const S_BOX_TOWER_OFFSET: B8 = B8::new(0x14);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PermutationVariant {
@@ -105,40 +130,32 @@ pub struct SBox<const V: usize> {
 
 impl<const V: usize> SBox<V> {
 	pub fn new(table: &mut TableBuilder, input: Expr<B8, V>) -> Self {
-		let aes_basis: [_; 8] = array::from_fn(|i| {
-			B8::from(
-				<AESTowerField8b as ExtensionField<B1>>::basis(i)
-					.expect("i in range 0..8; extension degree is 8"),
-			)
+		let b8_basis: [_; 8] = array::from_fn(|i| {
+			<B8 as ExtensionField<B1>>::basis(i).expect("i in range 0..8; extension degree is 8")
 		});
-		let pack_aes = move |bits: [Expr<B1, V>; 8]| {
+		let pack_b8 = move |bits: [Expr<B1, V>; 8]| {
 			bits.into_iter()
 				.enumerate()
-				.map(|(i, bit)| upcast_expr(bit) * aes_basis[i])
+				.map(|(i, bit)| upcast_expr(bit) * b8_basis[i])
 				.reduce(|a, b| a + b)
 				.expect("bits has length 8")
 		};
 
 		let inv_bits = array::from_fn(|i| table.add_committed(format!("inv_bits[{}]", i)));
-		let inv = table.add_linear_combination("inv", pack_aes(inv_bits.map(Expr::from)));
+		let inv = table.add_linear_combination("inv", pack_b8(inv_bits.map(Expr::from)));
 
 		// input * inv == 1 OR inv == 0
 		table.assert_zero("inv_valid_or_inv_zero", input.clone() * Expr::from(inv).pow(2) - inv);
 		// input * inv == 1 OR input == 0
 		table.assert_zero("inv_valid_or_input_zero", input.clone().pow(2) * inv - input.clone());
 
-		let output_bits = array::from_fn(|i| {
-			// Rijndael S-box affine transformation
-			let lincom =
-				inv_bits[i] + inv_bits[(i + 4) % 8] + inv_bits[(i + 5) % 8] + inv_bits[(i + 6) % 8];
-			lincom
-				+ if (0x63 >> i) & 1 == 0 {
-					B1::ZERO
-				} else {
-					B1::ONE
-				}
-		});
-		let output = table.add_linear_combination("output", pack_aes(output_bits));
+		// Rijndael S-box affine transformation
+		let linear_transform_expr = iter::zip(inv_bits, S_BOX_TOWER_MATRIX_COLS)
+			.map(|(inv_bit_i, scalar)| upcast_col(inv_bit_i) * scalar)
+			.reduce(|a, b| a + b)
+			.expect("inv_bits and S_BOX_TOWER_MATRIX_COLS have length 8");
+		let output = table
+			.add_linear_combination("output", linear_transform_expr.clone() + S_BOX_TOWER_OFFSET);
 
 		Self {
 			input,
@@ -150,39 +167,142 @@ impl<const V: usize> SBox<V> {
 
 	pub fn populate<U>(&self, index: &mut TableWitnessIndexSegment<U>) -> Result<()>
 	where
-		U: Pod + PackScalar<B8>,
+		U: Pod + PackScalar<B1> + PackScalar<B8>,
+		PackedType<U, B8>: PackedTransformationFactory<PackedType<U, B8>>,
 	{
 		let mut inv = index.get_mut(self.inv)?;
-		for (inv_i, val_i) in zip(&mut *inv, eval_expr(&self.input, index)) {
-			*inv_i = val_i.invert();
+
+		// Populate the inverse of the input.
+		for (inv_i, val_i) in iter::zip(&mut *inv, index.eval_expr(&self.input)?) {
+			*inv_i = val_i.invert_or_zero();
 		}
 
+		// Decompose the inverse bits.
 		let mut inv_bits = self
 			.inv_bits
 			.try_map(|inv_bits_i| index.get_mut(inv_bits_i))?;
 		for i in 0..index.size() {
-			let inv_val = get_packed_slice(inv, i);
+			let inv_val = get_packed_slice(&inv, i);
 			for (j, inv_bit_j) in ExtensionField::<B1>::iter_bases(&inv_val).enumerate() {
-				set_packed_slice(inv_bits[j], i, inv_bit_j);
+				set_packed_slice(&mut inv_bits[j], i, inv_bit_j);
 			}
 		}
 
-		// TODO: helper to evaluate an expression in the context of a witness index segment
+		// Apply the F2-linear transformation and populate the output.
+		let mut output = index.get_mut(self.output)?;
+
+		let transform_matrix = <PackedType<U, B8>>::make_packed_transformation(S_BOX_TOWER_MATRIX);
+		let transform_offset = <PackedType<U, B8>>::broadcast(S_BOX_TOWER_OFFSET);
+		for (out_i, inv_i) in iter::zip(&mut *output, &*inv) {
+			*out_i = transform_offset + transform_matrix.transform(inv_i);
+		}
+
 		Ok(())
 	}
 }
 
 #[cfg(test)]
 mod tests {
+	use binius_field::{arch::OptimalUnderlier128b, arithmetic_traits::InvertOrZero};
+	use bumpalo::Bump;
+	use rand::{prelude::StdRng, SeedableRng};
+
 	use super::*;
-	use crate::builder::Table;
+	use crate::builder::{ConstraintSystem, Statement};
+
+	#[test]
+	fn test_sbox() {
+		let mut cs = ConstraintSystem::new();
+		let mut table = cs.add_table("sbox test");
+
+		let input = table.add_committed::<B8, 1>("input");
+		let sbox = SBox::new(&mut table, input.into());
+
+		let table_id = table.id();
+
+		let allocator = Bump::new();
+
+		let statement = Statement {
+			boundaries: vec![],
+			table_sizes: vec![1 << 8],
+		};
+		let mut witness = cs
+			.build_witness::<OptimalUnderlier128b>(&allocator, &statement)
+			.unwrap();
+
+		let table_witness = witness.get_table(table_id).unwrap();
+
+		let mut rng = StdRng::seed_from_u64(0);
+		let mut segment = table_witness.full_segment();
+		for in_i in &mut *segment.get_mut(input).unwrap() {
+			*in_i = PackedField::random(&mut rng);
+		}
+
+		sbox.populate(&mut segment).unwrap();
+
+		let ccs = cs.compile(&statement).unwrap();
+		let witness = witness.into_multilinear_extension_index(&statement);
+
+		binius_core::constraint_system::validate::validate_witness(&ccs, &[], &witness).unwrap();
+	}
 
 	#[test]
 	fn test_p_permutation_round() {
-		let mut table = Table::new(0, "groestl permutation");
-		let mut builder = TableBuilder::new(&mut table);
+		let mut cs = ConstraintSystem::new();
+		let mut table = cs.add_table("groestl permutation");
 
-		let state_in = array::from_fn(|i| builder.add_committed(format!("state_in[{}]", i)));
-		let round = PermutationRound::new(&mut builder, PermutationVariant::P, state_in);
+		let state_in = array::from_fn(|i| table.add_committed(format!("state_in[{}]", i)));
+		let _round = PermutationRound::new(&mut table, PermutationVariant::P, state_in);
+	}
+
+	#[test]
+	fn test_isomorphic_sbox() {
+		#[rustfmt::skip]
+		const S_BOX: [u8; 256] = [
+			0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5, 0x30, 0x01, 0x67, 0x2b, 0xfe, 0xd7, 0xab, 0x76,
+			0xca, 0x82, 0xc9, 0x7d, 0xfa, 0x59, 0x47, 0xf0, 0xad, 0xd4, 0xa2, 0xaf, 0x9c, 0xa4, 0x72, 0xc0,
+			0xb7, 0xfd, 0x93, 0x26, 0x36, 0x3f, 0xf7, 0xcc, 0x34, 0xa5, 0xe5, 0xf1, 0x71, 0xd8, 0x31, 0x15,
+			0x04, 0xc7, 0x23, 0xc3, 0x18, 0x96, 0x05, 0x9a, 0x07, 0x12, 0x80, 0xe2, 0xeb, 0x27, 0xb2, 0x75,
+			0x09, 0x83, 0x2c, 0x1a, 0x1b, 0x6e, 0x5a, 0xa0, 0x52, 0x3b, 0xd6, 0xb3, 0x29, 0xe3, 0x2f, 0x84,
+			0x53, 0xd1, 0x00, 0xed, 0x20, 0xfc, 0xb1, 0x5b, 0x6a, 0xcb, 0xbe, 0x39, 0x4a, 0x4c, 0x58, 0xcf,
+			0xd0, 0xef, 0xaa, 0xfb, 0x43, 0x4d, 0x33, 0x85, 0x45, 0xf9, 0x02, 0x7f, 0x50, 0x3c, 0x9f, 0xa8,
+			0x51, 0xa3, 0x40, 0x8f, 0x92, 0x9d, 0x38, 0xf5, 0xbc, 0xb6, 0xda, 0x21, 0x10, 0xff, 0xf3, 0xd2,
+			0xcd, 0x0c, 0x13, 0xec, 0x5f, 0x97, 0x44, 0x17, 0xc4, 0xa7, 0x7e, 0x3d, 0x64, 0x5d, 0x19, 0x73,
+			0x60, 0x81, 0x4f, 0xdc, 0x22, 0x2a, 0x90, 0x88, 0x46, 0xee, 0xb8, 0x14, 0xde, 0x5e, 0x0b, 0xdb,
+			0xe0, 0x32, 0x3a, 0x0a, 0x49, 0x06, 0x24, 0x5c, 0xc2, 0xd3, 0xac, 0x62, 0x91, 0x95, 0xe4, 0x79,
+			0xe7, 0xc8, 0x37, 0x6d, 0x8d, 0xd5, 0x4e, 0xa9, 0x6c, 0x56, 0xf4, 0xea, 0x65, 0x7a, 0xae, 0x08,
+			0xba, 0x78, 0x25, 0x2e, 0x1c, 0xa6, 0xb4, 0xc6, 0xe8, 0xdd, 0x74, 0x1f, 0x4b, 0xbd, 0x8b, 0x8a,
+			0x70, 0x3e, 0xb5, 0x66, 0x48, 0x03, 0xf6, 0x0e, 0x61, 0x35, 0x57, 0xb9, 0x86, 0xc1, 0x1d, 0x9e,
+			0xe1, 0xf8, 0x98, 0x11, 0x69, 0xd9, 0x8e, 0x94, 0x9b, 0x1e, 0x87, 0xe9, 0xce, 0x55, 0x28, 0xdf,
+			0x8c, 0xa1, 0x89, 0x0d, 0xbf, 0xe6, 0x42, 0x68, 0x41, 0x99, 0x2d, 0x0f, 0xb0, 0x54, 0xbb, 0x16,
+		];
+
+		const S_BOX_MATRIX: FieldLinearTransformation<AESTowerField8b> =
+			FieldLinearTransformation::new_const(&[
+				AESTowerField8b::new(0x1F),
+				AESTowerField8b::new(0x3E),
+				AESTowerField8b::new(0x7C),
+				AESTowerField8b::new(0xF8),
+				AESTowerField8b::new(0xF1),
+				AESTowerField8b::new(0xE3),
+				AESTowerField8b::new(0xC7),
+				AESTowerField8b::new(0x8F),
+			]);
+		const S_BOX_OFFSET: AESTowerField8b = AESTowerField8b::new(0x63);
+
+		for i in 0u8..=255u8 {
+			let sbox_in = AESTowerField8b::new(i);
+			let expected_sbox_out = AESTowerField8b::new(S_BOX[i as usize]);
+
+			let sbox_out =
+				S_BOX_MATRIX.transform(&InvertOrZero::invert_or_zero(sbox_in)) + S_BOX_OFFSET;
+			assert_eq!(sbox_out, expected_sbox_out);
+
+			let sbox_in_b8 = B8::from(sbox_in);
+			let sbox_out_b8 = S_BOX_TOWER_MATRIX
+				.transform(&InvertOrZero::invert_or_zero(sbox_in_b8))
+				+ S_BOX_TOWER_OFFSET;
+			assert_eq!(AESTowerField8b::from(sbox_out_b8), expected_sbox_out);
+		}
 	}
 }

--- a/crates/m3/src/gadgets/hash/groestl.rs
+++ b/crates/m3/src/gadgets/hash/groestl.rs
@@ -1,0 +1,4 @@
+// Copyright 2025 Irreducible Inc.
+
+#[derive(Debug)]
+pub struct PermutationP {}

--- a/crates/m3/src/gadgets/hash/groestl.rs
+++ b/crates/m3/src/gadgets/hash/groestl.rs
@@ -2,35 +2,87 @@
 
 use std::array;
 
+use binius_core::oracle::ShiftVariant;
 use binius_field::{AESTowerField8b, ExtensionField, Field};
 
 use crate::builder::{upcast_expr, Col, Expr, TableBuilder, B1, B8};
 
-// #[derive(Debug)]
-// pub struct PermutationP {}
-//
-// impl PermutationP {
-// 	pub fn new() -> Self {
-// 		Self {}
-// 	}
-// }
+/// The first row of the circulant matrix defining the MixBytes step in Grøstl.
+const MIX_BYTES_VEC: [u8; 8] = [0x02, 0x02, 0x03, 0x04, 0x05, 0x03, 0x05, 0x07];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PermutationVariant {
+	P,
+	Q,
+}
 
 #[derive(Debug)]
 pub struct PermutationRound {
 	// Inputs
 	pub state_in: [Col<B8, 8>; 8],
-	//round_const: Col<B8, 8>,
+	round_const: Col<B8, 8>,
 	sbox: [SBox<8>; 8],
+	shift: [Col<B8, 8>; 8],
 	pub state_out: [Col<B8, 8>; 8],
 }
 
 impl PermutationRound {
-	pub fn new(table: &mut TableBuilder, state_in: [Col<B8, 8>; 8]) -> Self {
-		let sbox = array::from_fn(|i| SBox::new(table, state_in[i]));
-		let state_out = sbox.each_ref().map(|sbox| sbox.output);
+	pub fn new(
+		table: &mut TableBuilder,
+		pq: PermutationVariant,
+		state_in: [Col<B8, 8>; 8],
+	) -> Self {
+		let round_const = table.add_committed("RoundConstant");
+
+		// AddRoundConstant + SubBytes
+		let sbox = array::from_fn(|i| {
+			let sbox_in = match (i, pq) {
+				(0, PermutationVariant::P) => state_in[0] + round_const,
+				(_, PermutationVariant::P) => state_in[i].into(),
+				(7, PermutationVariant::Q) => state_in[7] + B8::new(0xFF) + round_const,
+				(_, PermutationVariant::Q) => state_in[i] + B8::new(0xFF),
+			};
+			SBox::new(&mut table.with_namespace(format!("SubBytes[{i}]")), sbox_in)
+		});
+
+		// ShiftBytes
+		let shift = array::from_fn(|i| {
+			let offset = match pq {
+				PermutationVariant::P => (8 - i) % 8,
+				PermutationVariant::Q => (8 - (2 * i + 1)) % 8,
+			};
+			if offset == 0 {
+				sbox[i].output
+			} else {
+				table.add_shifted(
+					format!("ShiftBytes[{i}]"),
+					sbox[i].output,
+					3,
+					i,
+					ShiftVariant::CircularLeft,
+				)
+			}
+		});
+
+		// MixBytes
+		let mix_bytes_scalars = MIX_BYTES_VEC.map(|byte| B8::from(AESTowerField8b::new(byte)));
+		let state_out = array::from_fn(|i| {
+			let mix_bytes: [_; 8] =
+				array::from_fn(|j| shift[i] * mix_bytes_scalars[(8 + i - j) % 8]);
+			table.add_linear_combination(
+				format!("MixBytes[{i}]"),
+				mix_bytes
+					.into_iter()
+					.reduce(|a, b| a + b)
+					.expect("mix_bytes has length 8"),
+			)
+		});
+
 		Self {
 			state_in,
+			round_const,
 			sbox,
+			shift,
 			state_out,
 		}
 	}
@@ -38,7 +90,6 @@ impl PermutationRound {
 
 #[derive(Debug)]
 pub struct SBox<const V: usize> {
-	pub input: Col<B8, V>,
 	/// Bits of the inverse of the input, in AES basis.
 	inv_bits: [Col<B1, V>; 8],
 	inv: Col<B8, V>,
@@ -46,7 +97,7 @@ pub struct SBox<const V: usize> {
 }
 
 impl<const V: usize> SBox<V> {
-	pub fn new(table: &mut TableBuilder, input: Col<B8, V>) -> Self {
+	pub fn new(table: &mut TableBuilder, input: Expr<B8, V>) -> Self {
 		let aes_basis: [_; 8] = array::from_fn(|i| {
 			B8::from(
 				<AESTowerField8b as ExtensionField<B1>>::basis(i)
@@ -65,9 +116,9 @@ impl<const V: usize> SBox<V> {
 		let inv = table.add_linear_combination("inv", pack_aes(inv_bits.map(Expr::from)));
 
 		// input * inv == 1 OR inv == 0
-		table.assert_zero("inv_valid_or_inv_zero", input * Expr::from(inv).pow(2) - inv);
+		table.assert_zero("inv_valid_or_inv_zero", input.clone() * Expr::from(inv).pow(2) - inv);
 		// input * inv == 1 OR input == 0
-		table.assert_zero("inv_valid_or_input_zero", Expr::from(input).pow(2) * inv - input);
+		table.assert_zero("inv_valid_or_input_zero", input.clone().pow(2) * inv - input.clone());
 
 		let output_bits = array::from_fn(|i| {
 			// Rijndael S-box affine transformation
@@ -83,7 +134,6 @@ impl<const V: usize> SBox<V> {
 		let output = table.add_linear_combination("output", pack_aes(output_bits));
 
 		Self {
-			input,
 			inv_bits,
 			inv,
 			output,
@@ -97,11 +147,11 @@ mod tests {
 	use crate::builder::Table;
 
 	#[test]
-	fn test_permutation_round() {
+	fn test_p_permutation_round() {
 		let mut table = Table::new(0, "groestl permutation");
 		let mut builder = TableBuilder::new(&mut table);
 
 		let state_in = array::from_fn(|i| builder.add_committed(format!("state_in[{}]", i)));
-		let round = PermutationRound::new(&mut builder, state_in);
+		let round = PermutationRound::new(&mut builder, PermutationVariant::P, state_in);
 	}
 }

--- a/crates/m3/src/gadgets/hash/groestl.rs
+++ b/crates/m3/src/gadgets/hash/groestl.rs
@@ -1,4 +1,75 @@
 // Copyright 2025 Irreducible Inc.
 
+use std::array;
+
+use binius_field::{ExtensionField, Field, TowerField};
+
+use crate::builder::{upcast_col, Col, Expr, TableBuilder, B1, B16, B8};
+
 #[derive(Debug)]
 pub struct PermutationP {}
+
+impl PermutationP {
+	pub fn new() -> Self {
+		Self {}
+	}
+}
+
+#[derive(Debug)]
+pub struct PermutationRound {
+	// Inputs
+	pub state_in: [Col<B8, 3>; 8],
+	round_const: Col<B8, 3>,
+	pub state_out: [Col<B8, 3>; 8],
+}
+
+impl PermutationRound {
+	pub fn new() -> Self {
+		Self {}
+	}
+}
+
+#[derive(Debug)]
+pub struct SBox<const V: usize> {
+	pub input: Col<B8, V>,
+	inv_bits: [Col<B1, V>; 8],
+	inv: Col<B8, V>,
+	pub output: Col<B8, V>,
+}
+
+impl<const V: usize> SBox<V> {
+	pub fn new(table: &mut TableBuilder, input: Col<B8, V>) -> Self {
+		let inv_bits = array::from_fn(|i| table.add_committed(format!("inv_bits[{}]", i)));
+
+		let inv =
+			table.add_linear_combination(
+				"inv",
+				inv_bits[0]
+					+ inv_bits[1] + inv_bits[2]
+					+ inv_bits[3] + inv_bits[4]
+					+ inv_bits[5] + inv_bits[6]
+					+ inv_bits[7],
+			);
+
+		table.assert_zero("inv_valid_or_inv_zero", input * Expr::from(inv).pow(2) - inv);
+		table.assert_zero("inv_valid_or_input_zero", Expr::from(input).pow(2) * inv - input);
+
+		let b8_basis = array::from_fn(|i| <B8 as ExtensionField<B1>>::basis(i));
+		let output =
+			table.add_linear_combination(
+				"output",
+				inv_bits[0]
+					+ inv_bits[1] + inv_bits[2]
+					+ inv_bits[3] + inv_bits[4]
+					+ inv_bits[5] + inv_bits[6]
+					+ inv_bits[7],
+			);
+
+		Self {
+			input,
+			inv_bits,
+			inv,
+			output,
+		}
+	}
+}

--- a/crates/m3/src/gadgets/hash/groestl.rs
+++ b/crates/m3/src/gadgets/hash/groestl.rs
@@ -13,7 +13,7 @@ use binius_field::{
 		FieldLinearTransformation, PackedTransformationFactory, Transformation,
 	},
 	packed::{get_packed_slice, set_packed_slice},
-	AESTowerField8b, ExtensionField, PackedField,
+	ExtensionField, PackedField,
 };
 use bytemuck::Pod;
 
@@ -134,7 +134,9 @@ impl<const V: usize> SBox<V> {
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{arch::OptimalUnderlier128b, arithmetic_traits::InvertOrZero};
+	use binius_field::{
+		arch::OptimalUnderlier128b, arithmetic_traits::InvertOrZero, AESTowerField8b,
+	};
 	use bumpalo::Bump;
 	use rand::{prelude::StdRng, SeedableRng};
 

--- a/crates/m3/src/gadgets/hash/groestl.rs
+++ b/crates/m3/src/gadgets/hash/groestl.rs
@@ -2,36 +2,44 @@
 
 use std::array;
 
-use binius_field::{ExtensionField, Field, TowerField};
+use binius_field::{AESTowerField8b, ExtensionField, Field};
 
-use crate::builder::{upcast_col, Col, Expr, TableBuilder, B1, B16, B8};
+use crate::builder::{upcast_expr, Col, Expr, TableBuilder, B1, B8};
 
-#[derive(Debug)]
-pub struct PermutationP {}
-
-impl PermutationP {
-	pub fn new() -> Self {
-		Self {}
-	}
-}
+// #[derive(Debug)]
+// pub struct PermutationP {}
+//
+// impl PermutationP {
+// 	pub fn new() -> Self {
+// 		Self {}
+// 	}
+// }
 
 #[derive(Debug)]
 pub struct PermutationRound {
 	// Inputs
-	pub state_in: [Col<B8, 3>; 8],
-	round_const: Col<B8, 3>,
-	pub state_out: [Col<B8, 3>; 8],
+	pub state_in: [Col<B8, 8>; 8],
+	//round_const: Col<B8, 8>,
+	sbox: [SBox<8>; 8],
+	pub state_out: [Col<B8, 8>; 8],
 }
 
 impl PermutationRound {
-	pub fn new() -> Self {
-		Self {}
+	pub fn new(table: &mut TableBuilder, state_in: [Col<B8, 8>; 8]) -> Self {
+		let sbox = array::from_fn(|i| SBox::new(table, state_in[i]));
+		let state_out = sbox.each_ref().map(|sbox| sbox.output);
+		Self {
+			state_in,
+			sbox,
+			state_out,
+		}
 	}
 }
 
 #[derive(Debug)]
 pub struct SBox<const V: usize> {
 	pub input: Col<B8, V>,
+	/// Bits of the inverse of the input, in AES basis.
 	inv_bits: [Col<B1, V>; 8],
 	inv: Col<B8, V>,
 	pub output: Col<B8, V>,
@@ -39,31 +47,40 @@ pub struct SBox<const V: usize> {
 
 impl<const V: usize> SBox<V> {
 	pub fn new(table: &mut TableBuilder, input: Col<B8, V>) -> Self {
+		let aes_basis: [_; 8] = array::from_fn(|i| {
+			B8::from(
+				<AESTowerField8b as ExtensionField<B1>>::basis(i)
+					.expect("i in range 0..8; extension degree is 8"),
+			)
+		});
+		let pack_aes = move |bits: [Expr<B1, V>; 8]| {
+			bits.into_iter()
+				.enumerate()
+				.map(|(i, bit)| upcast_expr(bit) * aes_basis[i])
+				.reduce(|a, b| a + b)
+				.expect("bits has length 8")
+		};
+
 		let inv_bits = array::from_fn(|i| table.add_committed(format!("inv_bits[{}]", i)));
+		let inv = table.add_linear_combination("inv", pack_aes(inv_bits.map(Expr::from)));
 
-		let inv =
-			table.add_linear_combination(
-				"inv",
-				inv_bits[0]
-					+ inv_bits[1] + inv_bits[2]
-					+ inv_bits[3] + inv_bits[4]
-					+ inv_bits[5] + inv_bits[6]
-					+ inv_bits[7],
-			);
-
+		// input * inv == 1 OR inv == 0
 		table.assert_zero("inv_valid_or_inv_zero", input * Expr::from(inv).pow(2) - inv);
+		// input * inv == 1 OR input == 0
 		table.assert_zero("inv_valid_or_input_zero", Expr::from(input).pow(2) * inv - input);
 
-		let b8_basis = array::from_fn(|i| <B8 as ExtensionField<B1>>::basis(i));
-		let output =
-			table.add_linear_combination(
-				"output",
-				inv_bits[0]
-					+ inv_bits[1] + inv_bits[2]
-					+ inv_bits[3] + inv_bits[4]
-					+ inv_bits[5] + inv_bits[6]
-					+ inv_bits[7],
-			);
+		let output_bits = array::from_fn(|i| {
+			// Rijndael S-box affine transformation
+			let lincom =
+				inv_bits[i] + inv_bits[(i + 4) % 8] + inv_bits[(i + 5) % 8] + inv_bits[(i + 6) % 8];
+			lincom
+				+ if (0x63 >> i) & 1 == 0 {
+					B1::ZERO
+				} else {
+					B1::ONE
+				}
+		});
+		let output = table.add_linear_combination("output", pack_aes(output_bits));
 
 		Self {
 			input,
@@ -71,5 +88,20 @@ impl<const V: usize> SBox<V> {
 			inv,
 			output,
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::builder::Table;
+
+	#[test]
+	fn test_permutation_round() {
+		let mut table = Table::new(0, "groestl permutation");
+		let mut builder = TableBuilder::new(&mut table);
+
+		let state_in = array::from_fn(|i| builder.add_committed(format!("state_in[{}]", i)));
+		let round = PermutationRound::new(&mut builder, state_in);
 	}
 }

--- a/crates/m3/src/gadgets/hash/mod.rs
+++ b/crates/m3/src/gadgets/hash/mod.rs
@@ -1,4 +1,3 @@
 // Copyright 2025 Irreducible Inc.
 
-pub mod hash;
-pub mod u32;
+mod groestl;

--- a/crates/m3/src/gadgets/hash/mod.rs
+++ b/crates/m3/src/gadgets/hash/mod.rs
@@ -1,3 +1,3 @@
 // Copyright 2025 Irreducible Inc.
 
-mod groestl;
+//mod groestl;

--- a/crates/m3/src/gadgets/hash/mod.rs
+++ b/crates/m3/src/gadgets/hash/mod.rs
@@ -1,3 +1,3 @@
 // Copyright 2025 Irreducible Inc.
 
-//mod groestl;
+pub mod groestl;

--- a/crates/m3/src/lib.rs
+++ b/crates/m3/src/lib.rs
@@ -1,5 +1,6 @@
-#![feature(array_try_map)]
 // Copyright 2025 Irreducible Inc.
+
+#![feature(array_try_map)]
 
 //! A library for building Binius constraint systems and instances using M3 arithmetization.
 //!

--- a/crates/m3/src/lib.rs
+++ b/crates/m3/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(array_try_map)]
 // Copyright 2025 Irreducible Inc.
 
 //! A library for building Binius constraint systems and instances using M3 arithmetization.


### PR DESCRIPTION
This is the first gadget towards building the Grøstl hash function with the M3 crate.

The main trickiness is constraining the hash over the canonical B8 tower field instead of the AES tower.

The input to the S-box is an `Expr` instead of a `Col` because the input can be a column with a round constant added, and it's more efficient to treat that as an expression than a linear combination column.