### PR TITLE
Fix`channel_id_bound`

### DIFF
--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -142,6 +142,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 
 	pub fn add_channel(&mut self, name: impl ToString) -> ChannelId {
 		let id = self.channels.len();
+		self.channel_id_bound += 1;
 		self.channels.push(Channel {
 			name: name.to_string(),
 		});


### PR DESCRIPTION
The field `channel_id_bound` was not being updated when adding a new channel to m3's constraint system.