### PR TITLE
Introduce a struct for a batch of rows of the same length

### DIFF
--- a/crates/core/benches/composition_poly.rs
+++ b/crates/core/benches/composition_poly.rs
@@ -8,7 +8,7 @@ use binius_field::{
 	PackedField,
 };
 use binius_macros::{arith_circuit_poly, composition_poly};
-use binius_math::{ArithExpr as Expr, CompositionPoly};
+use binius_math::{ArithExpr as Expr, CompositionPoly, RowsBatchRef};
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use rand::{thread_rng, RngCore};
 
@@ -48,14 +48,17 @@ fn benchmark_evaluate(c: &mut Criterion) {
 
 	let query128x1b = generate_input_data(&mut rng);
 	let query128x1b = query128x1b.iter().map(|q| q.as_slice()).collect::<Vec<_>>();
+	let batch_query128x1b = RowsBatchRef::new_from_data(&query128x1b, BATCH_SIZE);
 	let mut results128x1b = vec![PackedBinaryField128x1b::zero(); BATCH_SIZE];
 
 	let query16x8b = generate_input_data(&mut rng);
 	let query16x8b = query16x8b.iter().map(|q| q.as_slice()).collect::<Vec<_>>();
+	let batch_query16x8b = RowsBatchRef::new_from_data(&query16x8b, BATCH_SIZE);
 	let mut results16x8b = vec![PackedBinaryField16x8b::zero(); BATCH_SIZE];
 
 	let query1x128b = generate_input_data(&mut rng);
 	let query1x128b = query1x128b.iter().map(|q| q.as_slice()).collect::<Vec<_>>();
+	let batch_query1x128b = RowsBatchRef::new_from_data(&query1x128b, BATCH_SIZE);
 	let mut results1x128b = vec![PackedBinaryField1x128b::zero(); BATCH_SIZE];
 
 	let arith_circuit_poly = ArithCircuitPoly::new(
@@ -125,21 +128,21 @@ fn benchmark_evaluate(c: &mut Criterion) {
 	group.bench_function("arith_circuit_poly_128x1b", |bench| {
 		bench.iter(|| {
 			arith_circuit_poly
-				.batch_evaluate(&query128x1b, &mut results128x1b)
+				.batch_evaluate(&batch_query128x1b, &mut results128x1b)
 				.unwrap();
 		});
 	});
 	group.bench_function("arith_circuit_poly_cached_128x1b", |bench| {
 		bench.iter(|| {
 			arith_circuit_poly_cached
-				.batch_evaluate(&query128x1b, &mut results128x1b)
+				.batch_evaluate(&batch_query128x1b, &mut results128x1b)
 				.unwrap();
 		});
 	});
 	group.bench_function("composition_poly_128x1b", |bench| {
 		let poly = composition_poly!([h4, h5, h6, ch] = (h4 * h5 + (1 - h4) * h6) - ch);
 		bench.iter(|| {
-			poly.batch_evaluate(&query128x1b, &mut results128x1b)
+			poly.batch_evaluate(&batch_query128x1b, &mut results128x1b)
 				.unwrap();
 		});
 	});
@@ -147,42 +150,43 @@ fn benchmark_evaluate(c: &mut Criterion) {
 	group.bench_function("arith_circuit_poly_16x8b", |bench| {
 		bench.iter(|| {
 			arith_circuit_poly
-				.batch_evaluate(&query16x8b, &mut results16x8b)
+				.batch_evaluate(&batch_query16x8b, &mut results16x8b)
 				.unwrap();
 		});
 	});
 	group.bench_function("arith_circuit_poly_cached_16x8b", |bench| {
 		bench.iter(|| {
 			arith_circuit_poly_cached
-				.batch_evaluate(&query16x8b, &mut results16x8b)
+				.batch_evaluate(&batch_query16x8b, &mut results16x8b)
 				.unwrap();
 		});
 	});
 	group.bench_function("composition_poly_16x8b", |bench| {
 		let poly = composition_poly!([h4, h5, h6, ch] = (h4 * h5 + (1 - h4) * h6) - ch);
 		bench.iter(|| {
-			poly.batch_evaluate(&query16x8b, &mut results16x8b).unwrap();
+			poly.batch_evaluate(&batch_query16x8b, &mut results16x8b)
+				.unwrap();
 		});
 	});
 
 	group.bench_function("arith_circuit_poly_1x128b", |bench| {
 		bench.iter(|| {
 			arith_circuit_poly
-				.batch_evaluate(&query1x128b, &mut results1x128b)
+				.batch_evaluate(&batch_query1x128b, &mut results1x128b)
 				.unwrap();
 		});
 	});
 	group.bench_function("arith_circuit_poly_cached_1x128b", |bench| {
 		bench.iter(|| {
 			arith_circuit_poly_cached
-				.batch_evaluate(&query1x128b, &mut results1x128b)
+				.batch_evaluate(&batch_query1x128b, &mut results1x128b)
 				.unwrap();
 		});
 	});
 	group.bench_function("composition_poly_1x128b", |bench| {
 		let poly = composition_poly!([h4, h5, h6, ch] = (h4 * h5 + (1 - h4) * h6) - ch);
 		bench.iter(|| {
-			poly.batch_evaluate(&query1x128b, &mut results1x128b)
+			poly.batch_evaluate(&batch_query1x128b, &mut results1x128b)
 				.unwrap();
 		});
 	});

--- a/crates/core/benches/composition_poly.rs
+++ b/crates/core/benches/composition_poly.rs
@@ -48,17 +48,17 @@ fn benchmark_evaluate(c: &mut Criterion) {
 
 	let query128x1b = generate_input_data(&mut rng);
 	let query128x1b = query128x1b.iter().map(|q| q.as_slice()).collect::<Vec<_>>();
-	let batch_query128x1b = RowsBatchRef::new_from_data(&query128x1b, BATCH_SIZE);
+	let batch_query128x1b = RowsBatchRef::new(&query128x1b, BATCH_SIZE);
 	let mut results128x1b = vec![PackedBinaryField128x1b::zero(); BATCH_SIZE];
 
 	let query16x8b = generate_input_data(&mut rng);
 	let query16x8b = query16x8b.iter().map(|q| q.as_slice()).collect::<Vec<_>>();
-	let batch_query16x8b = RowsBatchRef::new_from_data(&query16x8b, BATCH_SIZE);
+	let batch_query16x8b = RowsBatchRef::new(&query16x8b, BATCH_SIZE);
 	let mut results16x8b = vec![PackedBinaryField16x8b::zero(); BATCH_SIZE];
 
 	let query1x128b = generate_input_data(&mut rng);
 	let query1x128b = query1x128b.iter().map(|q| q.as_slice()).collect::<Vec<_>>();
-	let batch_query1x128b = RowsBatchRef::new_from_data(&query1x128b, BATCH_SIZE);
+	let batch_query1x128b = RowsBatchRef::new(&query1x128b, BATCH_SIZE);
 	let mut results1x128b = vec![PackedBinaryField1x128b::zero(); BATCH_SIZE];
 
 	let arith_circuit_poly = ArithCircuitPoly::new(

--- a/crates/core/src/composition/index.rs
+++ b/crates/core/src/composition/index.rs
@@ -88,9 +88,9 @@ impl<P: PackedField, C: CompositionPoly<P>, const N: usize> CompositionPoly<P>
 		batch_query: &RowsBatchRef<P>,
 		evals: &mut [P],
 	) -> Result<(), binius_math::Error> {
-		let batch_subquery = batch_query.map(&self.indices);
+		let batch_subquery = batch_query.map(self.indices);
 		self.composition
-			.batch_evaluate(&batch_subquery.as_ref(), evals)
+			.batch_evaluate(&batch_subquery.get_ref(), evals)
 	}
 }
 

--- a/crates/core/src/composition/index.rs
+++ b/crates/core/src/composition/index.rs
@@ -3,7 +3,7 @@
 use std::fmt::Debug;
 
 use binius_field::{Field, PackedField};
-use binius_math::{ArithExpr, CompositionPoly};
+use binius_math::{ArithExpr, CompositionPoly, RowsBatchRef};
 use binius_utils::bail;
 
 use crate::polynomial::Error;
@@ -85,12 +85,12 @@ impl<P: PackedField, C: CompositionPoly<P>, const N: usize> CompositionPoly<P>
 
 	fn batch_evaluate(
 		&self,
-		batch_query: &[&[P]],
+		batch_query: &RowsBatchRef<P>,
 		evals: &mut [P],
 	) -> Result<(), binius_math::Error> {
-		let batch_subquery = self.indices.map(|index| batch_query[index]);
+		let batch_subquery = batch_query.map(&self.indices);
 		self.composition
-			.batch_evaluate(batch_subquery.as_slice(), evals)
+			.batch_evaluate(&batch_subquery.as_ref(), evals)
 	}
 }
 

--- a/crates/core/src/polynomial/arith_circuit.rs
+++ b/crates/core/src/polynomial/arith_circuit.rs
@@ -494,7 +494,7 @@ mod tests {
 
 		let mut evals = [P::default()];
 		typed_circuit
-			.batch_evaluate(&RowsBatchRef::new(&vec![], 1), &mut evals)
+			.batch_evaluate(&RowsBatchRef::new(&[], 1), &mut evals)
 			.unwrap();
 		assert_eq!(evals, [P::broadcast(F::new(123).into())]);
 	}
@@ -521,10 +521,10 @@ mod tests {
 		);
 
 		let mut evals = [P::default()];
-		let batch_query = vec![[P::broadcast(F::new(123).into())]; 1];
+		let batch_query = [[P::broadcast(F::new(123).into())]; 1];
 		let batch_query = RowsBatch::new_from_iter(batch_query.iter().map(|x| x.as_slice()), 1);
 		typed_circuit
-			.batch_evaluate(&batch_query.as_ref(), &mut evals)
+			.batch_evaluate(&batch_query.get_ref(), &mut evals)
 			.unwrap();
 		assert_eq!(evals, [P::broadcast(F::new(123).into())]);
 	}
@@ -653,7 +653,7 @@ mod tests {
 		];
 		let batch_query = RowsBatch::new_from_iter(batch_query.iter().map(|x| x.as_slice()), 3);
 
-		CompositionPoly::batch_evaluate(&circuit, &batch_query.as_ref(), &mut batch_result)
+		CompositionPoly::batch_evaluate(&circuit, &batch_query.get_ref(), &mut batch_result)
 			.unwrap();
 		assert_eq!(&batch_result, &[expected1, expected2, expected3]);
 	}
@@ -713,7 +713,7 @@ mod tests {
 			&[query1[1], query2[1], query3[1]],
 		];
 		let batch_query = RowsBatch::new_from_iter(batch_query.iter().map(|x| x.as_slice()), 3);
-		CompositionPoly::batch_evaluate(&circuit, &batch_query.as_ref(), &mut batch_result)
+		CompositionPoly::batch_evaluate(&circuit, &batch_query.get_ref(), &mut batch_result)
 			.unwrap();
 		assert_eq!(&batch_result, &[expected1, expected2, expected3]);
 	}

--- a/crates/core/src/polynomial/arith_circuit.rs
+++ b/crates/core/src/polynomial/arith_circuit.rs
@@ -294,10 +294,10 @@ impl<F: TowerField, P: PackedField<Scalar: ExtensionField<F>>> CompositionPoly<P
 
 	fn batch_evaluate(&self, batch_query: &RowsBatchRef<P>, evals: &mut [P]) -> Result<(), Error> {
 		let row_len = evals.len();
-		if batch_query.n_cols() != row_len {
+		if batch_query.row_len() != row_len {
 			bail!(Error::BatchEvaluateSizeMismatch {
 				expected: row_len,
-				actual: batch_query.n_cols(),
+				actual: batch_query.row_len(),
 			});
 		}
 
@@ -494,7 +494,7 @@ mod tests {
 
 		let mut evals = [P::default()];
 		typed_circuit
-			.batch_evaluate(&RowsBatchRef::new_from_data(&vec![], 1), &mut evals)
+			.batch_evaluate(&RowsBatchRef::new(&vec![], 1), &mut evals)
 			.unwrap();
 		assert_eq!(evals, [P::broadcast(F::new(123).into())]);
 	}

--- a/crates/core/src/polynomial/arith_circuit.rs
+++ b/crates/core/src/polynomial/arith_circuit.rs
@@ -86,8 +86,8 @@ impl CircuitNode {
 	/// Return either the input column or the slice with evaluations at one of the previous steps.
 	/// This method is used for batch evaluation.
 	fn get_sparse_chunk<'a, P: PackedField>(
-		&self,
-		inputs: &RowsBatchRef<'_, 'a, P>,
+		&'a self,
+		inputs: &'a RowsBatchRef<'a, P>,
 		evals: &'a [P],
 		row_len: usize,
 	) -> &'a [P] {

--- a/crates/core/src/protocols/sumcheck/prove/eq_ind.rs
+++ b/crates/core/src/protocols/sumcheck/prove/eq_ind.rs
@@ -5,7 +5,8 @@ use std::{marker::PhantomData, ops::Range};
 use binius_field::{util::eq, ExtensionField, Field, PackedExtension, PackedField, TowerField};
 use binius_hal::{make_portable_backend, ComputationBackend, Error as HalError, SumcheckEvaluator};
 use binius_math::{
-	CompositionPoly, EvaluationDomainFactory, EvaluationOrder, InterpolationDomain, MultilinearPoly,
+	CompositionPoly, EvaluationDomainFactory, EvaluationOrder, InterpolationDomain,
+	MultilinearPoly, RowsBatchRef,
 };
 use binius_maybe_rayon::prelude::*;
 use binius_utils::bail;
@@ -438,9 +439,9 @@ where
 		subcube_vars: usize,
 		subcube_index: usize,
 		is_infinity_point: bool,
-		batch_query: &[&[P]],
+		batch_query: &RowsBatchRef<P>,
 	) -> P {
-		let row_len = batch_query.first().map_or(0, |row| row.len());
+		let row_len = batch_query.n_cols();
 
 		stackalloc_with_default(row_len, |evals| {
 			if is_infinity_point {

--- a/crates/core/src/protocols/sumcheck/prove/eq_ind.rs
+++ b/crates/core/src/protocols/sumcheck/prove/eq_ind.rs
@@ -441,7 +441,7 @@ where
 		is_infinity_point: bool,
 		batch_query: &RowsBatchRef<P>,
 	) -> P {
-		let row_len = batch_query.n_cols();
+		let row_len = batch_query.row_len();
 
 		stackalloc_with_default(row_len, |evals| {
 			if is_infinity_point {

--- a/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
@@ -245,7 +245,7 @@ where
 		is_infinity_point: bool,
 		batch_query: &RowsBatchRef<P>,
 	) -> P {
-		let row_len = batch_query.n_cols();
+		let row_len = batch_query.row_len();
 
 		stackalloc_with_default(row_len, |evals| {
 			if is_infinity_point {

--- a/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
@@ -5,7 +5,8 @@ use std::{marker::PhantomData, ops::Range};
 use binius_field::{ExtensionField, Field, PackedExtension, PackedField, TowerField};
 use binius_hal::{ComputationBackend, SumcheckEvaluator};
 use binius_math::{
-	CompositionPoly, EvaluationDomainFactory, EvaluationOrder, InterpolationDomain, MultilinearPoly,
+	CompositionPoly, EvaluationDomainFactory, EvaluationOrder, InterpolationDomain,
+	MultilinearPoly, RowsBatchRef,
 };
 use binius_maybe_rayon::prelude::*;
 use binius_utils::bail;
@@ -242,9 +243,9 @@ where
 		_subcube_vars: usize,
 		_subcube_index: usize,
 		is_infinity_point: bool,
-		batch_query: &[&[P]],
+		batch_query: &RowsBatchRef<P>,
 	) -> P {
-		let row_len = batch_query.first().map_or(0, |row| row.len());
+		let row_len = batch_query.n_cols();
 
 		stackalloc_with_default(row_len, |evals| {
 			if is_infinity_point {

--- a/crates/core/src/protocols/sumcheck/prove/univariate.rs
+++ b/crates/core/src/protocols/sumcheck/prove/univariate.rs
@@ -507,8 +507,7 @@ where
 						.map(|evals| &evals[..pbase_prefix_len]);
 
 					stackalloc_with_iter(n_multilinears, extrapolated_evals_iter, |batch_query| {
-						let batch_query =
-							RowsBatchRef::new_from_data(batch_query, pbase_prefix_len);
+						let batch_query = RowsBatchRef::new(batch_query, pbase_prefix_len);
 
 						// Evaluate the small field composition
 						composition.batch_evaluate(

--- a/crates/core/src/protocols/sumcheck/prove/univariate.rs
+++ b/crates/core/src/protocols/sumcheck/prove/univariate.rs
@@ -9,7 +9,7 @@ use binius_field::{
 use binius_hal::{ComputationBackend, ComputationBackendExt};
 use binius_math::{
 	BinarySubspace, CompositionPoly, Error as MathError, EvaluationDomain, EvaluationOrder,
-	IsomorphicEvaluationDomainFactory, MLEDirectAdapter, MultilinearPoly,
+	IsomorphicEvaluationDomainFactory, MLEDirectAdapter, MultilinearPoly, RowsBatchRef,
 };
 use binius_maybe_rayon::prelude::*;
 use binius_ntt::{AdditiveNTT, OddInterpolate, SingleThreadedNTT};
@@ -507,9 +507,14 @@ where
 						.map(|evals| &evals[..pbase_prefix_len]);
 
 					stackalloc_with_iter(n_multilinears, extrapolated_evals_iter, |batch_query| {
+						let batch_query =
+							RowsBatchRef::new_from_data(batch_query, pbase_prefix_len);
+
 						// Evaluate the small field composition
-						composition
-							.batch_evaluate(batch_query, &mut composition_evals[..pbase_prefix_len])
+						composition.batch_evaluate(
+							&batch_query,
+							&mut composition_evals[..pbase_prefix_len],
+						)
 					})?;
 
 					// Accumulate round evals and multiply by the constant part of the

--- a/crates/hal/src/sumcheck_evaluator.rs
+++ b/crates/hal/src/sumcheck_evaluator.rs
@@ -3,6 +3,7 @@
 use std::ops::Range;
 
 use binius_field::{Field, PackedField};
+use binius_math::RowsBatchRef;
 
 /// Evaluations of a polynomial at a set of evaluation points.
 #[derive(Debug, Clone)]
@@ -27,7 +28,7 @@ pub trait SumcheckEvaluator<P: PackedField, Composition> {
 		subcube_vars: usize,
 		subcube_index: usize,
 		is_infinity_point: bool,
-		batch_query: &[&[P]],
+		batch_query: &RowsBatchRef<P>,
 	) -> P;
 
 	/// Returns the composition evaluated by this object.

--- a/crates/hal/src/sumcheck_round_calculator.rs
+++ b/crates/hal/src/sumcheck_round_calculator.rs
@@ -225,7 +225,7 @@ where
 							});
 
 					stackalloc_with_iter(n_multilinears, evals_z_iter, |evals_z| {
-						let evals_z = RowsBatchRef::new_from_data(evals_z, evals_z[0].len());
+						let evals_z = RowsBatchRef::new(evals_z, evals_z[0].len());
 
 						for (evaluator, round_evals) in
 							iter::zip(evaluators, round_evals.iter_mut())

--- a/crates/hal/src/sumcheck_round_calculator.rs
+++ b/crates/hal/src/sumcheck_round_calculator.rs
@@ -9,7 +9,7 @@ use std::iter;
 use binius_field::{Field, PackedExtension, PackedField, PackedSubfield};
 use binius_math::{
 	extrapolate_lines, CompositionPoly, EvaluationOrder, MLEDirectAdapter, MultilinearExtension,
-	MultilinearPoly, MultilinearQuery, MultilinearQueryRef,
+	MultilinearPoly, MultilinearQuery, MultilinearQueryRef, RowsBatchRef,
 };
 use binius_maybe_rayon::prelude::*;
 use binius_utils::bail;
@@ -225,6 +225,8 @@ where
 							});
 
 					stackalloc_with_iter(n_multilinears, evals_z_iter, |evals_z| {
+						let evals_z = RowsBatchRef::new_from_data(evals_z, evals_z[0].len());
+
 						for (evaluator, round_evals) in
 							iter::zip(evaluators, round_evals.iter_mut())
 						{
@@ -238,7 +240,7 @@ where
 									subcube_vars,
 									subcube_index,
 									is_infinity_point,
-									evals_z,
+									&evals_z,
 								);
 						}
 					});

--- a/crates/hal/src/sumcheck_round_calculator.rs
+++ b/crates/hal/src/sumcheck_round_calculator.rs
@@ -224,8 +224,9 @@ where
 								}
 							});
 
+					let row_len = 1 << subcube_vars.saturating_sub(P::LOG_WIDTH);
 					stackalloc_with_iter(n_multilinears, evals_z_iter, |evals_z| {
-						let evals_z = RowsBatchRef::new(evals_z, evals_z[0].len());
+						let evals_z = RowsBatchRef::new(evals_z, row_len);
 
 						for (evaluator, round_evals) in
 							iter::zip(evaluators, round_evals.iter_mut())

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -562,7 +562,7 @@ impl<'alloc, U: UnderlierType, F: TowerField> TableWitnessIndexSegment<'alloc, U
 			.iter()
 			.map(|col| col.as_ref().map(|col_ref| &**col_ref).unwrap_or(&dummy_col))
 			.collect::<Vec<_>>();
-		let cols = RowsBatchRef::new_from_data(&cols, 1 << log_packed_elems);
+		let cols = RowsBatchRef::new(&cols, 1 << log_packed_elems);
 
 		// REVIEW: This could be inefficient with very large segments because batch evaluation
 		// allocates more memory, proportional to the size of the segment. Because of how segments

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -17,7 +17,7 @@ use binius_field::{
 	underlier::{UnderlierType, WithUnderlier},
 	ExtensionField, PackedField, TowerField,
 };
-use binius_math::{CompositionPoly, MultilinearExtension, MultilinearPoly};
+use binius_math::{CompositionPoly, MultilinearExtension, MultilinearPoly, RowsBatchRef};
 use binius_maybe_rayon::prelude::*;
 use binius_utils::checked_arithmetics::{checked_log_2, log2_ceil_usize};
 use bytemuck::{must_cast_slice, must_cast_slice_mut, zeroed_vec, Pod};
@@ -562,6 +562,7 @@ impl<'alloc, U: UnderlierType, F: TowerField> TableWitnessIndexSegment<'alloc, U
 			.iter()
 			.map(|col| col.as_ref().map(|col_ref| &**col_ref).unwrap_or(&dummy_col))
 			.collect::<Vec<_>>();
+		let cols = RowsBatchRef::new_from_data(&cols, 1 << log_packed_elems);
 
 		// REVIEW: This could be inefficient with very large segments because batch evaluation
 		// allocates more memory, proportional to the size of the segment. Because of how segments

--- a/crates/macros/src/composition_poly.rs
+++ b/crates/macros/src/composition_poly.rs
@@ -75,7 +75,7 @@ impl ToTokens for CompositionPolyItem {
 					batch_query: &binius_math::RowsBatchRef<P>,
 					evals: &mut [P],
 				) -> Result<(), binius_math::Error> {
-					if batch_query.n_cols() != #n_vars {
+					if batch_query.row_len() != #n_vars {
 						return Err(binius_math::Error::IncorrectQuerySize { expected: #n_vars });
 					}
 

--- a/crates/macros/src/composition_poly.rs
+++ b/crates/macros/src/composition_poly.rs
@@ -35,7 +35,7 @@ impl ToTokens for CompositionPolyItem {
 		subst_vars(
 			&mut eval_batch,
 			vars,
-			&|i| parse_quote!(unsafe {*batch_query.get_unchecked(#i).get_unchecked(row)}),
+			&|i| parse_quote!(unsafe {*batch_query.rows().get_unchecked(#i).get_unchecked(row)}),
 		)
 		.expect("Failed to substitute vars");
 
@@ -72,25 +72,14 @@ impl ToTokens for CompositionPolyItem {
 
 				fn batch_evaluate(
 					&self,
-					batch_query: &[&[P]],
+					batch_query: &binius_math::RowsBatchRef<P>,
 					evals: &mut [P],
 				) -> Result<(), binius_math::Error> {
-					if batch_query.len() != #n_vars {
+					if batch_query.n_cols() != #n_vars {
 						return Err(binius_math::Error::IncorrectQuerySize { expected: #n_vars });
 					}
 
-					let row_len = evals.len();
-					for (i, row) in batch_query.iter().enumerate() {
-						if row.len() != row_len {
-							return Err(binius_math::Error::BatchEvaluateSizeMismatch {
-								index: i,
-								expected: row_len,
-								actual: row.len(),
-							});
-						}
-					}
-
-					for row in 0..batch_query[0].len() {
+					for row in 0..batch_query.rows()[0].len() {
 						evals[row] = #eval_batch;
 					}
 

--- a/crates/macros/tests/arithmetic_circuit.rs
+++ b/crates/macros/tests/arithmetic_circuit.rs
@@ -40,7 +40,7 @@ macro_rules! test_arithmetic_poly {
                 }
 
                 let mut batch_result = vec![<$packed>::zero(); BATCH_SIZE];
-                circuit.batch_evaluate(&RowsBatchRef::new_from_data(&query_data, BATCH_SIZE), &mut batch_result).unwrap();
+                circuit.batch_evaluate(&RowsBatchRef::new(&query_data, BATCH_SIZE), &mut batch_result).unwrap();
                 assert_eq!(&batch_result, &expected);
             }
         }

--- a/crates/macros/tests/arithmetic_circuit.rs
+++ b/crates/macros/tests/arithmetic_circuit.rs
@@ -2,7 +2,7 @@
 
 use binius_field::*;
 use binius_macros::arith_circuit_poly;
-use binius_math::CompositionPoly;
+use binius_math::{CompositionPoly, RowsBatchRef};
 use paste::paste;
 use rand::{rngs::StdRng, SeedableRng};
 
@@ -40,7 +40,7 @@ macro_rules! test_arithmetic_poly {
                 }
 
                 let mut batch_result = vec![<$packed>::zero(); BATCH_SIZE];
-                circuit.batch_evaluate(&query_data, &mut batch_result).unwrap();
+                circuit.batch_evaluate(&RowsBatchRef::new_from_data(&query_data, BATCH_SIZE), &mut batch_result).unwrap();
                 assert_eq!(&batch_result, &expected);
             }
         }

--- a/crates/math/src/composition_poly.rs
+++ b/crates/math/src/composition_poly.rs
@@ -48,10 +48,10 @@ where
 	/// This method has a default implementation.
 	fn batch_evaluate(&self, batch_query: &RowsBatchRef<P>, evals: &mut [P]) -> Result<(), Error> {
 		let row_len = evals.len();
-		if batch_query.n_cols() != row_len {
+		if batch_query.row_len() != row_len {
 			bail!(Error::BatchEvaluateSizeMismatch {
 				expected: row_len,
-				actual: batch_query.n_cols(),
+				actual: batch_query.row_len(),
 			});
 		}
 

--- a/crates/math/src/composition_poly.rs
+++ b/crates/math/src/composition_poly.rs
@@ -7,7 +7,7 @@ use binius_field::PackedField;
 use binius_utils::bail;
 use stackalloc::stackalloc_with_default;
 
-use crate::{ArithExpr, Error};
+use crate::{ArithExpr, Error, RowsBatchRef};
 
 /// A multivariate polynomial that is used as a composition of several multilinear polynomials.
 #[auto_impl(Arc, &)]
@@ -46,21 +46,18 @@ where
 	/// - no crosstalk between evaluations
 	///
 	/// This method has a default implementation.
-	fn batch_evaluate(&self, batch_query: &[&[P]], evals: &mut [P]) -> Result<(), Error> {
+	fn batch_evaluate(&self, batch_query: &RowsBatchRef<P>, evals: &mut [P]) -> Result<(), Error> {
 		let row_len = evals.len();
-		for (i, row) in batch_query.iter().enumerate() {
-			if row.len() != row_len {
-				bail!(Error::BatchEvaluateSizeMismatch {
-					index: i,
-					expected: row_len,
-					actual: row.len(),
-				});
-			}
+		if batch_query.n_cols() != row_len {
+			bail!(Error::BatchEvaluateSizeMismatch {
+				expected: row_len,
+				actual: batch_query.n_cols(),
+			});
 		}
 
-		stackalloc_with_default(batch_query.len(), |query| {
+		stackalloc_with_default(batch_query.n_rows(), |query| {
 			for (column, eval) in evals.iter_mut().enumerate() {
-				for (query_elem, batch_query_row) in query.iter_mut().zip(batch_query) {
+				for (query_elem, batch_query_row) in query.iter_mut().zip(batch_query.iter()) {
 					*query_elem = batch_query_row[column];
 				}
 

--- a/crates/math/src/error.rs
+++ b/crates/math/src/error.rs
@@ -23,14 +23,10 @@ pub enum Error {
 	#[error("{0}")]
 	FieldError(#[from] binius_field::Error),
 	#[error(
-		"batch evaluation expects all input slices to have the same length as the output slice;
-		at index {index}, expected length {expected}, got length {actual}"
+		"batch evaluation expects input slices to have the same length as the output slice;
+		expected length {expected}, got length {actual}"
 	)]
-	BatchEvaluateSizeMismatch {
-		index: usize,
-		expected: usize,
-		actual: usize,
-	},
+	BatchEvaluateSizeMismatch { expected: usize, actual: usize },
 	#[error("the query must have size {expected}")]
 	IncorrectQuerySize { expected: usize },
 	#[error("Polynomial error: {0}")]

--- a/crates/math/src/lib.rs
+++ b/crates/math/src/lib.rs
@@ -26,6 +26,7 @@ mod multilinear_extension;
 mod multilinear_query;
 mod packing_deref;
 mod piecewise_multilinear;
+mod rows_batch;
 mod tensor_prod_eq_ind;
 mod univariate;
 
@@ -42,5 +43,6 @@ pub use multilinear_extension::*;
 pub use multilinear_query::*;
 pub use packing_deref::*;
 pub use piecewise_multilinear::*;
+pub use rows_batch::*;
 pub use tensor_prod_eq_ind::*;
 pub use univariate::*;

--- a/crates/math/src/rows_batch.rs
+++ b/crates/math/src/rows_batch.rs
@@ -31,11 +31,10 @@ impl<'a, T> RowsBatch<'a, T> {
 	}
 
 	#[inline(always)]
-	pub fn get_ref(&self) -> RowsBatchRef<'a, '_, T> {
+	pub fn get_ref(&self) -> RowsBatchRef<'_, T> {
 		RowsBatchRef {
 			rows: self.rows.as_slice(),
 			row_len: self.row_len,
-			_pd: std::marker::PhantomData,
 		}
 	}
 }
@@ -43,28 +42,23 @@ impl<'a, T> RowsBatch<'a, T> {
 /// This struct is similar to `RowsBatch`, but it holds a reference to the slice of rows.
 /// Unfortunately due to liftime issues we can't have a single generic struct which is
 /// parameterized by a container type.
-pub struct RowsBatchRef<'a, 'b, T> {
-	rows: &'a [&'b [T]],
+pub struct RowsBatchRef<'a, T> {
+	rows: &'a [&'a [T]],
 	row_len: usize,
-	_pd: std::marker::PhantomData<&'b [&'a [T]]>,
 }
 
-impl<'a, 'b, T> RowsBatchRef<'a, 'b, T> {
+impl<'a, T> RowsBatchRef<'a, T> {
 	/// Create a new `RowsBatchRef` from a slice of rows and the given row length.
 	///
 	/// # Panics
 	/// In case if any of the rows has a length different from `n_cols`.
 	#[inline]
-	pub fn new(rows: &'a [&'b [T]], row_len: usize) -> Self {
+	pub fn new(rows: &'a [&'a [T]], row_len: usize) -> Self {
 		for row in rows {
 			assert_eq!(row.len(), row_len);
 		}
 
-		Self {
-			rows,
-			row_len,
-			_pd: std::marker::PhantomData,
-		}
+		Self { rows, row_len }
 	}
 
 	#[inline]

--- a/crates/math/src/rows_batch.rs
+++ b/crates/math/src/rows_batch.rs
@@ -1,68 +1,89 @@
 // Copyright 2025 Irreducible Inc.
 
+/// This struct represents a batch of rows, each row having the same length equal to `row_len`.
 pub struct RowsBatch<'a, T> {
 	rows: Vec<&'a [T]>,
-	n_cols: usize,
+	row_len: usize,
 }
 
 impl<'a, T> RowsBatch<'a, T> {
+	/// Create a new `RowsBatch` from a vector of rows and the given row length
+	#[inline]
 	pub fn new(rows: Vec<&'a [T]>, cols: usize) -> Self {
 		for row in &rows {
 			assert_eq!(row.len(), cols);
 		}
 
-		Self { rows, n_cols: cols }
+		Self {
+			rows,
+			row_len: cols,
+		}
 	}
 
+	#[inline]
 	pub fn new_from_iter(rows: impl IntoIterator<Item = &'a [T]>, n_cols: usize) -> Self {
 		let rows = rows.into_iter().map(|x| &x[..n_cols]).collect();
-		Self { rows, n_cols }
+		Self {
+			rows,
+			row_len: n_cols,
+		}
 	}
 
+	#[inline(always)]
 	pub fn as_ref(&self) -> RowsBatchRef<'a, '_, T> {
 		RowsBatchRef {
 			rows: self.rows.as_slice(),
-			n_cols: self.n_cols,
+			row_len: self.row_len,
 			_pd: std::marker::PhantomData,
 		}
 	}
 }
 
+/// This struct is similar to `RowsBatch`, but it holds a reference to the slice of rows.
+/// Unfortunately due to liftime issues we can't have a single generic struct which is
+/// parameterized by a container type.
 pub struct RowsBatchRef<'a, 'b, T> {
 	rows: &'a [&'b [T]],
-	n_cols: usize,
+	row_len: usize,
 	_pd: std::marker::PhantomData<&'b [&'a [T]]>,
 }
 
 impl<'a, 'b, T> RowsBatchRef<'a, 'b, T> {
-	pub fn new_from_data(rows: &'a [&'b [T]], n_cols: usize) -> Self {
+	/// Create a new `RowsBatchRef` from a slice of rows and the given row length.
+	#[inline]
+	pub fn new(rows: &'a [&'b [T]], n_cols: usize) -> Self {
 		for row in rows {
 			assert_eq!(row.len(), n_cols);
 		}
 
 		Self {
 			rows,
-			n_cols,
+			row_len: n_cols,
 			_pd: std::marker::PhantomData,
 		}
 	}
 
+	#[inline]
 	pub fn iter(&self) -> impl Iterator<Item = &'a [T]> + '_ {
 		self.rows.as_ref().iter().copied()
 	}
 
+	#[inline(always)]
 	pub fn rows(&self) -> &[&'a [T]] {
 		self.rows.as_ref()
 	}
 
+	#[inline(always)]
 	pub fn n_rows(&self) -> usize {
 		self.rows.as_ref().len()
 	}
 
-	pub fn n_cols(&self) -> usize {
-		self.n_cols
+	#[inline(always)]
+	pub fn row_len(&self) -> usize {
+		self.row_len
 	}
 
+	#[inline(always)]
 	pub fn is_empty(&self) -> bool {
 		self.rows.as_ref().is_empty()
 	}
@@ -76,7 +97,7 @@ impl<'a, 'b, T> RowsBatchRef<'a, 'b, T> {
 
 		RowsBatch {
 			rows,
-			n_cols: self.n_cols,
+			row_len: self.row_len,
 		}
 	}
 }

--- a/crates/math/src/rows_batch.rs
+++ b/crates/math/src/rows_batch.rs
@@ -1,0 +1,82 @@
+// Copyright 2025 Irreducible Inc.
+
+pub struct RowsBatch<'a, T> {
+	rows: Vec<&'a [T]>,
+	n_cols: usize,
+}
+
+impl<'a, T> RowsBatch<'a, T> {
+	pub fn new(rows: Vec<&'a [T]>, cols: usize) -> Self {
+		for row in &rows {
+			assert_eq!(row.len(), cols);
+		}
+
+		Self { rows, n_cols: cols }
+	}
+
+	pub fn new_from_iter(rows: impl IntoIterator<Item = &'a [T]>, n_cols: usize) -> Self {
+		let rows = rows.into_iter().map(|x| &x[..n_cols]).collect();
+		Self { rows, n_cols }
+	}
+
+	pub fn as_ref(&self) -> RowsBatchRef<'a, '_, T> {
+		RowsBatchRef {
+			rows: self.rows.as_slice(),
+			n_cols: self.n_cols,
+			_pd: std::marker::PhantomData,
+		}
+	}
+}
+
+pub struct RowsBatchRef<'a, 'b, T> {
+	rows: &'a [&'b [T]],
+	n_cols: usize,
+	_pd: std::marker::PhantomData<&'b [&'a [T]]>,
+}
+
+impl<'a, 'b, T> RowsBatchRef<'a, 'b, T> {
+	pub fn new_from_data(rows: &'a [&'b [T]], n_cols: usize) -> Self {
+		for row in rows {
+			assert_eq!(row.len(), n_cols);
+		}
+
+		Self {
+			rows,
+			n_cols,
+			_pd: std::marker::PhantomData,
+		}
+	}
+
+	pub fn iter(&self) -> impl Iterator<Item = &'a [T]> + '_ {
+		self.rows.as_ref().iter().copied()
+	}
+
+	pub fn rows(&self) -> &[&'a [T]] {
+		self.rows.as_ref()
+	}
+
+	pub fn n_rows(&self) -> usize {
+		self.rows.as_ref().len()
+	}
+
+	pub fn n_cols(&self) -> usize {
+		self.n_cols
+	}
+
+	pub fn is_empty(&self) -> bool {
+		self.rows.as_ref().is_empty()
+	}
+
+	pub fn map(&self, indices: impl AsRef<[usize]>) -> RowsBatch<'a, T> {
+		let rows = indices
+			.as_ref()
+			.iter()
+			.map(|&i| self.rows.as_ref()[i])
+			.collect();
+
+		RowsBatch {
+			rows,
+			n_cols: self.n_cols,
+		}
+	}
+}


### PR DESCRIPTION
It appeared that we are creating that big batch of values when proving Vision32 that just checking if all the rows in the batch are of the same length takes signifficant amount of time since we are doing it for each `batch_evaluate` call. in this PR we introduce a special struct that guarantees that all the rows are of the same length by checking it at the moment of creation. Also I like this approach more because this struct helps self-describe the argument of `batch_evaluate` .
For proving Vision32 this saves about 15% of overall time.