### PR TITLE
[m3] Make `WitnessIndex` tables a vec of options

### DIFF
--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -163,11 +163,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 				.zip(&statement.table_sizes)
 				.map(|(table, &table_size)| {
 					if table_size > 0 {
-						Some(TableWitnessIndex::new(
-							allocator,
-							table,
-							table_size,
-						))
+						Some(TableWitnessIndex::new(allocator, table, table_size))
 					} else {
 						None
 					}

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -166,7 +166,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 						Some(TableWitnessIndex::new(
 							allocator,
 							table,
-							statement.table_sizes[table.id],
+							table_size,
 						))
 					} else {
 						None

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -160,8 +160,17 @@ impl<F: TowerField> ConstraintSystem<F> {
 			tables: self
 				.tables
 				.iter()
-				.map(|table| {
-					TableWitnessIndex::new(allocator, table, statement.table_sizes[table.id])
+				.zip(&statement.table_sizes)
+				.map(|(table, &table_size)| {
+					if table_size > 0 {
+						Some(TableWitnessIndex::new(
+							allocator,
+							table,
+							statement.table_sizes[table.id],
+						))
+					} else {
+						None
+					}
 				})
 				.collect(),
 		})

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -53,7 +53,7 @@ impl<'cs, 'alloc, U: UnderlierType, F: TowerField> WitnessIndex<'cs, 'alloc, U, 
 		table: &T,
 		rows: &[T::Event],
 	) -> Result<(), Error> {
-		if rows.len() > 0 {
+		if rows.is_empty() {
 			let table_id = table.id();
 			let witness = self
 				.get_table(table_id)

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -53,7 +53,7 @@ impl<'cs, 'alloc, U: UnderlierType, F: TowerField> WitnessIndex<'cs, 'alloc, U, 
 		table: &T,
 		rows: &[T::Event],
 	) -> Result<(), Error> {
-		if rows.is_empty() {
+		if !rows.is_empty() {
 			let table_id = table.id();
 			let witness = self
 				.get_table(table_id)


### PR DESCRIPTION
This change was missing in #159. Without it, I was getting size mismatches between columns when pushing/pulling from empty tables to the channel.
I'm also changing the signatures of `fill` in `TableFiller` trait. I'm adding `+ Clone` in order to reuse the events (see for example [this use case](https://github.com/IrreducibleOSS/zCrayVM/blob/c63d851780e6ddeb75536ece51868b3dac635c91/assembly/src/event/arithmetization/ret.rs#L132))