### PR TITLE
[Mul] gkr exp + lookups 

### DIFF
--- a/crates/circuits/src/arithmetic/mod.rs
+++ b/crates/circuits/src/arithmetic/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 pub mod mul;
+pub mod static_exp;
 pub mod u32;
 
 /// Whether to allow or disallow arithmetic overflow

--- a/crates/circuits/src/arithmetic/mul.rs
+++ b/crates/circuits/src/arithmetic/mul.rs
@@ -8,19 +8,23 @@
 //!
 //! You can read more information in [Integer Multiplication in Binius](https://www.irreducible.com/posts/integer-multiplication-in-binius).
 
+use std::array;
+
 use anyhow::Error;
 use binius_core::oracle::OracleId;
 use binius_field::{
 	as_packed_field::PackedType,
 	packed::{get_packed_slice, set_packed_slice},
-	BinaryField, BinaryField1b, Field, TowerField,
+	BinaryField, BinaryField16b, BinaryField1b, BinaryField64b, Field, TowerField,
 };
 use binius_macros::arith_expr;
 use binius_maybe_rayon::iter::{
 	IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator,
 };
 use binius_utils::bail;
+use itertools::izip;
 
+use super::static_exp::u16_static_exp_lookups;
 use crate::builder::{
 	types::{F, U},
 	ConstraintSystemBuilder,
@@ -146,6 +150,216 @@ where
 		cout_high_exp_result_id,
 		exp_pow2(FExpBase::MULTIPLICATIVE_GENERATOR, cout_low_bits.len()).into(),
 		FExpBase::TOWER_LEVEL,
+	);
+
+	Ok(cout_bits)
+}
+
+/// u32 Multiplication based on plain lookups for static exponentiation
+/// and gkr_exp for dynamic exponentiation
+///
+/// The core idea of this method is to verify the equality $x \cdot y = c$
+/// by checking if
+///
+/// $(g^{xlow} \cdot (g^{2^{16}})^{xhigh})^y = \prod_{i=0}^{3} (g^{2^{(16 \cdot i)}})^{c_i} $,
+/// where $c_i$ is a $i$ 16-bit
+pub fn u32_mul<const LOG_MAX_MULTIPLICITY: usize>(
+	builder: &mut ConstraintSystemBuilder,
+	name: impl ToString,
+	xin_bits: [OracleId; 32],
+	yin_bits: [OracleId; 32],
+) -> Result<[OracleId; 64], anyhow::Error> {
+	let log_rows = builder.log_rows(xin_bits)?;
+
+	let name = name.to_string();
+
+	let [xin_low, xin_high] = array::from_fn(|i| {
+		let bits: [(usize, F); 16] =
+			array::from_fn(|j| (xin_bits[16 * i + j], <F as TowerField>::basis(0, j).unwrap()));
+
+		builder
+			.add_linear_combination("xin_low", log_rows, bits)
+			.unwrap()
+	});
+
+	if let Some(witness) = builder.witness() {
+		let xin_columns = xin_bits
+			.iter()
+			.map(|&id| witness.get::<BinaryField1b>(id).map(|x| x.packed()))
+			.collect::<Result<Vec<_>, Error>>()?;
+
+		let xin_numbers = columns_to_numbers(&xin_columns);
+
+		let mut xin_low = witness.new_column::<BinaryField16b>(xin_low);
+		let xin_low = xin_low.as_mut_slice::<u16>();
+
+		let mut xin_high = witness.new_column::<BinaryField16b>(xin_high);
+		let xin_high = xin_high.as_mut_slice::<u16>();
+
+		izip!(xin_numbers, xin_low, xin_high).for_each(|(xin, low, high)| {
+			*low = (xin & 0xFFFF) as u16;
+			*high = (xin >> 16) as u16;
+		});
+	}
+
+	//$g^{xlow}$
+	let (xin_low_exp_res_id, g) = u16_static_exp_lookups::<LOG_MAX_MULTIPLICITY>(
+		builder,
+		"xin_low_exp_res",
+		xin_low,
+		BinaryField64b::MULTIPLICATIVE_GENERATOR,
+		None,
+	)?;
+
+	//$(g^{2^{16}})^{xhigh}$
+	let (xin_high_exp_res_id, g_16) = u16_static_exp_lookups::<LOG_MAX_MULTIPLICITY>(
+		builder,
+		"xin_high_exp_res",
+		xin_high,
+		exp_pow2(BinaryField64b::MULTIPLICATIVE_GENERATOR, 16),
+		None,
+	)?;
+
+	//$g^{xin}$
+	let xin_exp_res_id =
+		builder.add_committed("xin_exp_result", log_rows, BinaryField64b::TOWER_LEVEL);
+
+	builder.assert_zero(
+		"xin_exp_res_id zerocheck",
+		[xin_low_exp_res_id, xin_high_exp_res_id, xin_exp_res_id],
+		arith_expr!(
+			[xin_low_exp_res, xin_high_exp_res, xin_exp_result_id] =
+				xin_low_exp_res * xin_high_exp_res - xin_exp_result_id
+		)
+		.convert_field(),
+	);
+
+	if let Some(witness) = builder.witness() {
+		let xin_low_exp_res = witness
+			.get::<BinaryField64b>(xin_low_exp_res_id)?
+			.as_slice::<BinaryField64b>();
+
+		let xin_high_exp_res = witness
+			.get::<BinaryField64b>(xin_high_exp_res_id)?
+			.as_slice::<BinaryField64b>();
+
+		let mut xin_exp_res = witness.new_column::<BinaryField64b>(xin_exp_res_id);
+		let xin_exp_res = xin_exp_res.as_mut_slice::<BinaryField64b>();
+		xin_exp_res
+			.par_iter_mut()
+			.enumerate()
+			.for_each(|(i, xin_exp_res)| {
+				*xin_exp_res = xin_low_exp_res[i] * xin_high_exp_res[i];
+			});
+	}
+
+	//$(g^{x})^{y}$
+	let yin_exp_result_id = builder.add_committed(
+		format!("{} yin_exp_result", name),
+		log_rows,
+		BinaryField64b::TOWER_LEVEL,
+	);
+
+	builder.add_dynamic_exp(yin_bits.to_vec(), yin_exp_result_id, xin_exp_res_id);
+
+	let cout_bits: [OracleId; 64] =
+		builder.add_committed_multiple("cout_bits", log_rows, BinaryField1b::TOWER_LEVEL);
+
+	let cout: [OracleId; 4] = array::from_fn(|i| {
+		let bits: [(usize, F); 16] =
+			array::from_fn(|j| (cout_bits[16 * i + j], <F as TowerField>::basis(0, j).unwrap()));
+
+		builder
+			.add_linear_combination("cout 16b", log_rows, bits)
+			.unwrap()
+	});
+
+	if let Some(witness) = builder.witness() {
+		let xin_columns = xin_bits
+			.iter()
+			.map(|&id| witness.get::<BinaryField1b>(id).map(|x| x.packed()))
+			.collect::<Result<Vec<_>, Error>>()?;
+
+		let yin_columns = yin_bits
+			.iter()
+			.map(|&id| witness.get::<BinaryField1b>(id).map(|x| x.packed()))
+			.collect::<Result<Vec<_>, Error>>()?;
+
+		let result = columns_to_numbers(&xin_columns)
+			.into_iter()
+			.zip(columns_to_numbers(&yin_columns))
+			.map(|(x, y)| x * y)
+			.collect::<Vec<_>>();
+
+		let mut cout_columns = cout_bits
+			.iter()
+			.map(|&id| witness.new_column::<BinaryField1b>(id))
+			.collect::<Vec<_>>();
+
+		let mut cout_columns = cout_columns
+			.iter_mut()
+			.map(|column| column.packed())
+			.collect::<Vec<_>>();
+
+		numbers_to_columns(&result, &mut cout_columns);
+
+		let mut cout = cout.map(|id| witness.new_column::<BinaryField16b>(id));
+
+		let mut cout = cout
+			.iter_mut()
+			.map(|cout| cout.as_mut_slice::<u16>())
+			.collect::<Vec<_>>();
+
+		cout.iter_mut().enumerate().for_each(|(j, cout)| {
+			cout.par_iter_mut().enumerate().for_each(|(i, cout)| {
+				let value = result[i];
+
+				*cout = ((value >> (j * 16)) & 0xFFFF) as u16;
+			});
+		});
+	}
+
+	//$(g^{2^{(16 \cdot i)}})^{c_i}$ where $c_i$ is a $i$ 16-bit
+	let cout_exp_res_id = (0..4)
+		.map(|i| {
+			let g_table = match i {
+				0 => Some(g),
+				1 => Some(g_16),
+				_ => None,
+			};
+
+			u16_static_exp_lookups::<LOG_MAX_MULTIPLICITY>(
+				builder,
+				format!("cout_exp_result_id {}", i),
+				cout[i],
+				exp_pow2(BinaryField64b::MULTIPLICATIVE_GENERATOR, 16 * i),
+				g_table,
+			)
+			.map(|res| res.0)
+		})
+		.collect::<Result<Vec<_>, anyhow::Error>>()?;
+
+	// Handling special case when $x == 0$ $y == 0$ $c == 2^{2 \cdot n} -1$
+	builder.assert_zero(
+		name.clone(),
+		[xin_bits[0], yin_bits[0], cout_bits[0]],
+		arith_expr!([x, y, c] = x * y - c).convert_field(),
+	);
+
+	// $(g^{xlow} \cdot (g^{2^{16}})^{xhigh})^y = \prod_{i=0}^{3} (g^{2^{(16 \cdot i)}})^{c_i} $
+	builder.assert_zero(
+		name,
+		[
+			yin_exp_result_id,
+			cout_exp_res_id[0],
+			cout_exp_res_id[1],
+			cout_exp_res_id[2],
+			cout_exp_res_id[3],
+		],
+		arith_expr!(
+			[yin, cout_0, cout_1, cout_2, cout_3] = cout_0 * cout_1 * cout_2 * cout_3 - yin
+		)
+		.convert_field(),
 	);
 
 	Ok(cout_bits)

--- a/crates/circuits/src/arithmetic/static_exp.rs
+++ b/crates/circuits/src/arithmetic/static_exp.rs
@@ -1,0 +1,111 @@
+// Copyright 2025 Irreducible Inc.
+
+use anyhow::Ok;
+use binius_core::oracle::OracleId;
+use binius_field::{BinaryField128b, BinaryField16b, BinaryField64b, PackedField, TowerField};
+use binius_maybe_rayon::{
+	iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator},
+	slice::ParallelSliceMut,
+};
+
+use crate::{
+	builder::{types::F, ConstraintSystemBuilder},
+	plain_lookup,
+};
+
+pub fn build_exp_table(
+	g: BinaryField64b,
+	builder: &mut ConstraintSystemBuilder,
+	name: impl ToString,
+) -> Result<OracleId, anyhow::Error> {
+	let chunk_size = 1024;
+
+	let table = builder.add_committed(name, 16, BinaryField128b::TOWER_LEVEL);
+
+	if let Some(witness) = builder.witness() {
+		let mut table = witness.new_column::<BinaryField128b>(table);
+
+		let table = table.as_mut_slice::<u128>();
+
+		table
+			.par_chunks_mut(chunk_size)
+			.enumerate()
+			.for_each(|(i, chunk)| {
+				let offset = i * chunk_size;
+				let mut current_g = g.pow(offset as u64);
+				chunk.iter_mut().enumerate().for_each(|(i, el)| {
+					let current_g_u64: u64 = current_g.into();
+					*el = (((offset + i) as u128) << 64) | current_g_u64 as u128;
+					current_g *= g;
+				})
+			})
+	}
+
+	Ok(table)
+}
+
+pub fn u16_static_exp_lookups<const LOG_MAX_MULTIPLICITY: usize>(
+	builder: &mut ConstraintSystemBuilder,
+	name: impl ToString,
+	xin: OracleId,
+	g: BinaryField64b,
+	g_lookup_table: Option<OracleId>,
+) -> Result<(OracleId, OracleId), anyhow::Error> {
+	let log_rows = builder.log_rows([xin])?;
+
+	let name = name.to_string();
+
+	let exp_result = builder.add_committed(
+		format!("{} exp_result", name),
+		log_rows,
+		BinaryField64b::TOWER_LEVEL,
+	);
+
+	let g_lookup_table = if let Some(id) = g_lookup_table {
+		id
+	} else {
+		build_exp_table(g, builder, format!("{} g_lookup_table", name))?
+	};
+
+	let lookup_values = builder.add_linear_combination(
+		format!("{} lookup_values", name),
+		log_rows,
+		[
+			(xin, <F as TowerField>::basis(4, 4)?),
+			(exp_result, <F as TowerField>::basis(6, 0)?),
+		],
+	)?;
+
+	if let Some(witness) = builder.witness() {
+		let xin = witness.get::<BinaryField16b>(xin)?.as_slice::<u16>();
+
+		let mut exp_result = witness.new_column::<BinaryField64b>(exp_result);
+
+		let exp_result = exp_result.as_mut_slice::<BinaryField64b>();
+
+		exp_result.par_iter_mut().enumerate().for_each(|(i, exp)| {
+			*exp = g.pow(xin[i] as u64);
+		});
+
+		let mut lookup_values = witness.new_column::<BinaryField128b>(lookup_values);
+
+		let lookup_values = lookup_values.as_mut_slice::<u128>();
+
+		lookup_values
+			.iter_mut()
+			.enumerate()
+			.for_each(|(i, look_val)| {
+				let exp_result_u64: u64 = exp_result[i].into();
+				*look_val = ((xin[i] as u128) << 64) | exp_result_u64 as u128;
+			});
+	}
+
+	plain_lookup::plain_lookup::<BinaryField128b, LOG_MAX_MULTIPLICITY>(
+		builder,
+		g_lookup_table,
+		lookup_values,
+		1 << log_rows,
+	)?;
+
+	Ok((exp_result, g_lookup_table))
+}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -79,6 +79,10 @@ path = "b32_mul.rs"
 name = "blake3_circuit"
 path = "blake3_circuit.rs"
 
+[[example]]
+name = "u32_mul_gkr_exp_lookups"
+path = "u32_mul_gkr_exp_lookups.rs"
+
 [lints.clippy]
 needless_range_loop = "allow"
 

--- a/examples/u32_mul_gkr_exp_lookups.rs
+++ b/examples/u32_mul_gkr_exp_lookups.rs
@@ -1,0 +1,109 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use std::array;
+
+use anyhow::Result;
+use binius_circuits::{
+	arithmetic::mul,
+	builder::{types::U, ConstraintSystemBuilder},
+};
+use binius_core::{
+	constraint_system, fiat_shamir::HasherChallenger, oracle::OracleId, tower::CanonicalTowerFamily,
+};
+use binius_field::BinaryField1b;
+use binius_hal::make_portable_backend;
+use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
+use binius_math::DefaultEvaluationDomainFactory;
+use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
+use bytesize::ByteSize;
+use clap::{value_parser, Parser};
+use tracing_profile::init_tracing;
+
+#[derive(Debug, Parser)]
+struct Args {
+	/// The number of multiplication to do.
+	#[arg(short, long, default_value_t = 512, value_parser = value_parser!(u32).range(512..))]
+	n_muls: u32,
+	/// The negative binary logarithm of the Reed–Solomon code rate.
+	#[arg(long, default_value_t = 1, value_parser = value_parser!(u32).range(1..))]
+	log_inv_rate: u32,
+}
+
+fn main() -> Result<()> {
+	const SECURITY_BITS: usize = 100;
+
+	adjust_thread_pool()
+		.as_ref()
+		.expect("failed to init thread pool");
+
+	let args = Args::parse();
+
+	let _guard = init_tracing().expect("failed to initialize tracing");
+
+	println!("Verifying {} u32 multiplication", args.n_muls);
+
+	let log_n_muls = log2_ceil_usize(args.n_muls as usize);
+
+	let allocator = bumpalo::Bump::new();
+	let mut builder = ConstraintSystemBuilder::new_with_witness(&allocator);
+
+	let trace_gen_scope = tracing::info_span!("generating trace").entered();
+	let in_a: [OracleId; 32] = array::from_fn(|i| {
+		binius_circuits::unconstrained::unconstrained::<BinaryField1b>(
+			&mut builder,
+			format!("in_a_{}", i),
+			log_n_muls,
+		)
+		.unwrap()
+	});
+	let in_b: [OracleId; 32] = array::from_fn(|i| {
+		binius_circuits::unconstrained::unconstrained::<BinaryField1b>(
+			&mut builder,
+			format!("in_b_{}", i),
+			log_n_muls,
+		)
+		.unwrap()
+	});
+
+	mul::u32_mul::<22>(&mut builder, "u32_mul", in_a, in_b).unwrap();
+
+	drop(trace_gen_scope);
+
+	let witness = builder
+		.take_witness()
+		.expect("builder created with witness");
+	let constraint_system = builder.build()?;
+
+	let domain_factory = DefaultEvaluationDomainFactory::default();
+	let backend = make_portable_backend();
+
+	let proof = constraint_system::prove::<
+		U,
+		CanonicalTowerFamily,
+		_,
+		Groestl256,
+		Groestl256ByteCompression,
+		HasherChallenger<Groestl256>,
+		_,
+	>(
+		&constraint_system,
+		args.log_inv_rate as usize,
+		SECURITY_BITS,
+		&[],
+		witness,
+		&domain_factory,
+		&backend,
+	)?;
+
+	println!("Proof size: {}", ByteSize::b(proof.get_proof_size() as u64));
+
+	constraint_system::verify::<
+		U,
+		CanonicalTowerFamily,
+		Groestl256,
+		Groestl256ByteCompression,
+		HasherChallenger<Groestl256>,
+	>(&constraint_system, args.log_inv_rate as usize, SECURITY_BITS, &[], proof)?;
+
+	Ok(())
+}


### PR DESCRIPTION
An optimized by commits version of Mul that uses lookups for static exponentiation and gkr_exp for dynamic exponentiation.
This is much faster than my previous implementation, but still slower  than gkr_exp on supermicro (26.92s vs 24.87s).

Commits for 2^{24} muls :
| Name                   | log_rows | TOWER_LEVEL |
|------------------------|---------|-------------|
| xin_low_exp_res       | 24      | 6           |
| g table              | 16      | 7           |
| xin_high_exp_res      | 24      | 6           |
| g_16 table           | 16      | 7           |
| xin_exp_result       | 24      | 6           |
| yin_exp_result       | 24      | 6           |
| cout_0               | 24      | 4           |
| cout_1               | 24      | 4           |
| cout_2               | 24      | 4           |
| cout_3               | 24      | 4           |
| cout_exp_result 0    | 24      | 6           |
| cout_exp_result 1    | 24      | 6           |
| cout_exp_result 2    | 24      | 6           |
| g_32 table          | 16      | 7           |
| cout_exp_result 3    | 24      | 6           |
| g_48 table          | 16      | 7           |

Committing to g tables can be avoided if the verifier precomputes them.
xin_exp_result can be changed to composite, but currently, it is slower than committing + zero_check
