### PR TITLE
Modify hasher challenger

### DIFF
--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -492,9 +492,8 @@ where
 		&backend,
 	)?;
 
-	Ok(Proof {
-		transcript: transcript.finalize(),
-	})
+	let (proof, _interactions) = transcript.finalize();
+	Ok(Proof { transcript: proof })
 }
 
 type TypeErasedUnivariateZerocheck<'a, F> = Box<dyn UnivariateZerocheckProver<'a, F> + 'a>;

--- a/crates/core/src/constraint_system/verify.rs
+++ b/crates/core/src/constraint_system/verify.rs
@@ -74,7 +74,7 @@ where
 
 	let Proof { transcript } = proof;
 
-	let mut transcript = VerifierTranscript::<Challenger_>::new(transcript);
+	let mut transcript = VerifierTranscript::<Challenger_>::new(transcript, None);
 	transcript.observe().write_slice(boundaries);
 
 	let merkle_scheme = BinaryMerkleTreeScheme::<_, Hash, _>::new(Compress::default());

--- a/crates/core/src/fiat_shamir/hasher_challenger.rs
+++ b/crates/core/src/fiat_shamir/hasher_challenger.rs
@@ -13,6 +13,7 @@ use super::Challenger;
 /// Challenger type which implements `[Buf]` that has similar functionality as `[CanSample]`
 #[derive(Debug, Default)]
 pub struct HasherSampler<H: Digest> {
+	sample_count: usize,
 	index: usize,
 	buffer: Output<H>,
 	hasher: H,
@@ -21,60 +22,126 @@ pub struct HasherSampler<H: Digest> {
 /// Challenger type which implements `[BufMut]` that has similar functionality as `[CanObserve]`
 #[derive(Debug, Default)]
 pub struct HasherObserver<H: Digest + BlockSizeUser> {
+	observation_count: usize,
 	index: usize,
 	buffer: Block<H>,
 	hasher: H,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Interaction {
+	Observe(usize),
+	Sample(usize),
+}
+
+#[derive(Debug)]
+pub enum ObserverOrSampler<H: Digest + BlockSizeUser> {
+	Observer(HasherObserver<H>),
+	Sampler(HasherSampler<H>),
+}
+
+impl<H: Digest + BlockSizeUser + Default> Default for ObserverOrSampler<H> {
+	fn default() -> Self {
+		Self::Sampler(HasherSampler::default())
+	}
 }
 
 /// Challenger interface over hashes that implement `[Digest]` trait,
 ///
 /// This challenger works over bytes instead of Field elements
 #[derive(Debug)]
-pub enum HasherChallenger<H: Digest + BlockSizeUser> {
-	Observer(HasherObserver<H>),
-	Sampler(HasherSampler<H>),
+pub struct HasherChallenger<H: Digest + BlockSizeUser> {
+	interactions: Vec<Interaction>,
+	observer_or_sampler: ObserverOrSampler<H>,
 }
 
 impl<H> Default for HasherChallenger<H>
 where
-	H: Digest + BlockSizeUser,
+	H: Digest + BlockSizeUser + FixedOutputReset,
 {
 	fn default() -> Self {
-		Self::Observer(HasherObserver {
-			hasher: H::new(),
-			index: 0,
-			buffer: Block::<H>::default(),
-		})
+		Self::new(H::digest([]))
+	}
+}
+
+/// Initialize the `HasherChallenger` with an `initial_digest` that reflects both the statement and the constraint system,
+/// e.g. had by hashing the hash of the statement and the hash of the serialized constraint system.
+impl<H> HasherChallenger<H>
+where
+	H: Digest + BlockSizeUser,
+{
+	fn new(initial_digest: Output<H>) -> Self {
+		let mut hasher = H::new();
+		Digest::update(&mut hasher, &initial_digest);
+
+		Self {
+			interactions: Vec::new(),
+			observer_or_sampler: ObserverOrSampler::Sampler(HasherSampler {
+				sample_count: 0,
+				hasher,
+				index: 0,
+				buffer: initial_digest,
+			}),
+		}
 	}
 }
 
 impl<H: Digest + BlockSizeUser + FixedOutputReset + Default> Challenger for HasherChallenger<H> {
 	/// This returns the inner challenger which implements `[BufMut]`
 	fn observer(&mut self) -> &mut impl BufMut {
-		match self {
-			Self::Observer(observer) => observer,
-			Self::Sampler(sampler) => {
-				*self = Self::Observer(mem::take(sampler).into_observer());
-				match self {
-					Self::Observer(observer) => observer,
-					_ => unreachable!(),
+		let observer = match mem::take(&mut self.observer_or_sampler) {
+			ObserverOrSampler::Observer(observer) => observer,
+			ObserverOrSampler::Sampler(sampler) => {
+				let (observer, sample_count) = sampler.into_observer();
+				if sample_count > 0 {
+					self.interactions.push(Interaction::Sample(sample_count));
 				}
+				observer
 			}
+		};
+		self.observer_or_sampler = ObserverOrSampler::Observer(observer);
+		match &mut self.observer_or_sampler {
+			ObserverOrSampler::Observer(observer) => observer,
+			_ => unreachable!(),
 		}
 	}
 
 	/// This returns the inner challenger which implements `[Buf]`
 	fn sampler(&mut self) -> &mut impl Buf {
-		match self {
-			Self::Sampler(sampler) => sampler,
-			Self::Observer(observer) => {
-				*self = Self::Sampler(mem::take(observer).into_sampler());
-				match self {
-					Self::Sampler(sampler) => sampler,
-					_ => unreachable!(),
+		let sampler = match mem::take(&mut self.observer_or_sampler) {
+			ObserverOrSampler::Observer(observer) => {
+				let (sampler, observation_count) = observer.into_sampler();
+				if observation_count > 0 {
+					self.interactions
+						.push(Interaction::Observe(observation_count));
+				}
+				sampler
+			}
+			ObserverOrSampler::Sampler(sampler) => sampler,
+		};
+		self.observer_or_sampler = ObserverOrSampler::Sampler(sampler);
+		match &mut self.observer_or_sampler {
+			ObserverOrSampler::Sampler(sampler) => sampler,
+			_ => unreachable!(),
+		}
+	}
+
+	fn finalize(mut self) -> Vec<Interaction> {
+		match self.observer_or_sampler {
+			ObserverOrSampler::Observer(observer) => {
+				if observer.observation_count > 0 {
+					self.interactions
+						.push(Interaction::Observe(observer.observation_count))
+				}
+			}
+			ObserverOrSampler::Sampler(sampler) => {
+				if sampler.sample_count > 0 {
+					self.interactions
+						.push(Interaction::Sample(sampler.sample_count))
 				}
 			}
 		}
+		self.interactions
 	}
 }
 
@@ -82,14 +149,14 @@ impl<H> HasherSampler<H>
 where
 	H: Digest + Default + BlockSizeUser,
 {
-	fn into_observer(mut self) -> HasherObserver<H> {
-		Digest::update(&mut self.hasher, self.index.to_le_bytes());
-
-		HasherObserver {
+	fn into_observer(self) -> (HasherObserver<H>, usize) {
+		let observer = HasherObserver {
+			observation_count: 0,
 			hasher: self.hasher,
 			index: 0,
 			buffer: Block::<H>::default(),
-		}
+		};
+		(observer, self.sample_count)
 	}
 }
 
@@ -112,13 +179,16 @@ impl<H> HasherObserver<H>
 where
 	H: Digest + BlockSizeUser + Default,
 {
-	fn into_sampler(mut self) -> HasherSampler<H> {
+	fn into_sampler(mut self) -> (HasherSampler<H>, usize) {
 		self.flush();
-		HasherSampler {
+
+		let sampler = HasherSampler {
+			sample_count: 0,
 			hasher: self.hasher,
 			index: <H as Digest>::output_size(),
 			buffer: Output::<H>::default(),
-		}
+		};
+		(sampler, self.observation_count)
 	}
 }
 
@@ -145,6 +215,8 @@ where
 	}
 
 	fn advance(&mut self, mut cnt: usize) {
+		self.sample_count += cnt;
+
 		// Must handle the case when `cnt` is 0
 		if self.index == <H as Digest>::output_size() {
 			self.fill_buffer();
@@ -171,6 +243,8 @@ where
 	}
 
 	unsafe fn advance_mut(&mut self, mut cnt: usize) {
+		self.observation_count += cnt;
+
 		while cnt > 0 {
 			let remaining = min(<H as BlockSizeUser>::block_size() - self.index, cnt);
 			cnt -= remaining;
@@ -197,35 +271,54 @@ mod tests {
 	#[test]
 	fn test_starting_sampler() {
 		let mut hasher = Groestl256::default();
+		let empty_string_digest = Groestl256::digest([]);
+		Digest::update(&mut hasher, empty_string_digest);
+
 		let mut challenger = HasherChallenger::<Groestl256>::default();
+
+		// first sampling
 		let mut out = [0u8; 8];
 		challenger.sampler().copy_to_slice(&mut out);
 
-		let first_hash_out = hasher.finalize_reset();
-		hasher.update(first_hash_out);
+		let first_hash_out = empty_string_digest;
 
 		assert_eq!(first_hash_out[0..8], out);
 
+		// second sampling
 		let mut out = [0u8; 24];
 		challenger.sampler().copy_to_slice(&mut out);
 		assert_eq!(first_hash_out[8..], out);
 
+		// first observing
 		challenger.observer().put_slice(&[0x48, 0x55]);
-		hasher.update([32, 0, 0, 0, 0, 0, 0, 0]);
 		hasher.update([0x48, 0x55]);
 
+		// third sampling
 		let mut out_after_observe = [0u8; 2];
 		challenger.sampler().copy_to_slice(&mut out_after_observe);
 
 		let second_hash_out = hasher.finalize_reset();
 
 		assert_eq!(out_after_observe, second_hash_out[..2]);
+
+		assert_eq!(
+			challenger.finalize(),
+			vec![
+				Interaction::Sample(32),
+				Interaction::Observe(2),
+				Interaction::Sample(2)
+			]
+		);
 	}
 
 	#[test]
 	fn test_starting_observer() {
 		let mut hasher = Groestl256::default();
+		Digest::update(&mut hasher, Groestl256::digest([]));
+
 		let mut challenger = HasherChallenger::<Groestl256>::default();
+
+		// first observing
 		let mut observable = [0u8; 1019];
 		thread_rng().fill_bytes(&mut observable);
 		challenger.observer().put_slice(&observable[..39]);
@@ -234,6 +327,7 @@ mod tests {
 		challenger.observer().put_slice(&observable[987..]);
 		hasher.update(observable);
 
+		// first sampling
 		let mut out = [0u8; 7];
 		challenger.sampler().copy_to_slice(&mut out);
 
@@ -242,13 +336,13 @@ mod tests {
 
 		assert_eq!(first_hash_out[..7], out);
 
+		// second observing
 		thread_rng().fill_bytes(&mut observable);
 		challenger.observer().put_slice(&observable[..128]);
-		// updated with index of sampler first
-		hasher.update([7, 0, 0, 0, 0, 0, 0, 0]);
 
 		hasher.update(&observable[..128]);
 
+		// second sampling
 		let mut out = [0u8; 32];
 		challenger.sampler().copy_to_slice(&mut out);
 
@@ -257,14 +351,37 @@ mod tests {
 
 		assert_eq!(second_hasher_out[..], out);
 
+		// third observing
 		challenger.observer().put_slice(&observable[128..]);
-		hasher.update([32, 0, 0, 0, 0, 0, 0, 0]);
 		hasher.update(&observable[128..]);
 
+		// third sampling
 		let mut out_again = [0u8; 7];
 		challenger.sampler().copy_to_slice(&mut out_again);
 
 		let final_hasher_out = hasher.finalize_reset();
 		assert_eq!(final_hasher_out[..7], out_again);
+
+		assert_eq!(
+			challenger.finalize(),
+			vec![
+				Interaction::Observe(1019),
+				Interaction::Sample(7),
+				Interaction::Observe(128),
+				Interaction::Sample(32),
+				Interaction::Observe(891),
+				Interaction::Sample(7),
+			]
+		);
+	}
+
+	#[test]
+	fn test_empty_interactions() {
+		let mut challenger = HasherChallenger::<Groestl256>::default();
+		challenger.observer();
+		challenger.observer();
+		challenger.sampler();
+		challenger.observer();
+		assert_eq!(challenger.finalize(), vec![]);
 	}
 }

--- a/crates/core/src/fiat_shamir/mod.rs
+++ b/crates/core/src/fiat_shamir/mod.rs
@@ -4,7 +4,7 @@ mod hasher_challenger;
 mod sampling;
 
 use bytes::{Buf, BufMut};
-pub use hasher_challenger::HasherChallenger;
+pub use hasher_challenger::{HasherChallenger, Interaction};
 pub use sampling::*;
 
 /// A Fiat-Shamir challenger that can observe prover messages and sample verifier randomness.
@@ -14,4 +14,7 @@ pub trait Challenger {
 
 	/// Returns and infinite buffer for writing data that the challenger observes.
 	fn observer(&mut self) -> &mut impl BufMut;
+
+	/// Returns the sequence of interactions
+	fn finalize(self) -> Vec<Interaction>;
 }

--- a/crates/core/src/protocols/evalcheck/tests.rs
+++ b/crates/core/src/protocols/evalcheck/tests.rs
@@ -596,5 +596,5 @@ fn test_evalcheck_serialization() {
 
 	assert_eq!(out_deserialized, second_linear_combination);
 
-	transcript.finalize().unwrap()
+	transcript.finalize().unwrap();
 }

--- a/crates/core/src/protocols/gkr_exp/tests.rs
+++ b/crates/core/src/protocols/gkr_exp/tests.rs
@@ -308,6 +308,6 @@ fn good_proof_verifies() {
 			batch_verify::batch_verify(evaluation_order, &claims, &mut verifier_transcript)
 				.unwrap();
 
-		verifier_transcript.finalize().unwrap()
+		verifier_transcript.finalize().unwrap();
 	}
 }

--- a/crates/core/src/protocols/sumcheck/univariate.rs
+++ b/crates/core/src/protocols/sumcheck/univariate.rs
@@ -573,7 +573,7 @@ mod tests {
 			)
 			.unwrap();
 
-			verifier_proof.finalize().unwrap()
+			verifier_proof.finalize().unwrap();
 		}
 	}
 }

--- a/crates/core/src/transcript/error.rs
+++ b/crates/core/src/transcript/error.rs
@@ -8,4 +8,10 @@ pub enum Error {
 	NotEnoughBytes,
 	#[error("Serialization error: {0}")]
 	Serialization(#[from] binius_utils::SerializationError),
+	#[error("Interaction mismatch at round {round:?}: prover {prover:?}, verifier {verifier:?}")]
+	InteractionMismatch {
+		round: usize,
+		prover: super::Interaction,
+		verifier: super::Interaction,
+	},
 }


### PR DESCRIPTION
I've made two complementary changes to `HasherChallenger`. 

- When switching from sampling to observing, the number of samples that were performed is no longer recorded. Recording the number of samples was proposed by @djadjka such that sampling different numbers of challenges in one round implies different challenges in subsequent rounds. Due to the second change in this PR described next, recording the number of samples is no longer necessary. It also much-simplifies writing the challenger in zCray-lang.
- When initializing the `HasherChallenger`, previously we initialized with the empty hasher, and do so in a `default` method. Now we instead pass in an `initial_digest` to initialize the hasher, and do so in a `new` method. This initial digest will be the digest of some form of hashing both the serialized constraint system, and the statement being proven. For now, without this hashing in place yet, all instantiations of the `HasherChallenger` continue to call `default` rather than `new`, and within `default` I call `new` passing in the digest of the empty string.
Making this change entails initializing the `HasherChallenger` in sampling state rather than observing state.

Here's why the second change safely allows for the first change.
If the verifier performs a different number of samples in one round, that means the constraint system must be different, since there is one deterministic verifier algorithm for each constraint system. If the constraint system is different, that means the `initial_hash` initializing the `HasherChallenger` is different. If the `HasherChallenger` is initialized differently, the challenges sampled from it will be different. Therefore, we have achieved the same effect as @djadjka, enforcing that sampling two different numbers of challenges in one rounds implies different challenges in subsequent rounds.

