### PR TITLE
Save duplication partial evaluation in evalcheck and ring_switch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ thread_local = "1.1.7"
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 trait-set = "0.3.0"
 tracing = "0.1.38"
-tracing-profile = "0.10.1"
+tracing-profile = {path="../tracing-profile"}
 transpose = "0.2.2"
 
 [profile.release]

--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -45,7 +45,7 @@ use crate::{
 		fri::CommitOutput,
 		gkr_exp,
 		gkr_gpa::{self, GrandProductBatchProveOutput, GrandProductWitness, LayerClaim},
-		greedy_evalcheck,
+		greedy_evalcheck::{self, GreedyEvalcheckProveOutput},
 		sumcheck::{
 			self, constraint_set_zerocheck_claim, immediate_switchover_heuristic,
 			prove::{
@@ -445,7 +445,11 @@ where
 		sumcheck::make_eval_claims(zerocheck_oracle_metas, multilinear_zerocheck_output)?;
 
 	// Prove evaluation claims
-	let eval_claims = greedy_evalcheck::prove::<_, _, FDomain<Tower>, _, _>(
+	let GreedyEvalcheckProveOutput {
+		eval_claims,
+		memoized_queries,
+		memoized_partial_evals,
+	} = greedy_evalcheck::prove::<_, _, FDomain<Tower>, _, _>(
 		&mut oracles,
 		&mut witness,
 		[non_zero_prodcheck_eval_claims, flush_eval_claims]
@@ -474,6 +478,8 @@ where
 		&system,
 		&committed_multilins,
 		&mut transcript,
+		memoized_queries,
+		memoized_partial_evals,
 		backend,
 	)?;
 

--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -17,7 +17,8 @@ use super::{
 	evalcheck::{EvalcheckMultilinearClaim, EvalcheckProof},
 	subclaims::{
 		add_composite_sumcheck_to_constraints, calculate_projected_mles, composite_sumcheck_meta,
-		fill_eq_witness_for_composites, MemoizedQueries, ProjectedBivariateMeta,
+		fill_eq_witness_for_composites, memoize_partial_evals, MemoizedQueries,
+		ProjectedBivariateMeta,
 	},
 	EvalPoint, EvalPointOracleIdMap,
 };
@@ -30,7 +31,7 @@ use crate::{
 		packed_sumcheck_meta, process_packed_sumcheck, process_shifted_sumcheck,
 		shifted_sumcheck_meta,
 	},
-	witness::MultilinearExtensionIndex,
+	witness::{MultilinearExtensionIndex, MultilinearWitness},
 };
 
 /// A mutable prover state.
@@ -61,7 +62,8 @@ where
 	projected_bivariate_claims: Vec<EvalcheckMultilinearClaim<F>>,
 
 	new_sumchecks_constraints: Vec<ConstraintSetBuilder<F>>,
-	memoized_queries: MemoizedQueries<PackedType<U, F>, Backend>,
+	pub memoized_queries: MemoizedQueries<PackedType<U, F>, Backend>,
+	pub memoized_partial_evals: EvalPointOracleIdMap<MultilinearWitness<'b, PackedType<U, F>>, F>,
 	backend: &'a Backend,
 }
 
@@ -91,6 +93,7 @@ where
 			claims_without_evals_dedup: EvalPointOracleIdMap::new(),
 			projected_bivariate_claims: Vec::new(),
 			memoized_queries: MemoizedQueries::new(),
+			memoized_partial_evals: EvalPointOracleIdMap::new(),
 			backend,
 			incomplete_proof_claims: EvalPointOracleIdMap::new(),
 		}
@@ -238,11 +241,19 @@ where
 
 		for (claim, meta, projected) in izip!(
 			std::mem::take(&mut self.projected_bivariate_claims),
-			projected_bivariate_metas,
+			projected_bivariate_metas.clone(),
 			projected_mles
 		) {
 			self.process_sumcheck(claim, meta, projected)?;
 		}
+
+		memoize_partial_evals(
+			&projected_bivariate_metas,
+			&self.projected_bivariate_claims,
+			self.oracles,
+			self.witness_index,
+			&mut self.memoized_partial_evals,
+		);
 
 		// Step 4: Find and return the proofs of the original claims.
 
@@ -611,7 +622,7 @@ where
 				eval,
 				self.witness_index,
 				&mut self.new_sumchecks_constraints,
-				projected.expect("projected is required by shifted oracle"),
+				projected,
 			),
 
 			MultilinearPolyVariant::Packed(packed) => process_packed_sumcheck(
@@ -622,7 +633,7 @@ where
 				eval,
 				self.witness_index,
 				&mut self.new_sumchecks_constraints,
-				projected.expect("projected is required by packed oracle"),
+				projected,
 			),
 
 			MultilinearPolyVariant::Composite(composite) => {

--- a/crates/core/src/protocols/evalcheck/subclaims.rs
+++ b/crates/core/src/protocols/evalcheck/subclaims.rs
@@ -24,12 +24,12 @@ use binius_math::{
 use binius_maybe_rayon::prelude::*;
 use binius_utils::bail;
 
-use super::{error::Error, evalcheck::EvalcheckMultilinearClaim};
+use super::{error::Error, evalcheck::EvalcheckMultilinearClaim, EvalPointOracleIdMap};
 use crate::{
 	fiat_shamir::Challenger,
 	oracle::{
 		CompositeMLE, ConstraintSet, ConstraintSetBuilder, Error as OracleError,
-		MultilinearOracleSet, OracleId, Packed, ProjectionVariant, Shifted,
+		MultilinearOracleSet, MultilinearPolyVariant, OracleId, Packed, ProjectionVariant, Shifted,
 	},
 	polynomial::MultivariatePoly,
 	protocols::sumcheck::{
@@ -77,7 +77,7 @@ pub fn process_shifted_sumcheck<U, F>(
 	eval: F,
 	witness_index: &mut MultilinearExtensionIndex<U, F>,
 	constraint_builders: &mut Vec<ConstraintSetBuilder<F>>,
-	projected: MultilinearExtension<PackedType<U, F>>,
+	projected: Option<MultilinearExtension<PackedType<U, F>>>,
 ) -> Result<(), Error>
 where
 	PackedType<U, F>: PackedFieldIndexable,
@@ -137,7 +137,7 @@ pub fn composite_sumcheck_meta<F: TowerField>(
 		multiplier_id: oracles.add_transparent(EqIndPartialEval::new(eval_point.to_vec()))?,
 		inner_id: None,
 		projected_id: None,
-		projected_n_vars: eval_point.len(),
+		projected_n_vars: 0,
 	})
 }
 
@@ -182,7 +182,7 @@ pub fn process_packed_sumcheck<U, F>(
 	eval: F,
 	witness_index: &mut MultilinearExtensionIndex<U, F>,
 	constraint_builders: &mut Vec<ConstraintSetBuilder<F>>,
-	projected: MultilinearExtension<PackedType<U, F>>,
+	projected: Option<MultilinearExtension<PackedType<U, F>>>,
 ) -> Result<(), Error>
 where
 	U: UnderlierType + PackScalar<F>,
@@ -269,7 +269,7 @@ fn process_projected_bivariate_witness<'a, U, F>(
 	meta: ProjectedBivariateMeta,
 	eval_point: &[F],
 	multiplier_witness_ctr: impl FnOnce(&[F]) -> Result<MultilinearWitness<'a, PackedType<U, F>>, Error>,
-	projected: MultilinearExtension<PackedType<U, F>>,
+	projected: Option<MultilinearExtension<PackedType<U, F>>>,
 ) -> Result<(), Error>
 where
 	U: UnderlierType + PackScalar<F>,
@@ -285,7 +285,10 @@ where
 	let projected_eval_point = if let Some(projected_id) = projected_id {
 		witness_index.update_multilin_poly(vec![(
 			projected_id,
-			MLEDirectAdapter::from(projected).upcast_arc_dyn(),
+			MLEDirectAdapter::from(
+				projected.expect("projected should exist if projected_id exist"),
+			)
+			.upcast_arc_dyn(),
 		)])?;
 
 		&eval_point[..projected_n_vars]
@@ -296,7 +299,7 @@ where
 	let m = multiplier_witness_ctr(projected_eval_point)?;
 
 	if !witness_index.has(multiplier_id) {
-		witness_index.update_multilin_poly(vec![(multiplier_id, m)])?;
+		witness_index.update_multilin_poly([(multiplier_id, m)])?;
 	}
 	Ok(())
 }
@@ -328,27 +331,52 @@ where
 	projected_bivariate_claims
 		.par_iter()
 		.zip(metas)
-		.map(|(claim, meta)| {
-			match meta.inner_id {
-				Some(inner_id) => {
-					{
-						// packed / shifted
-						let inner_multilin = witness_index.get_multilin_poly(inner_id)?;
-						let eval_point = &claim.eval_point[meta.projected_n_vars..];
-						let query = memoized_queries
-							.full_query_readonly(eval_point)
-							.ok_or(Error::MissingQuery)?;
-						Ok(Some(
-							backend
-								.evaluate_partial_high(&inner_multilin, query.to_ref())
-								.map_err(Error::from)?,
-						))
-					}
-				}
-				None => Ok(None), // composite
+		.map(|(claim, meta)| match (meta.inner_id, meta.projected_id) {
+			(Some(inner_id), Some(_)) => {
+				let inner_multilin = witness_index.get_multilin_poly(inner_id)?;
+				let eval_point = &claim.eval_point[meta.projected_n_vars..];
+				let query = memoized_queries
+					.full_query_readonly(eval_point)
+					.ok_or(Error::MissingQuery)?;
+				Ok(Some(
+					backend
+						.evaluate_partial_high(&inner_multilin, query.to_ref())
+						.map_err(Error::from)?,
+				))
 			}
+			_ => Ok(None),
 		})
 		.collect::<Result<Vec<Option<_>>, Error>>()
+}
+
+pub fn memoize_partial_evals<'a, U, F>(
+	metas: &[ProjectedBivariateMeta],
+	projected_bivariate_claims: &[EvalcheckMultilinearClaim<F>],
+	oracles: &mut MultilinearOracleSet<F>,
+	witness_index: &MultilinearExtensionIndex<'a, U, F>,
+	memoized_partial_evals: &mut EvalPointOracleIdMap<MultilinearWitness<'a, PackedType<U, F>>, F>,
+) where
+	U: UnderlierType + PackScalar<F>,
+	F: TowerField,
+{
+	projected_bivariate_claims
+		.iter()
+		.zip(metas)
+		.filter(|(_, meta)| meta.inner_id.is_some())
+		.for_each(|(claim, meta)| {
+			let inner_id = meta.inner_id.unwrap();
+			if matches!(oracles.oracle(inner_id).variant, MultilinearPolyVariant::Committed)
+				&& meta.projected_id.is_some()
+			{
+				let eval_point = claim.eval_point[meta.projected_n_vars..].to_vec().into();
+
+				let projected_id = meta.projected_id.expect("checked above");
+
+				let projected = witness_index.get_multilin_poly(projected_id).unwrap();
+
+				memoized_partial_evals.insert(inner_id, eval_point, projected);
+			}
+		});
 }
 
 /// Each composite oracle induces a new eq oracle, for which we need to fill the witness
@@ -377,14 +405,14 @@ where
 	let eq_indicators = dedup_eval_points
 		.into_iter()
 		.map(|eval_point| {
-			let mle = MLEDirectAdapter::from(MultilinearExtension::from_values(
+			let mle = MultilinearExtension::from_values(
 				memoized_queries
 					.full_query_readonly(eval_point)
 					.expect("computed above")
 					.expansion()
 					.to_vec(),
-			)?)
-			.upcast_arc_dyn();
+			)?
+			.specialize_arc_dyn();
 			Ok((eval_point, mle))
 		})
 		.collect::<Result<HashMap<_, _>, Error>>()?;
@@ -464,7 +492,7 @@ impl<P: PackedField, Backend: ComputationBackend> MemoizedQueries<P, Backend> {
 		&mut self,
 		eval_points: &[&[P::Scalar]],
 		backend: &Backend,
-	) -> Result<(), Error> {
+	) -> Result<(), binius_hal::Error> {
 		let deduplicated_eval_points = eval_points.iter().collect::<HashSet<_>>();
 
 		let new_queries = deduplicated_eval_points
@@ -474,9 +502,8 @@ impl<P: PackedField, Backend: ComputationBackend> MemoizedQueries<P, Backend> {
 				backend
 					.multilinear_query::<P>(ep)
 					.map(|res| (ep.to_vec(), res))
-					.map_err(Error::from)
 			})
-			.collect::<Result<Vec<_>, Error>>()?;
+			.collect::<Result<Vec<_>, binius_hal::Error>>()?;
 
 		self.memo.extend(new_queries);
 

--- a/crates/core/src/protocols/greedy_evalcheck/prove.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/prove.rs
@@ -3,7 +3,7 @@
 use binius_field::{
 	as_packed_field::{PackScalar, PackedType},
 	underlier::UnderlierType,
-	ExtensionField, PackedFieldIndexable, TowerField,
+	ExtensionField, Field, PackedField, PackedFieldIndexable, TowerField,
 };
 use binius_hal::ComputationBackend;
 use binius_math::EvaluationDomainFactory;
@@ -14,24 +14,31 @@ use crate::{
 	fiat_shamir::Challenger,
 	oracle::MultilinearOracleSet,
 	protocols::evalcheck::{
-		serialize_evalcheck_proof, subclaims::prove_bivariate_sumchecks_with_switchover,
-		EvalcheckMultilinearClaim, EvalcheckProver,
+		serialize_evalcheck_proof,
+		subclaims::{prove_bivariate_sumchecks_with_switchover, MemoizedQueries},
+		EvalPointOracleIdMap, EvalcheckMultilinearClaim, EvalcheckProver,
 	},
 	transcript::{write_u64, ProverTranscript},
-	witness::MultilinearExtensionIndex,
+	witness::{MultilinearExtensionIndex, MultilinearWitness},
 };
+
+pub struct GreedyEvalcheckProveOutput<'a, F: Field, P: PackedField, Backend: ComputationBackend> {
+	pub eval_claims: Vec<EvalcheckMultilinearClaim<F>>,
+	pub memoized_queries: MemoizedQueries<P, Backend>,
+	pub memoized_partial_evals: EvalPointOracleIdMap<MultilinearWitness<'a, P>, F>,
+}
 
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip_all, name = "greedy_evalcheck::prove")]
-pub fn prove<U, F, DomainField, Challenger_, Backend>(
+pub fn prove<'a, U, F, DomainField, Challenger_, Backend>(
 	oracles: &mut MultilinearOracleSet<F>,
-	witness_index: &mut MultilinearExtensionIndex<U, F>,
+	witness_index: &'a mut MultilinearExtensionIndex<U, F>,
 	claims: impl IntoIterator<Item = EvalcheckMultilinearClaim<F>>,
 	switchover_fn: impl Fn(usize) -> usize + Clone + 'static,
 	transcript: &mut ProverTranscript<Challenger_>,
 	domain_factory: impl EvaluationDomainFactory<DomainField>,
 	backend: &Backend,
-) -> Result<Vec<EvalcheckMultilinearClaim<F>>, Error>
+) -> Result<GreedyEvalcheckProveOutput<'a, F, PackedType<U, F>, Backend>, Error>
 where
 	U: UnderlierType + PackScalar<F> + PackScalar<DomainField>,
 	F: TowerField + ExtensionField<DomainField>,
@@ -82,5 +89,10 @@ where
 		.committed_eval_claims_mut()
 		.drain(..)
 		.collect::<Vec<_>>();
-	Ok(committed_claims)
+
+	Ok(GreedyEvalcheckProveOutput {
+		eval_claims: committed_claims,
+		memoized_queries: evalcheck_prover.memoized_queries,
+		memoized_partial_evals: evalcheck_prover.memoized_partial_evals,
+	})
 }

--- a/crates/core/src/ring_switch/common.rs
+++ b/crates/core/src/ring_switch/common.rs
@@ -193,5 +193,6 @@ fn group_claims_by_eval_point<F: TowerField>(
 			});
 		claim_to_suffix_index.push(suffix_id);
 	}
+
 	Ok((prefix_descs, claim_to_prefix_index, suffix_descs, claim_to_suffix_index))
 }

--- a/crates/core/src/ring_switch/prove.rs
+++ b/crates/core/src/ring_switch/prove.rs
@@ -134,15 +134,13 @@ where
 	Tower: TowerFamily<B128 = F>,
 	Backend: ComputationBackend,
 {
-	let eval_points = system
+	let suffixes = system
 		.suffix_descs
 		.par_iter()
 		.map(|desc| Arc::as_ref(&desc.suffix))
 		.collect::<Vec<_>>();
 
-	memoized_queries
-		.memoize_query_par(&eval_points, backend)
-		.unwrap();
+	memoized_queries.memoize_query_par(&suffixes, backend)?;
 
 	let tensor_elems = system
 		.sumcheck_claim_descs

--- a/crates/core/src/ring_switch/tests.rs
+++ b/crates/core/src/ring_switch/tests.rs
@@ -27,7 +27,10 @@ use crate::{
 	merkle_tree::{BinaryMerkleTreeProver, MerkleTreeProver, MerkleTreeScheme},
 	oracle::{MultilinearOracleSet, MultilinearPolyVariant, OracleId},
 	piop,
-	protocols::{evalcheck::EvalcheckMultilinearClaim, fri::CommitOutput},
+	protocols::{
+		evalcheck::{subclaims::MemoizedQueries, EvalPointOracleIdMap, EvalcheckMultilinearClaim},
+		fri::CommitOutput,
+	},
 	ring_switch::prove::ReducedWitness,
 	tower::{CanonicalTowerFamily, PackedTop, TowerFamily, TowerUnderlier},
 	transcript::ProverTranscript,
@@ -240,7 +243,15 @@ fn test_prove_verify_claim_reduction_with_naive_validation() {
 		let ReducedWitness {
 			transparents: transparent_witnesses,
 			sumcheck_claims: prover_sumcheck_claims,
-		} = prove::<_, _, _, Tower, _, _>(&system, &witnesses, &mut proof, &backend).unwrap();
+		} = prove::<_, _, _, Tower, _, _>(
+			&system,
+			&witnesses,
+			&mut proof,
+			MemoizedQueries::new(),
+			EvalPointOracleIdMap::new(),
+			&backend,
+		)
+		.unwrap();
 
 		let mut proof = proof.into_verifier();
 		let ReducedClaim {
@@ -313,7 +324,15 @@ fn commit_prove_verify_piop<U, Tower, MTScheme, MTProver>(
 	let ReducedWitness {
 		transparents: transparent_multilins,
 		sumcheck_claims,
-	} = prove::<_, _, _, Tower, _, _>(&system, &committed_multilins, &mut proof, &backend).unwrap();
+	} = prove::<_, _, _, Tower, _, _>(
+		&system,
+		&committed_multilins,
+		&mut proof,
+		MemoizedQueries::new(),
+		EvalPointOracleIdMap::new(),
+		&backend,
+	)
+	.unwrap();
 
 	let domain_factory = DefaultEvaluationDomainFactory::<Tower::B8>::default();
 	piop::prove(


### PR DESCRIPTION
Both evalcheck and ring_switch may perform the same evaluate_partial_high operation on multilinear polynomial witnesses. In evalcheck, this occurs when computing projections. The multilinears then get stored in a memoization map to make sure they are not recomputed in evalcheck. Then in ring_switch, the prover computes the partial high evaluations to compute the tensor algebra elements sent. The prover save the computation of the projection, if available, so it is not recomputed during ring switching.