### PR TITLE
EqIndSumcheck follow-ups

### DIFF
--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -382,7 +382,6 @@ where
 				reduced_multilinears,
 				univariatized_multilinear_evals,
 				univariate_challenge,
-				&domain_factory,
 				backend,
 			)?;
 

--- a/crates/core/src/protocols/sumcheck/common.rs
+++ b/crates/core/src/protocols/sumcheck/common.rs
@@ -313,10 +313,7 @@ where
 {
 	degrees
 		.into_iter()
-		.map(|degree| {
-			let domain = evaluation_domain_factory.create_with_infinity(degree + 1, degree >= 2)?;
-			Ok(domain.into())
-		})
+		.map(|degree| Ok(evaluation_domain_factory.create(degree + 1)?.into()))
 		.collect()
 }
 

--- a/crates/core/src/protocols/sumcheck/error.rs
+++ b/crates/core/src/protocols/sumcheck/error.rs
@@ -117,6 +117,8 @@ pub enum VerificationError {
 	NumberOfRounds,
 	#[error("the number of final evaluations must match the number of instances")]
 	NumberOfFinalEvaluations,
+	#[error("the number of reduced multilinear evaluations should conform to the claim shape")]
+	NumberOfMultilinearEvals,
 	#[error("the final batch composite evaluation is incorrect")]
 	IncorrectBatchEvaluation,
 	#[error("the proof contains an incorrect evaluation of the eq indicator")]

--- a/crates/math/src/error.rs
+++ b/crates/math/src/error.rs
@@ -10,8 +10,6 @@ pub enum Error {
 	MatrixNotSquare,
 	#[error("the matrix is singular")]
 	MatrixIsSingular,
-	#[error("domain size needs to be at least one")]
-	DomainSizeAtLeastOne,
 	#[error("domain size is larger than the field")]
 	DomainSizeTooLarge,
 	#[error("the inputted packed values slice had an unexpected length")]


### PR DESCRIPTION
Two leftovers from #114:

1) `verify_sumcheck_outputs` returns proper `VerificationError`s instead of panicking
2) `EvaluationDomainFactory` is back to having `create` method only, all domains of size three and up include the Karatsuba infinity point

Regarding the latter change, most univariate skip code requires explicit construction of the domain from the binary subspace now, which I actually consider an improvement, because univariate skip relies on domain structure and it's good to have this specified explicitly (especially with the potential change to novel polynomial basis representation of the univariatized round polynomials).