### PR TITLE
feat: enable flushes with custom selectors on `m3`

### DIFF
--- a/crates/m3/src/builder/channel.rs
+++ b/crates/m3/src/builder/channel.rs
@@ -10,6 +10,7 @@ pub struct Flush {
 	pub column_indices: Vec<ColumnIndex>,
 	pub channel_id: ChannelId,
 	pub direction: FlushDirection,
+	pub selector: Option<ColumnIndex>,
 }
 
 /// A channel.

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -233,7 +233,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 					.collect::<Vec<_>>();
 
 				// StepDown witness data is populated in WitnessIndex::into_multilinear_extension_index
-				let selector =
+				let step_down =
 					oracles.add_transparent(StepDown::new(n_vars, count * values_per_row)?)?;
 
 				// Translate flushes for the compiled constraint system.
@@ -241,6 +241,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 					column_indices,
 					channel_id,
 					direction,
+					selector,
 				} in flushes
 				{
 					let flush_oracles = column_indices
@@ -251,7 +252,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 						oracles: flush_oracles,
 						channel_id: *channel_id,
 						direction: *direction,
-						selector,
+						selector: selector.unwrap_or(step_down),
 						multiplicity: 1,
 					});
 				}

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -264,6 +264,34 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		self.table.partition_mut(1).push(channel, cols);
 	}
 
+	pub fn pull_selected<FSub>(
+		&mut self,
+		channel: ChannelId,
+		cols: impl IntoIterator<Item = Col<FSub>>,
+		selector: Col<FSub>,
+	) where
+		FSub: TowerField,
+		F: ExtensionField<FSub>,
+	{
+		self.table
+			.partition_mut(1)
+			.pull_selected(channel, cols, selector);
+	}
+
+	pub fn push_selected<FSub>(
+		&mut self,
+		channel: ChannelId,
+		cols: impl IntoIterator<Item = Col<FSub>>,
+		selector: Col<FSub>,
+	) where
+		FSub: TowerField,
+		F: ExtensionField<FSub>,
+	{
+		self.table
+			.partition_mut(1)
+			.push_selected(channel, cols, selector);
+	}
+
 	fn namespaced_name(&self, name: impl ToString) -> String {
 		let name = name.to_string();
 		match &self.namespace {
@@ -334,7 +362,7 @@ impl<F: TowerField> TablePartition<F> {
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
 	{
-		self.flush(channel, FlushDirection::Pull, cols.into_iter().map(upcast_col))
+		self.flush(channel, FlushDirection::Pull, cols.into_iter().map(upcast_col), None)
 	}
 
 	pub fn push<FSub>(&mut self, channel: ChannelId, cols: impl IntoIterator<Item = Col<FSub>>)
@@ -342,7 +370,41 @@ impl<F: TowerField> TablePartition<F> {
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
 	{
-		self.flush(channel, FlushDirection::Push, cols.into_iter().map(upcast_col))
+		self.flush(channel, FlushDirection::Push, cols.into_iter().map(upcast_col), None);
+	}
+
+	pub fn pull_selected<FSub>(
+		&mut self,
+		channel: ChannelId,
+		cols: impl IntoIterator<Item = Col<FSub>>,
+		selector: Col<FSub>,
+	) where
+		FSub: TowerField,
+		F: ExtensionField<FSub>,
+	{
+		self.flush(
+			channel,
+			FlushDirection::Pull,
+			cols.into_iter().map(upcast_col),
+			Some(upcast_col(selector)),
+		)
+	}
+
+	pub fn push_selected<FSub>(
+		&mut self,
+		channel: ChannelId,
+		cols: impl IntoIterator<Item = Col<FSub>>,
+		selector: Col<FSub>,
+	) where
+		FSub: TowerField,
+		F: ExtensionField<FSub>,
+	{
+		self.flush(
+			channel,
+			FlushDirection::Push,
+			cols.into_iter().map(upcast_col),
+			Some(upcast_col(selector)),
+		)
 	}
 
 	fn flush(
@@ -350,6 +412,7 @@ impl<F: TowerField> TablePartition<F> {
 		channel_id: ChannelId,
 		direction: FlushDirection,
 		cols: impl IntoIterator<Item = Col<F>>,
+		selector: Option<Col<F>>,
 	) {
 		let column_indices = cols
 			.into_iter()
@@ -358,10 +421,12 @@ impl<F: TowerField> TablePartition<F> {
 				col.table_index
 			})
 			.collect();
+		let selector = selector.map(|c| c.table_index);
 		self.flushes.push(Flush {
 			column_indices,
 			channel_id,
 			direction,
+			selector,
 		});
 	}
 }


### PR DESCRIPTION
Add `pull_selected` and `push_selected` functions to `TableBuilder` and `TablePartition`, allowing API consumers to provide selectors for flushes.

The `StepDown` selector is used as a fallback in case one is not provided.