### PR TITLE
[m3] Fix for proving when table size is too small

### DIFF
--- a/crates/core/src/piop/commit.rs
+++ b/crates/core/src/piop/commit.rs
@@ -116,6 +116,7 @@ fn n_packed_vars_for_committed_oracle<F: TowerField>(
 		.checked_sub(F::TOWER_LEVEL - tower_level)
 		.ok_or_else(|| Error::OracleTooSmall {
 			id: oracle.id(),
+			n_vars,
 			min_vars: F::TOWER_LEVEL - tower_level,
 		})
 }

--- a/crates/core/src/piop/error.rs
+++ b/crates/core/src/piop/error.rs
@@ -9,8 +9,12 @@ use crate::{
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-	#[error("committed oracle {id} has too few variables, must be at least {min_vars}")]
-	OracleTooSmall { id: OracleId, min_vars: usize },
+	#[error("committed oracle {id} has too few variables; only has {n_vars}, must be at least {min_vars}")]
+	OracleTooSmall {
+		id: OracleId,
+		n_vars: usize,
+		min_vars: usize,
+	},
 	#[error("committed polynomials are not sorted in ascending order by number of variables")]
 	CommittedsNotSorted,
 	#[error("transparent polynomials are not sorted in ascending order by number of variables")]

--- a/crates/core/src/piop/prove.rs
+++ b/crates/core/src/piop/prove.rs
@@ -119,6 +119,7 @@ where
 				// i is not an OracleId, but whatever, that's a problem for whoever has to debug
 				// this
 				id: i,
+				n_vars: multilin.n_vars(),
 				min_vars: multilin.log_extension_degree(),
 			});
 		}

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -13,7 +13,7 @@ use binius_core::{
 };
 use binius_field::{underlier::UnderlierType, TowerField};
 use binius_math::LinearNormalForm;
-use binius_utils::checked_arithmetics::{log2_ceil_usize, log2_strict_usize};
+use binius_utils::checked_arithmetics::log2_strict_usize;
 use bumpalo::Bump;
 
 use super::{
@@ -209,8 +209,9 @@ impl<F: TowerField> ConstraintSystem<F> {
 			}
 
 			// Add multilinear oracles for all table columns.
+			let log_capacity = table.log_capacity(count);
 			for column_info in table.columns.iter() {
-				let n_vars = log2_ceil_usize(count) + column_info.shape.log_values_per_row;
+				let n_vars = log_capacity + column_info.shape.log_values_per_row;
 				let oracle_id = add_oracle_for_column(
 					&mut oracles,
 					&oracle_lookup,
@@ -233,7 +234,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 					..
 				} = partition;
 
-				let n_vars = log2_ceil_usize(count) + log2_strict_usize(*values_per_row);
+				let n_vars = log_capacity + log2_strict_usize(*values_per_row);
 
 				let partition_oracle_ids = columns
 					.iter()

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -14,7 +14,7 @@ use binius_field::{
 	ExtensionField, TowerField,
 };
 use binius_utils::{
-	checked_arithmetics::{checked_log_2, log2_strict_usize},
+	checked_arithmetics::{checked_log_2, log2_ceil_usize, log2_strict_usize},
 	sparse_index::SparseIndex,
 };
 
@@ -447,14 +447,17 @@ impl<F: TowerField> Table<F> {
 
 	/// Returns the binary logarithm of the minimum capacity.
 	///
-	/// This value is chosen so that every column fills at least one large field element in packed
-	/// representation. This is because the polynomial commitment scheme requires full packed
-	/// field elements.
+	/// This value is chosen so that every committed column fills at least one large field element
+	/// in packed representation. This is because the polynomial commitment scheme requires full
+	/// packed field elements.
 	pub fn min_log_capacity(&self) -> usize {
 		let min_cell_size = self
 			.columns
 			.iter()
-			.map(|col| col.shape.log_cell_size())
+			.filter_map(|col| match col.col {
+				ColumnDef::Committed { .. } => Some(col.shape.log_cell_size()),
+				_ => None,
+			})
 			.min()
 			// return 0 if table has no columns
 			.unwrap_or(F::TOWER_LEVEL);
@@ -469,7 +472,7 @@ impl<F: TowerField> Table<F> {
 	/// This will normally be the next power of two greater than the table size, but could require
 	/// more padding to get a minimum capacity.
 	pub fn log_capacity(&self, table_size: usize) -> usize {
-		log2_strict_usize(table_size).max(self.min_log_capacity())
+		log2_ceil_usize(table_size).max(self.min_log_capacity())
 	}
 
 	fn new_column<FSub, const V: usize>(

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -670,7 +670,7 @@ pub fn fill_table_sequential<U: UnderlierType, F: TowerField, T: TableFiller<U, 
 mod tests {
 	use assert_matches::assert_matches;
 	use binius_field::{
-		arch::OptimalUnderlier128b,
+		arch::{OptimalUnderlier128b, OptimalUnderlier256b},
 		packed::{len_packed_slice, set_packed_slice},
 	};
 
@@ -807,17 +807,20 @@ mod tests {
 		let allocator = bumpalo::Bump::new();
 		let table_size = 7;
 		let mut index =
-			TableWitnessIndex::<OptimalUnderlier128b>::new(&allocator, &inner_table, table_size);
+			TableWitnessIndex::<OptimalUnderlier256b>::new(&allocator, &inner_table, table_size);
 
-		assert_eq!(index.min_log_segment_size(), 3);
+		assert_eq!(index.log_capacity(), 4);
+		assert_eq!(index.min_log_segment_size(), 4);
 
-		let mut iter = index.segments(4);
-		assert_eq!(iter.next().unwrap().log_size(), 3);
+		let mut iter = index.segments(5);
+		// Check that the segment size is clamped to the capacity.
+		assert_eq!(iter.next().unwrap().log_size(), 4);
 		assert!(iter.next().is_none());
 		drop(iter);
 
 		let mut iter = index.segments(2);
-		assert_eq!(iter.next().unwrap().log_size(), 3);
+		// Check that the segment size is clamped to the minimum segment size.
+		assert_eq!(iter.next().unwrap().log_size(), 4);
 		assert!(iter.next().is_none());
 		drop(iter);
 	}


### PR DESCRIPTION
When the smallest committed column is too small, it currently causes an `OracleTooSmall` error in the PIOP compiler. This correctly ensures that table capacities get padded enough to avoid the problem.