### PR TITLE
[piop] Make piop compiler work with high-to-low sumcheck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ lazy_static = "1.5.0"
 paste = "1.0.15"
 proc-macro2 = "1.0.81"
 proptest = "1.2.0"
+p3-util = { version = "0.1.0", git = "https://github.com/Plonky3/Plonky3" }
 quote = "1.0.36"
 rand = { version = "0.8.5", default-features = false, features = ["std_rng"] }
 rayon = "1.8.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -25,6 +25,7 @@ either.workspace = true
 getset.workspace = true
 inventory.workspace = true
 itertools.workspace = true
+p3-util.workspace = true
 rand.workspace = true
 stackalloc.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
This is a quick modification to make the FRI-Binius PCS use high-to-low sumcheck. The trick is simply that we bit-reverse the multilinear coefficients before committing. This has the effect of bit-reversing their encodings as well, and everything works pretty nicely.

I'm not that happy about re-introducing the dependency on p3-util or `PackedFieldIndexable`, but this was the fastest way to get it working. @GraDKh maybe you have ideas how to fix that?