### PR TITLE
[field] Friendlier function for getting field bases

### DIFF
--- a/crates/circuits/src/vision.rs
+++ b/crates/circuits/src/vision.rs
@@ -224,7 +224,7 @@ fn inv_constraint_expr<F: TowerField>() -> Result<ArithExpr<F>> {
 
 	// x == 0 AND inv == 0
 	// TODO: Implement `mul_primitive` expression for ArithExpr
-	let beta = <F as ExtensionField<BinaryField1b>>::basis(1 << 5)?;
+	let beta = <F as ExtensionField<BinaryField1b>>::basis_checked(1 << 5)?;
 	let zero_case = x + inv * ArithExpr::Const(beta);
 
 	// (x * inv == 1) OR (x == 0 AND inv == 0)

--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -550,7 +550,7 @@ mod tests {
 				Ok(val
 					* F::from_underlier(F::Underlier::from(ISOMORPHIC_ALPHAS[iota].to_underlier())))
 			}
-			_ => <F as ExtensionField<BinaryField1b>>::basis(1 << iota).map(|b| val * b),
+			_ => <F as ExtensionField<BinaryField1b>>::basis_checked(1 << iota).map(|b| val * b),
 		};
 		assert_eq!(result.is_ok(), expected.is_ok());
 		if result.is_ok() {

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -65,7 +65,7 @@ where
 				max: n_basis_elts,
 			});
 		}
-		<Self as ExtensionField<BinaryField1b>>::basis(i << iota)
+		<Self as ExtensionField<BinaryField1b>>::basis_checked(i << iota)
 	}
 
 	/// Multiplies a field element by the canonical primitive element of the extension $T_{\iota + 1} / T_{iota}$.
@@ -77,7 +77,7 @@ where
 	///
 	/// * `Error::ExtensionDegreeTooHigh` if `iota >= Self::TOWER_LEVEL`
 	fn mul_primitive(self, iota: usize) -> Result<Self, Error> {
-		Ok(self * <Self as ExtensionField<BinaryField1b>>::basis(1 << iota)?)
+		Ok(self * <Self as ExtensionField<BinaryField1b>>::basis_checked(1 << iota)?)
 	}
 }
 
@@ -576,7 +576,7 @@ macro_rules! impl_field_extension {
 			const LOG_DEGREE: usize = $log_degree;
 
 			#[inline]
-			fn basis(i: usize) -> Result<Self, Error> {
+			fn basis_checked(i: usize) -> Result<Self, Error> {
 				use $crate::underlier::UnderlierWithBitOps;
 
 				if i >= 1 << $log_degree {
@@ -1176,7 +1176,8 @@ pub(crate) mod tests {
 
 	fn test_mul_primitive<F: TowerField>(val: F, iota: usize) {
 		let result = val.mul_primitive(iota);
-		let expected = <F as ExtensionField<BinaryField1b>>::basis(1 << iota).map(|b| val * b);
+		let expected =
+			<F as ExtensionField<BinaryField1b>>::basis_checked(1 << iota).map(|b| val * b);
 		assert_eq!(result.is_ok(), expected.is_ok());
 		if result.is_ok() {
 			assert_eq!(result.unwrap(), expected.unwrap());

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -54,6 +54,8 @@ where
 	/// from `elem.min_tower_level()`.
 	fn min_tower_level(self) -> usize;
 
+	/// Returns the i'th basis element of this field as an extension over the tower subfield with
+	/// level $\iota$.
 	fn basis(iota: usize, i: usize) -> Result<Self, Error> {
 		if iota > Self::TOWER_LEVEL {
 			return Err(Error::ExtensionDegreeTooHigh);
@@ -79,6 +81,22 @@ where
 	fn mul_primitive(self, iota: usize) -> Result<Self, Error> {
 		Ok(self * <Self as ExtensionField<BinaryField1b>>::basis_checked(1 << iota)?)
 	}
+}
+
+/// Returns the i'th basis element of `FExt` as a field extension of `FSub`.
+///
+/// This is an alias function for [`ExtensionField::basis`].
+///
+/// ## Pre-conditions
+///
+/// * `i` must be in the range $[0, d)$, where $d$ is the field extension degree.
+#[inline]
+pub fn ext_basis<FExt, FSub>(i: usize) -> FExt
+where
+	FSub: Field,
+	FExt: ExtensionField<FSub>,
+{
+	<FExt as ExtensionField<FSub>>::basis(i)
 }
 
 pub(super) trait TowerExtensionField:

--- a/crates/field/src/extension.rs
+++ b/crates/field/src/extension.rs
@@ -27,7 +27,23 @@ pub trait ExtensionField<F: Field>:
 	const DEGREE: usize = 1 << Self::LOG_DEGREE;
 
 	/// For `0 <= i < DEGREE`, returns `i`-th basis field element.
-	fn basis(i: usize) -> Result<Self, Error>;
+	///
+	/// ## Pre-conditions
+	///
+	/// * `i` must be in the range [0, `Self::DEGREE`).
+	fn basis(i: usize) -> Self {
+		Self::basis_checked(i).expect("pre-condition: 0 <= i < DEGREE")
+	}
+
+	/// For `0 <= i < DEGREE`, returns `i`-th basis field element.
+	///
+	/// This is the same operation as [`Self::basis`], but it returns an error result instead of
+	/// panicking if the index is out of range.
+	///
+	/// ## Throws
+	///
+	/// * `Error::ExtensionDegreeMismatch` unless `i` is in the range [0, `Self::DEGREE`).
+	fn basis_checked(i: usize) -> Result<Self, Error>;
 
 	/// Create an extension field element from a slice of base field elements in order
 	/// consistent with `basis(i)` return values.
@@ -71,7 +87,7 @@ impl<F: Field> ExtensionField<F> for F {
 	const LOG_DEGREE: usize = 0;
 
 	#[inline(always)]
-	fn basis(i: usize) -> Result<Self, Error> {
+	fn basis_checked(i: usize) -> Result<Self, Error> {
 		if i != 0 {
 			return Err(Error::ExtensionDegreeMismatch);
 		}

--- a/crates/field/src/extension.rs
+++ b/crates/field/src/extension.rs
@@ -31,6 +31,7 @@ pub trait ExtensionField<F: Field>:
 	/// ## Pre-conditions
 	///
 	/// * `i` must be in the range [0, `Self::DEGREE`).
+	#[inline]
 	fn basis(i: usize) -> Self {
 		Self::basis_checked(i).expect("pre-condition: 0 <= i < DEGREE")
 	}

--- a/crates/field/src/polyval.rs
+++ b/crates/field/src/polyval.rs
@@ -422,7 +422,7 @@ impl ExtensionField<BinaryField1b> for BinaryField128bPolyval {
 	const LOG_DEGREE: usize = 7;
 
 	#[inline]
-	fn basis(i: usize) -> Result<Self, Error> {
+	fn basis_checked(i: usize) -> Result<Self, Error> {
 		if i >= 128 {
 			return Err(Error::ExtensionDegreeMismatch);
 		}

--- a/crates/m3/src/gadgets/hash/groestl.rs
+++ b/crates/m3/src/gadgets/hash/groestl.rs
@@ -20,9 +20,7 @@ use binius_field::{
 };
 use bytemuck::Pod;
 
-use crate::builder::{
-	upcast_col, upcast_expr, Col, Expr, TableBuilder, TableWitnessSegment, B1, B8,
-};
+use crate::builder::{upcast_col, Col, Expr, TableBuilder, TableWitnessSegment, B1, B8};
 
 /// The first row of the circulant matrix defining the MixBytes step in Grøstl.
 const MIX_BYTES_VEC: [u8; 8] = [0x02, 0x02, 0x03, 0x04, 0x05, 0x03, 0x05, 0x07];
@@ -327,17 +325,8 @@ struct SBox<const V: usize> {
 
 impl<const V: usize> SBox<V> {
 	pub fn new(table: &mut TableBuilder, input: Expr<B8, V>) -> Self {
-		let b8_basis: [_; 8] = array::from_fn(ext_basis::<B8, B1>);
-		let pack_b8 = move |bits: [Expr<B1, V>; 8]| {
-			bits.into_iter()
-				.enumerate()
-				.map(|(i, bit)| upcast_expr(bit) * b8_basis[i])
-				.reduce(|a, b| a + b)
-				.expect("bits has length 8")
-		};
-
 		let inv_bits = array::from_fn(|i| table.add_committed(format!("inv_bits[{}]", i)));
-		let inv = table.add_computed("inv", pack_b8(inv_bits.map(Expr::from)));
+		let inv = table.add_computed("inv", pack_b8(inv_bits));
 
 		// input * inv == 1 OR inv == 0
 		table.assert_zero("inv_valid_or_inv_zero", input.clone() * Expr::from(inv).pow(2) - inv);
@@ -394,6 +383,15 @@ impl<const V: usize> SBox<V> {
 
 		Ok(())
 	}
+}
+
+fn pack_b8<const V: usize>(bits: [Col<B1, V>; 8]) -> Expr<B8, V> {
+	let b8_basis: [_; 8] = array::from_fn(ext_basis::<B8, B1>);
+	bits.into_iter()
+		.enumerate()
+		.map(|(i, bit)| upcast_col(bit) * b8_basis[i])
+		.reduce(|a, b| a + b)
+		.expect("bits has length 8")
 }
 
 #[cfg(test)]

--- a/crates/m3/src/gadgets/hash/groestl.rs
+++ b/crates/m3/src/gadgets/hash/groestl.rs
@@ -11,6 +11,7 @@ use array_util::ArrayExt;
 use binius_core::oracle::ShiftVariant;
 use binius_field::{
 	as_packed_field::{PackScalar, PackedType},
+	ext_basis,
 	linear_transformation::{
 		FieldLinearTransformation, PackedTransformationFactory, Transformation,
 	},
@@ -326,7 +327,7 @@ struct SBox<const V: usize> {
 
 impl<const V: usize> SBox<V> {
 	pub fn new(table: &mut TableBuilder, input: Expr<B8, V>) -> Self {
-		let b8_basis: [_; 8] = array::from_fn(<B8 as ExtensionField<B1>>::basis);
+		let b8_basis: [_; 8] = array::from_fn(ext_basis::<B8, B1>);
 		let pack_b8 = move |bits: [Expr<B1, V>; 8]| {
 			bits.into_iter()
 				.enumerate()

--- a/crates/m3/src/gadgets/hash/groestl.rs
+++ b/crates/m3/src/gadgets/hash/groestl.rs
@@ -326,9 +326,7 @@ struct SBox<const V: usize> {
 
 impl<const V: usize> SBox<V> {
 	pub fn new(table: &mut TableBuilder, input: Expr<B8, V>) -> Self {
-		let b8_basis: [_; 8] = array::from_fn(|i| {
-			<B8 as ExtensionField<B1>>::basis(i).expect("i in range 0..8; extension degree is 8")
-		});
+		let b8_basis: [_; 8] = array::from_fn(<B8 as ExtensionField<B1>>::basis);
 		let pack_b8 = move |bits: [Expr<B1, V>; 8]| {
 			bits.into_iter()
 				.enumerate()

--- a/crates/math/src/binary_subspace.rs
+++ b/crates/math/src/binary_subspace.rs
@@ -32,7 +32,7 @@ impl<F: BinaryField> BinarySubspace<F> {
 	/// * `Error::DomainSizeTooLarge` if `dim` is greater than this subspace's dimension.
 	pub fn with_dim(dim: usize) -> Result<Self, Error> {
 		let basis = (0..dim)
-			.map(|i| F::basis(i).map_err(|_| Error::DomainSizeTooLarge))
+			.map(|i| F::basis_checked(i).map_err(|_| Error::DomainSizeTooLarge))
 			.collect::<Result<_, _>>()?;
 		Ok(Self { basis })
 	}
@@ -112,9 +112,7 @@ impl<F: BinaryField> BinarySubspace<F> {
 
 impl<F: BinaryField> Default for BinarySubspace<F> {
 	fn default() -> Self {
-		let basis = (0..F::DEGREE)
-			.map(|i| F::basis(i).expect("index is in range"))
-			.collect();
+		let basis = (0..F::DEGREE).map(|i| F::basis(i)).collect();
 		Self { basis }
 	}
 }


### PR DESCRIPTION
The `ext_basis<FExt, FSub>` function is now an easy way to get field extension bases.