### PR TITLE
fixes in FRI `calculate_n_test_queries`

### DIFF
--- a/crates/core/src/protocols/fri/common.rs
+++ b/crates/core/src/protocols/fri/common.rs
@@ -284,7 +284,7 @@ where
 	if allowed_query_err <= 0.0 {
 		return Err(Error::ParameterError);
 	}
-	let n_queries = (allowed_query_err.log2() / per_query_err.log2()).ceil() as usize;
+	let n_queries = allowed_query_err.log(per_query_err).ceil() as usize;
 	Ok(n_queries)
 }
 


### PR DESCRIPTION
- use sumcheck error of 2 ⋅ ℓ' / |𝒯_τ|, instead of ℓ' / |𝒯_τ|. the missing factor of 2 is a carry-over from a previous time, when we were using (the strong version of) Angus's § 3 optimization. now, because of row-batching, we can't do this anymore—our sumcheck is no longer with an eq-indicator.
- calculate the number of queries in one shot, instead of using only `security_bits` and then adding integers post-hoc. to do this, we just need to subtract the `folding_err` and `per_query_err` from 2^{-security_bits} before taking log_2 and dividing the result by log_2(per_query_err).