### PR TITLE
Efficient plain lookups

### DIFF
--- a/crates/circuits/src/builder/witness.rs
+++ b/crates/circuits/src/builder/witness.rs
@@ -30,6 +30,7 @@ pub struct Builder<'arena> {
 struct WitnessBuilderEntry<'arena> {
 	witness: Result<MultilinearWitness<'arena, PackedType<U, F>>, binius_math::Error>,
 	tower_level: usize,
+	nonzero_scalars_prefix: usize,
 	data: &'arena [U],
 }
 
@@ -50,16 +51,30 @@ impl<'arena> Builder<'arena> {
 		U: PackScalar<FS>,
 		F: ExtensionField<FS>,
 	{
+		let nonzero_scalars_prefix = 1 << self.oracles.borrow().n_vars(id);
+		self.new_column_with_nonzero_scalars_prefix(id, nonzero_scalars_prefix)
+	}
+
+	pub fn new_column_with_nonzero_scalars_prefix<FS: TowerField>(
+		&self,
+		id: OracleId,
+		nonzero_scalars_prefix: usize,
+	) -> EntryBuilder<'arena, FS> where
+        U: PackScalar<FS>,
+        F: ExtensionField<FS>,
+    {
 		let oracles = self.oracles.borrow();
 		let log_rows = oracles.n_vars(id);
+		// TODO: validate nonzero_scalars_prefix
 		let len = 1 << log_rows.saturating_sub(<PackedType<U, FS>>::LOG_WIDTH);
 		let data = bumpalo::vec![in self.bump; U::default(); len].into_bump_slice_mut();
 		EntryBuilder {
 			_marker: PhantomData,
-			log_rows,
-			id,
-			data: Some(data),
 			entries: self.entries.clone(),
+			id,
+			log_rows,
+			nonzero_scalars_prefix,
+			data: Some(data),
 		}
 	}
 
@@ -74,15 +89,17 @@ impl<'arena> Builder<'arena> {
 	{
 		let oracles = self.oracles.borrow();
 		let log_rows = oracles.n_vars(id);
+        let nonzero_scalars_prefix = 1 << log_rows;
 		let len = 1 << log_rows.saturating_sub(<PackedType<U, FS>>::LOG_WIDTH);
 		let default = WithUnderlier::to_underlier(PackedType::<U, FS>::broadcast(default));
 		let data = bumpalo::vec![in self.bump; default; len].into_bump_slice_mut();
 		EntryBuilder {
 			_marker: PhantomData,
-			log_rows,
-			id,
-			data: Some(data),
 			entries: self.entries.clone(),
+			id,
+			log_rows,
+            nonzero_scalars_prefix,
+			data: Some(data),
 		}
 	}
 
@@ -114,6 +131,7 @@ impl<'arena> Builder<'arena> {
 		Ok(WitnessEntry {
 			data: entry.data,
 			log_rows: oracles.n_vars(id),
+            nonzero_scalars_prefix: entry.nonzero_scalars_prefix,
 			_marker: PhantomData,
 		})
 	}
@@ -137,6 +155,7 @@ impl<'arena> Builder<'arena> {
 		}
 		entries[id] = Some(WitnessBuilderEntry {
 			data: entry.data,
+            nonzero_scalars_prefix: entry.nonzero_scalars_prefix,
 			tower_level: FS::TOWER_LEVEL,
 			witness: MultilinearExtension::new(entry.log_rows, entry.packed())
 				.map(|x| x.specialize_arc_dyn()),
@@ -151,9 +170,9 @@ impl<'arena> Builder<'arena> {
 			.into_inner()
 			.into_iter()
 			.enumerate()
-			.filter_map(|(id, entry)| entry.map(|entry| Ok((id, entry.witness?))))
+			.filter_map(|(id, entry)| entry.map(|entry| Ok((id, entry.witness?, entry.nonzero_scalars_prefix))))
 			.collect::<Result<Vec<_>, Error>>()?;
-		result.update_multilin_poly(entries)?;
+		result.update_multilin_poly_with_nonzero_scalars_prefixes(entries)?;
 		Ok(result)
 	}
 }
@@ -165,6 +184,7 @@ where
 {
 	data: &'arena [U],
 	log_rows: usize,
+    nonzero_scalars_prefix: usize,
 	_marker: PhantomData<FS>,
 }
 
@@ -187,9 +207,11 @@ where
 		FE: TowerField + ExtensionField<FS>,
 		U: PackScalar<FE>,
 	{
+        let log_extension_degree = <FE as ExtensionField<FS>>::LOG_DEGREE;
 		WitnessEntry {
 			data: self.data,
-			log_rows: self.log_rows - <FE as ExtensionField<FS>>::LOG_DEGREE,
+			log_rows: self.log_rows - log_extension_degree,
+            nonzero_scalars_prefix: self.nonzero_scalars_prefix.div_ceil(1 << log_extension_degree),
 			_marker: PhantomData,
 		}
 	}
@@ -210,6 +232,7 @@ where
 	entries: Rc<RefCell<Vec<Option<WitnessBuilderEntry<'arena>>>>>,
 	id: OracleId,
 	log_rows: usize,
+	nonzero_scalars_prefix: usize,
 	data: Option<&'arena mut [U]>,
 }
 
@@ -247,11 +270,13 @@ where
 		let data = Option::take(&mut self.data).expect("data is always Some until this point");
 		let mut entries = self.entries.borrow_mut();
 		let id = self.id;
+		let nonzero_scalars_prefix = self.nonzero_scalars_prefix;
 		if id >= entries.len() {
 			entries.resize_with(id + 1, || None);
 		}
 		entries[id] = Some(WitnessBuilderEntry {
 			data,
+			nonzero_scalars_prefix,
 			tower_level: FS::TOWER_LEVEL,
 			witness: MultilinearExtension::new(
 				self.log_rows,

--- a/crates/circuits/src/builder/witness.rs
+++ b/crates/circuits/src/builder/witness.rs
@@ -59,10 +59,11 @@ impl<'arena> Builder<'arena> {
 		&self,
 		id: OracleId,
 		nonzero_scalars_prefix: usize,
-	) -> EntryBuilder<'arena, FS> where
-        U: PackScalar<FS>,
-        F: ExtensionField<FS>,
-    {
+	) -> EntryBuilder<'arena, FS>
+	where
+		U: PackScalar<FS>,
+		F: ExtensionField<FS>,
+	{
 		let oracles = self.oracles.borrow();
 		let log_rows = oracles.n_vars(id);
 		// TODO: validate nonzero_scalars_prefix
@@ -89,7 +90,7 @@ impl<'arena> Builder<'arena> {
 	{
 		let oracles = self.oracles.borrow();
 		let log_rows = oracles.n_vars(id);
-        let nonzero_scalars_prefix = 1 << log_rows;
+		let nonzero_scalars_prefix = 1 << log_rows;
 		let len = 1 << log_rows.saturating_sub(<PackedType<U, FS>>::LOG_WIDTH);
 		let default = WithUnderlier::to_underlier(PackedType::<U, FS>::broadcast(default));
 		let data = bumpalo::vec![in self.bump; default; len].into_bump_slice_mut();
@@ -98,7 +99,7 @@ impl<'arena> Builder<'arena> {
 			entries: self.entries.clone(),
 			id,
 			log_rows,
-            nonzero_scalars_prefix,
+			nonzero_scalars_prefix,
 			data: Some(data),
 		}
 	}
@@ -131,7 +132,7 @@ impl<'arena> Builder<'arena> {
 		Ok(WitnessEntry {
 			data: entry.data,
 			log_rows: oracles.n_vars(id),
-            nonzero_scalars_prefix: entry.nonzero_scalars_prefix,
+			nonzero_scalars_prefix: entry.nonzero_scalars_prefix,
 			_marker: PhantomData,
 		})
 	}
@@ -155,7 +156,7 @@ impl<'arena> Builder<'arena> {
 		}
 		entries[id] = Some(WitnessBuilderEntry {
 			data: entry.data,
-            nonzero_scalars_prefix: entry.nonzero_scalars_prefix,
+			nonzero_scalars_prefix: entry.nonzero_scalars_prefix,
 			tower_level: FS::TOWER_LEVEL,
 			witness: MultilinearExtension::new(entry.log_rows, entry.packed())
 				.map(|x| x.specialize_arc_dyn()),
@@ -184,7 +185,7 @@ where
 {
 	data: &'arena [U],
 	log_rows: usize,
-    nonzero_scalars_prefix: usize,
+	nonzero_scalars_prefix: usize,
 	_marker: PhantomData<FS>,
 }
 
@@ -207,11 +208,13 @@ where
 		FE: TowerField + ExtensionField<FS>,
 		U: PackScalar<FE>,
 	{
-        let log_extension_degree = <FE as ExtensionField<FS>>::LOG_DEGREE;
+		let log_extension_degree = <FE as ExtensionField<FS>>::LOG_DEGREE;
 		WitnessEntry {
 			data: self.data,
 			log_rows: self.log_rows - log_extension_degree,
-            nonzero_scalars_prefix: self.nonzero_scalars_prefix.div_ceil(1 << log_extension_degree),
+			nonzero_scalars_prefix: self
+				.nonzero_scalars_prefix
+				.div_ceil(1 << log_extension_degree),
 			_marker: PhantomData,
 		}
 	}

--- a/crates/circuits/src/plain_lookup.rs
+++ b/crates/circuits/src/plain_lookup.rs
@@ -335,7 +335,7 @@ mod tests {
 
 	#[test]
 	fn test_plain_u8_mul_lookup() {
-		const MAX_LOG_MULTIPLICITY: usize = 18;
+		const MAX_LOG_MULTIPLICITY: usize = 20;
 		let log_lookup_count = 19;
 
 		let log_inv_rate = 1;

--- a/crates/core/src/protocols/sumcheck/prove/prover_state.rs
+++ b/crates/core/src/protocols/sumcheck/prove/prover_state.rs
@@ -223,7 +223,6 @@ where
 	#[instrument(skip_all, level = "debug")]
 	pub fn calculate_round_evals<Evaluator, Composition>(
 		&self,
-		const_eval_suffix: usize,
 		evaluators: &[Evaluator],
 	) -> Result<Vec<RoundEvals<F>>, Error>
 	where
@@ -233,7 +232,6 @@ where
 		Ok(self.backend.sumcheck_compute_round_evals(
 			self.evaluation_order,
 			self.n_vars,
-			const_eval_suffix,
 			self.tensor_query.as_ref().map(Into::into),
 			&self.multilinears,
 			evaluators,

--- a/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
@@ -209,7 +209,7 @@ where
 			})
 			.collect::<Vec<_>>();
 
-		let round_evals = self.state.calculate_round_evals(0, &evaluators)?;
+		let round_evals = self.state.calculate_round_evals(&evaluators)?;
 		self.state
 			.calculate_round_coeffs_from_evals(&evaluators, batch_coeff, round_evals)
 	}

--- a/crates/hal/src/backend.rs
+++ b/crates/hal/src/backend.rs
@@ -44,12 +44,10 @@ pub trait ComputationBackend: Send + Sync + Debug {
 	) -> Result<Self::Vec<P>, Error>;
 
 	/// Calculate the accumulated evaluations for an arbitrary round of zerocheck.
-	#[allow(clippy::too_many_arguments)]
 	fn sumcheck_compute_round_evals<FDomain, P, M, Evaluator, Composition>(
 		&self,
 		evaluation_order: EvaluationOrder,
 		n_vars: usize,
-		const_eval_suffix: usize,
 		tensor_query: Option<MultilinearQueryRef<P>>,
 		multilinears: &[SumcheckMultilinear<P, M>],
 		evaluators: &[Evaluator],
@@ -106,7 +104,6 @@ where
 		&self,
 		evaluation_order: EvaluationOrder,
 		n_vars: usize,
-		const_eval_suffix: usize,
 		tensor_query: Option<MultilinearQueryRef<P>>,
 		multilinears: &[SumcheckMultilinear<P, M>],
 		evaluators: &[Evaluator],
@@ -123,7 +120,6 @@ where
 			self,
 			evaluation_order,
 			n_vars,
-			const_eval_suffix,
 			tensor_query,
 			multilinears,
 			evaluators,

--- a/crates/hal/src/cpu.rs
+++ b/crates/hal/src/cpu.rs
@@ -41,7 +41,6 @@ impl ComputationBackend for CpuBackend {
 		&self,
 		evaluation_order: EvaluationOrder,
 		n_vars: usize,
-		const_eval_suffix: usize,
 		tensor_query: Option<MultilinearQueryRef<P>>,
 		multilinears: &[SumcheckMultilinear<P, M>],
 		evaluators: &[Evaluator],
@@ -57,7 +56,6 @@ impl ComputationBackend for CpuBackend {
 		calculate_round_evals(
 			evaluation_order,
 			n_vars,
-			const_eval_suffix,
 			tensor_query,
 			multilinears,
 			evaluators,

--- a/crates/hal/src/sumcheck_evaluator.rs
+++ b/crates/hal/src/sumcheck_evaluator.rs
@@ -33,7 +33,8 @@ pub trait SumcheckEvaluator<P: PackedField, Composition> {
 	/// Compute sum of evals over the suffix where the composite is guaranteed to evaluate to a constant.
 	///
 	/// It is assumed that all required inputs are known at the evaluator creation time, as `const_eval_suffix` is
-	/// determined dynamically by the sumcheck round calculator.
+	/// determined dynamically by the sumcheck round calculator and may be _smaller_ than the return value of the method
+	/// with the same name.
 	///
 	/// See doc comments to [EvaluationDomain](binius_math::EvaluationDomain) for the intuition
 	/// behind `is_infinity_point`.
@@ -51,4 +52,13 @@ pub trait SumcheckEvaluator<P: PackedField, Composition> {
 	/// In case of zerocheck returns eq_ind that the results should be folded with.
 	/// In case of sumcheck returns None.
 	fn eq_ind_partial_eval(&self) -> Option<&[P]>;
+
+	/// Trace suffix where the composite is guaranteed to evaluate to a constant. The non-constant prefix
+	/// would get processed via `process_subcube_at_eval_point`, whereas the remainder gets handled via
+	/// `process_constant_eval_suffix`. Due to the fact that sumcheck operates over whole subcubes the
+	/// `const_eval_suffix` passed to `process_constant_eval_suffix` may be _smaller_ that the return value
+	/// of this method.
+	fn const_eval_suffix(&self) -> usize {
+		0
+	}
 }

--- a/crates/hal/src/sumcheck_round_calculation.rs
+++ b/crates/hal/src/sumcheck_round_calculation.rs
@@ -14,7 +14,7 @@ use binius_math::{
 	MultilinearQueryRef,
 };
 use binius_maybe_rayon::prelude::*;
-use binius_utils::{bail, checked_arithmetics::log2_ceil_usize};
+use binius_utils::bail;
 use bytemuck::zeroed_vec;
 use itertools::{izip, Either, Itertools};
 use stackalloc::stackalloc_with_iter;
@@ -57,6 +57,7 @@ trait SumcheckMultilinearAccess<P: PackedField> {
 	/// * `subcube_vars`  - the number of variables in the sub-subcube to evaluate over
 	/// * `subcube_index` - the index of the subcube within the $n-1$-variate hypercube
 	/// * `index_vars`    - number of bits in the `subcube_index`
+	/// * `tensor_query`  - multilinear query of pre-switchover challenges (empty if all folded)
 	/// * `scratch_space` - optional scratch space
 	/// * `evals_0`       - `subcube_vars`-variate hypercube with current variables substituted for 0
 	/// * `evals_1`       - `subcube_vars`-variate hypercube with current variables substituted for 1
@@ -67,6 +68,7 @@ trait SumcheckMultilinearAccess<P: PackedField> {
 		subcube_vars: usize,
 		subcube_index: usize,
 		index_vars: usize,
+		tensor_query: MultilinearQueryRef<P>,
 		scratch_space: Option<&mut [P]>,
 		evals_0: &mut [P],
 		evals_1: &mut [P],
@@ -80,7 +82,6 @@ trait SumcheckMultilinearAccess<P: PackedField> {
 pub(crate) fn calculate_round_evals<FDomain, F, P, M, Evaluator, Composition>(
 	evaluation_order: EvaluationOrder,
 	n_vars: usize,
-	const_eval_suffix: usize,
 	tensor_query: Option<MultilinearQueryRef<P>>,
 	multilinears: &[SumcheckMultilinear<P, M>],
 	evaluators: &[Evaluator],
@@ -98,28 +99,20 @@ where
 
 	let empty_query = MultilinearQuery::with_capacity(0);
 	let tensor_query = tensor_query.unwrap_or_else(|| empty_query.to_ref());
-	let subcube_vars = subcube_vars_for_bits::<P>(
-		MAX_SRC_SUBCUBE_LOG_BITS,
-		log2_ceil_usize((1 << (n_vars - 1)) - const_eval_suffix),
-		tensor_query.n_vars(),
-		n_vars - 1,
-	);
 
 	match evaluation_order {
 		EvaluationOrder::LowToHigh => calculate_round_evals_with_access(
+			LowToHighAccess,
 			n_vars,
-			const_eval_suffix,
-			subcube_vars,
-			&LowToHighAccess { tensor_query },
+			tensor_query,
 			multilinears,
 			evaluators,
 			finite_evaluation_points,
 		),
 		EvaluationOrder::HighToLow => calculate_round_evals_with_access(
+			HighToLowAccess,
 			n_vars,
-			const_eval_suffix,
-			subcube_vars,
-			&HighToLowAccess { tensor_query },
+			tensor_query,
 			multilinears,
 			evaluators,
 			finite_evaluation_points,
@@ -128,10 +121,9 @@ where
 }
 
 fn calculate_round_evals_with_access<FDomain, F, P, M, Evaluator, Access, Composition>(
+	access: Access,
 	n_vars: usize,
-	const_eval_suffix: usize,
-	subcube_vars: usize,
-	access: &Access,
+	tensor_query: MultilinearQueryRef<P>,
 	multilinears: &[SumcheckMultilinear<P, M>],
 	evaluators: &[Evaluator],
 	nontrivial_evaluation_points: &[FDomain],
@@ -145,9 +137,6 @@ where
 	Access: SumcheckMultilinearAccess<P> + Sync,
 	Composition: CompositionPoly<P>,
 {
-	assert!(const_eval_suffix <= 1 << (n_vars - 1));
-	assert!(subcube_vars < n_vars);
-
 	let n_multilinears = multilinears.len();
 	let n_round_evals = evaluators
 		.iter()
@@ -165,12 +154,42 @@ where
 		bail!(Error::IncorrectNontrivialEvalPointsLength);
 	}
 
+	// Here we assume that at least one multilinear would be "full"
+	// REVIEW: come up with a better heuristic
+	let subcube_vars = subcube_vars_for_bits::<P>(
+		MAX_SRC_SUBCUBE_LOG_BITS,
+		n_vars - 1,
+		tensor_query.n_vars(),
+		n_vars - 1,
+	);
+
+	let subcube_count_by_evaluator = evaluators
+		.iter()
+		.map(|evaluator| {
+			((1 << (n_vars - 1)) - evaluator.const_eval_suffix()).div_ceil(1 << subcube_vars)
+		})
+		.collect::<Vec<_>>();
+
+	let mut subcube_count_by_multilinear = vec![0; n_multilinears];
+
+	for (&evaluator_subcube_count, evaluator) in izip!(&subcube_count_by_evaluator, evaluators) {
+		let used_vars = evaluator.composition().expression().vars_usage();
+
+		for (multilinear_subcube_count, usage_flag) in
+			izip!(&mut subcube_count_by_multilinear, used_vars)
+		{
+			if usage_flag {
+				*multilinear_subcube_count =
+					(*multilinear_subcube_count).max(evaluator_subcube_count);
+			}
+		}
+	}
+
 	let index_vars = n_vars - 1 - subcube_vars;
-	let subcube_count = ((1 << (n_vars - 1)) - const_eval_suffix).div_ceil(1 << subcube_vars);
-	let packed_accumulators = (0..subcube_count)
+	let packed_accumulators = (0..1 << index_vars)
 		.into_par_iter()
 		.try_fold(
-			|| ParFoldStates::new(access, n_multilinears, n_round_evals.clone(), subcube_vars),
+			|| ParFoldStates::new(&access, n_multilinears, n_round_evals.clone(), subcube_vars),
 			|mut par_fold_states, subcube_index| {
 				let ParFoldStates {
 					multilinear_evals,
@@ -178,16 +197,21 @@ where
 					round_evals,
 				} = &mut par_fold_states;
 
-				for (multilinear, evals) in izip!(multilinears, multilinear_evals.iter_mut()) {
-					access.subcube_evaluations(
-						multilinear,
-						subcube_vars,
-						subcube_index,
-						index_vars,
-						scratch_space.as_deref_mut(),
-						&mut evals.evals_0,
-						&mut evals.evals_1,
-					)?;
+				for (multilinear, evals, &subcube_count) in
+					izip!(multilinears, multilinear_evals.iter_mut(), &subcube_count_by_multilinear)
+				{
+					if subcube_index < subcube_count {
+						access.subcube_evaluations(
+							multilinear,
+							subcube_vars,
+							subcube_index,
+							index_vars,
+							tensor_query,
+							scratch_space.as_deref_mut(),
+							&mut evals.evals_0,
+							&mut evals.evals_1,
+						)?;
+					}
 				}
 
 				// Proceed by evaluation point first to share interpolation work between evaluators.
@@ -204,9 +228,10 @@ where
 					//                                   = f(1, xs) - f(0, xs)
 					//   index 3 and above - remaining finite evaluation points
 					let evals_z_iter =
-						multilinear_evals
-							.iter_mut()
-							.map(|evals| match eval_point_index {
+						izip!(multilinear_evals.iter_mut(), &subcube_count_by_multilinear).map(
+							|(evals, &subcube_count)| match eval_point_index {
+								// This multilinear is not accessed, return arbitrary slice
+								_ if subcube_index >= subcube_count => evals.evals_0.as_slice(),
 								0 => evals.evals_0.as_slice(),
 								1 => evals.evals_1.as_slice(),
 								2 => {
@@ -240,14 +265,17 @@ where
 
 									evals.evals_z.as_slice()
 								}
-							});
+							},
+						);
 
 					stackalloc_with_iter(n_multilinears, evals_z_iter, |evals_z| {
-						for (evaluator, round_evals) in
-							iter::zip(evaluators, round_evals.iter_mut())
+						for (evaluator, round_evals, &subcube_count) in
+							izip!(evaluators, round_evals.iter_mut(), &subcube_count_by_evaluator)
 						{
 							let eval_point_indices = evaluator.eval_point_indices();
-							if !eval_point_indices.contains(&eval_point_index) {
+							if !eval_point_indices.contains(&eval_point_index)
+								|| subcube_index >= subcube_count
+							{
 								continue;
 							}
 
@@ -277,7 +305,7 @@ where
 					.collect()
 			},
 			|lhs, rhs| {
-				let sum = iter::zip(lhs, rhs)
+				let sum = izip!(lhs, rhs)
 					.map(|(mut lhs_vals, rhs_vals)| {
 						for (lhs_val, rhs_val) in lhs_vals.iter_mut().zip(rhs_vals) {
 							*lhs_val += rhs_val;
@@ -289,8 +317,8 @@ where
 			},
 		)?;
 
-	let round_evals = izip!(packed_accumulators, evaluators)
-		.map(|(packed_round_evals, evaluator)| {
+	let round_evals = izip!(packed_accumulators, evaluators, subcube_count_by_evaluator)
+		.map(|(packed_round_evals, evaluator, subcube_count)| {
 			let mut round_evals = packed_round_evals
 				.into_iter()
 				// Truncate subcubes smaller than packing width.
@@ -370,11 +398,9 @@ impl<P: PackedField> ParFoldStates<P> {
 }
 
 #[derive(Debug)]
-struct LowToHighAccess<'a, P: PackedField> {
-	tensor_query: MultilinearQueryRef<'a, P>,
-}
+struct LowToHighAccess;
 
-impl<P: PackedField> SumcheckMultilinearAccess<P> for LowToHighAccess<'_, P> {
+impl<P: PackedField> SumcheckMultilinearAccess<P> for LowToHighAccess {
 	fn scratch_space_len(&self, subcube_vars: usize) -> Option<usize> {
 		// We need to sample evaluations at both 0 & 1 prior to deinterleaving, thus +1.
 		Some(1 << (subcube_vars + 1).saturating_sub(P::LOG_WIDTH))
@@ -386,6 +412,7 @@ impl<P: PackedField> SumcheckMultilinearAccess<P> for LowToHighAccess<'_, P> {
 		subcube_vars: usize,
 		subcube_index: usize,
 		_index_vars: usize,
+		tensor_query: MultilinearQueryRef<P>,
 		scratch_space: Option<&mut [P]>,
 		evals_0: &mut [P],
 		evals_1: &mut [P],
@@ -403,11 +430,11 @@ impl<P: PackedField> SumcheckMultilinearAccess<P> for LowToHighAccess<'_, P> {
 
 		match multilinear {
 			SumcheckMultilinear::Transparent { multilinear, .. } => {
-				if self.tensor_query.n_vars() == 0 {
+				if tensor_query.n_vars() == 0 {
 					multilinear.subcube_evals(subcube_vars + 1, subcube_index, 0, scratch_space)?
 				} else {
 					multilinear.subcube_partial_low_evals(
-						self.tensor_query,
+						tensor_query,
 						subcube_vars + 1,
 						subcube_index,
 						scratch_space,
@@ -470,11 +497,9 @@ impl<P: PackedField> SumcheckMultilinearAccess<P> for LowToHighAccess<'_, P> {
 }
 
 #[derive(Debug)]
-struct HighToLowAccess<'a, P: PackedField> {
-	tensor_query: MultilinearQueryRef<'a, P>,
-}
+struct HighToLowAccess;
 
-impl<P: PackedField> SumcheckMultilinearAccess<P> for HighToLowAccess<'_, P> {
+impl<P: PackedField> SumcheckMultilinearAccess<P> for HighToLowAccess {
 	fn scratch_space_len(&self, _subcube_vars: usize) -> Option<usize> {
 		None
 	}
@@ -485,6 +510,7 @@ impl<P: PackedField> SumcheckMultilinearAccess<P> for HighToLowAccess<'_, P> {
 		subcube_vars: usize,
 		subcube_index: usize,
 		index_vars: usize,
+		tensor_query: MultilinearQueryRef<P>,
 		_scratch_space: Option<&mut [P]>,
 		evals_0: &mut [P],
 		evals_1: &mut [P],
@@ -497,7 +523,7 @@ impl<P: PackedField> SumcheckMultilinearAccess<P> for HighToLowAccess<'_, P> {
 
 		match multilinear {
 			SumcheckMultilinear::Transparent { multilinear, .. } => {
-				if self.tensor_query.n_vars() == 0 {
+				if tensor_query.n_vars() == 0 {
 					multilinear.subcube_evals(subcube_vars, subcube_index, 0, evals_0)?;
 					multilinear.subcube_evals(
 						subcube_vars,
@@ -507,13 +533,13 @@ impl<P: PackedField> SumcheckMultilinearAccess<P> for HighToLowAccess<'_, P> {
 					)?;
 				} else {
 					multilinear.subcube_partial_high_evals(
-						self.tensor_query,
+						tensor_query,
 						subcube_vars,
 						subcube_index,
 						evals_0,
 					)?;
 					multilinear.subcube_partial_high_evals(
-						self.tensor_query,
+						tensor_query,
 						subcube_vars,
 						subcube_index | 1 << index_vars,
 						evals_1,


### PR DESCRIPTION
> depends on #162 

- augments `plain_lookup` with an ability to use the permuted version of `lookup_t` committed in the non-increasing multiplicity order; that allows leveraging nonzero scalars prefixes optimization in flush sumchecks, and, eventually, GKR reductions
- interface changed to Lasso-like, but taking multiplicities as an additional prover parameter (instead of `u->t` mapping in Lasso)
- supports "wide" lookups (many columns of the same type), but committing to the permuted lookup version within the gadget enforces all the columns to be of the same `FTable` type and with `PackedFieldIndexable` packing for the sake of simplicity