### PR TITLE
Flushing constants without OracleIds

### DIFF
--- a/crates/circuits/src/builder/constraint_system.rs
+++ b/crates/circuits/src/builder/constraint_system.rs
@@ -34,7 +34,7 @@ pub struct ConstraintSystemBuilder<'arena> {
 	oracles: Rc<RefCell<MultilinearOracleSet<F>>>,
 	constraints: ConstraintSetBuilder<F>,
 	non_zero_oracle_ids: Vec<OracleId>,
-	flushes: Vec<Flush>,
+	flushes: Vec<Flush<F>>,
 	exponents: Vec<Exp<F>>,
 	step_down_dedup: HashMap<(usize, usize), OracleId>,
 	witness: Option<witness::Builder<'arena>>,
@@ -116,6 +116,7 @@ impl<'arena> ConstraintSystemBuilder<'arena> {
 	where
 		U: PackScalar<BinaryField1b>,
 	{	
+		//We assume there is atleast one non constant in the collection of oracle ids.
 		let non_const_oracles: Vec<usize> = oracle_ids.clone().into_iter().filter_map(|id|match id {
 			OracleOrConst::Oracle(oracle_id)	=> Some(oracle_id),
 			OracleOrConst::Const{ base, tower_level} => None
@@ -151,6 +152,7 @@ impl<'arena> ConstraintSystemBuilder<'arena> {
 		oracle_ids: impl IntoIterator<Item = OracleOrConst<F>> + Clone,
 		multiplicity: u64,
 	) -> anyhow::Result<()> {
+		//We assume there is atleast one non constant in the collection of oracle ids.
 		let non_const_oracles: Vec<usize> = oracle_ids.clone().into_iter().filter_map(|id|match id {
 			OracleOrConst::Oracle(oracle_id)	=> Some(oracle_id),
 			OracleOrConst::Const{ base, tower_level} => None

--- a/crates/circuits/src/collatz.rs
+++ b/crates/circuits/src/collatz.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_core::{
-	constraint_system::channel::{Boundary, ChannelId, FlushDirection},
+	constraint_system::channel::{Boundary, ChannelId, FlushDirection, OracleOrConst},
 	oracle::OracleId,
 };
 use binius_field::{
@@ -85,10 +85,10 @@ impl Collatz {
 		let half = arithmetic::u32::half(builder, "half", even, arithmetic::Flags::Checked)?;
 
 		let even_packed = arithmetic::u32::packed(builder, "even_packed", even)?;
-		builder.receive(channel, count, [even_packed])?;
+		builder.receive(channel, count, [OracleOrConst::Oracle(even_packed)])?;
 
 		let half_packed = arithmetic::u32::packed(builder, "half_packed", half)?;
-		builder.send(channel, count, [half_packed])?;
+		builder.send(channel, count, [OracleOrConst::Oracle(half_packed)])?;
 
 		Ok(())
 	}
@@ -126,11 +126,11 @@ impl Collatz {
 		)?;
 
 		let odd_packed = arithmetic::u32::packed(builder, "odd_packed", odd)?;
-		builder.receive(channel, count, [odd_packed])?;
+		builder.receive(channel, count, [OracleOrConst::Oracle(odd_packed)])?;
 
 		let triple_plus_one_packed =
 			arithmetic::u32::packed(builder, "triple_plus_one_packed", triple_plus_one)?;
-		builder.send(channel, count, [triple_plus_one_packed])?;
+		builder.send(channel, count, [OracleOrConst::Oracle(triple_plus_one_packed)])?;
 
 		Ok(())
 	}

--- a/crates/circuits/src/lasso/lasso.rs
+++ b/crates/circuits/src/lasso/lasso.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use anyhow::{ensure, Error, Result};
-use binius_core::{constraint_system::channel::ChannelId, oracle::OracleId};
+use binius_core::{constraint_system::channel::{ChannelId, OracleOrConst}, oracle::OracleId};
 use binius_field::{
 	as_packed_field::{PackScalar, PackedType},
 	ExtensionField, Field, PackedFieldIndexable, TowerField,
@@ -124,20 +124,20 @@ where
 	let oracles_prefix_t = lookup_t.as_ref().iter().copied();
 
 	// populate table using initial timestamps
-	builder.send(channel, 1 << t_log_rows, oracles_prefix_t.clone().chain([lookup_o]))?;
+	builder.send(channel, 1 << t_log_rows, oracles_prefix_t.clone().chain([lookup_o]).map(|id| OracleOrConst::Oracle(id)))?;
 
 	// for every value looked up, pull using current timestamp and push with incremented timestamp
 	izip!(lookups_u, lookups_r, lookups_w, n_lookups).try_for_each(
 		|(lookup_u, lookup_r, lookup_w, &n_lookup)| -> Result<()> {
 			let oracle_prefix_u = lookup_u.as_ref().iter().copied();
-			builder.receive(channel, n_lookup, oracle_prefix_u.clone().chain([lookup_r]))?;
-			builder.send(channel, n_lookup, oracle_prefix_u.chain([lookup_w]))?;
+			builder.receive(channel, n_lookup, oracle_prefix_u.clone().chain([lookup_r]).map(|id| OracleOrConst::Oracle(id)))?;
+			builder.send(channel, n_lookup, oracle_prefix_u.chain([lookup_w]).map(|id| OracleOrConst::Oracle(id)))?;
 			Ok(())
 		},
 	)?;
 
 	// depopulate table using final timestamps
-	builder.receive(channel, 1 << t_log_rows, oracles_prefix_t.chain([lookup_f]))?;
+	builder.receive(channel, 1 << t_log_rows, oracles_prefix_t.chain([lookup_f]).map(|id| OracleOrConst::Oracle(id)))?;
 
 	Ok(())
 }

--- a/crates/circuits/src/lib.rs
+++ b/crates/circuits/src/lib.rs
@@ -28,7 +28,7 @@ mod tests {
 	use binius_core::{
 		constraint_system::{
 			self,
-			channel::{validate_witness, Boundary, FlushDirection},
+			channel::{validate_witness, Boundary, FlushDirection, OracleOrConst},
 		},
 		fiat_shamir::HasherChallenger,
 		oracle::ShiftVariant,
@@ -125,16 +125,16 @@ mod tests {
 		}
 
 		builder
-			.flush(FlushDirection::Pull, channel_id, even_counter, [even])
+			.flush(FlushDirection::Pull, channel_id, even_counter, [OracleOrConst::Oracle(even)])
 			.unwrap();
 		builder
-			.flush(FlushDirection::Push, channel_id, even_counter, [half])
+			.flush(FlushDirection::Push, channel_id, even_counter, [OracleOrConst::Oracle(half)])
 			.unwrap();
 		builder
-			.flush(FlushDirection::Pull, channel_id, odd_counter, [odd])
+			.flush(FlushDirection::Pull, channel_id, odd_counter, [OracleOrConst::Oracle(odd)])
 			.unwrap();
 		builder
-			.flush(FlushDirection::Push, channel_id, odd_counter, [output])
+			.flush(FlushDirection::Push, channel_id, odd_counter, [OracleOrConst::Oracle(output)])
 			.unwrap();
 
 		let witness = builder
@@ -246,13 +246,13 @@ mod tests {
 				channel,
 				1 << n_vars,
 				vec![
-					column_x,
-					column_y,
-					column_comp_1,
-					column_shift,
-					column_comp_2,
-					column_packed,
-					column_comp_3,
+					OracleOrConst::Oracle(column_y),
+					OracleOrConst::Oracle(column_x),
+					OracleOrConst::Oracle(column_comp_1),
+					OracleOrConst::Oracle(column_shift),
+					OracleOrConst::Oracle(column_comp_2),
+					OracleOrConst::Oracle(column_packed),
+					OracleOrConst::Oracle(column_comp_3),
 				],
 			)
 			.unwrap();
@@ -261,13 +261,13 @@ mod tests {
 				channel,
 				1 << n_vars,
 				vec![
-					column_x,
-					column_y,
-					column_comp_1,
-					column_shift,
-					column_comp_2,
-					column_packed,
-					column_comp_3,
+					OracleOrConst::Oracle(column_x),
+					OracleOrConst::Oracle(column_y),
+					OracleOrConst::Oracle(column_comp_1),
+					OracleOrConst::Oracle(column_shift),
+					OracleOrConst::Oracle(column_comp_2),
+					OracleOrConst::Oracle(column_packed),
+					OracleOrConst::Oracle(column_comp_3),
 				],
 			)
 			.unwrap();

--- a/crates/circuits/src/plain_lookup.rs
+++ b/crates/circuits/src/plain_lookup.rs
@@ -3,7 +3,7 @@
 use std::{cmp::Reverse, fmt::Debug, hash::Hash};
 
 use anyhow::{ensure, Result};
-use binius_core::{constraint_system::channel::FlushDirection, oracle::OracleId};
+use binius_core::{constraint_system::channel::{FlushDirection, OracleOrConst}, oracle::OracleId};
 use binius_field::{
 	as_packed_field::{PackScalar, PackedType},
 	packed::set_packed_slice,
@@ -143,11 +143,11 @@ where
 	let permutation_channel = builder.add_channel();
 	let multiplicity_channel = builder.add_channel();
 
-	builder.send(permutation_channel, 1 << t_log_rows, permuted_lookup_t.iter().copied())?;
-	builder.receive(permutation_channel, 1 << t_log_rows, lookup_t.as_ref().iter().copied())?;
+	builder.send(permutation_channel, 1 << t_log_rows, permuted_lookup_t.iter().copied().map(|id| OracleOrConst::Oracle(id)))?;
+	builder.receive(permutation_channel, 1 << t_log_rows, lookup_t.as_ref().iter().copied().map(|id| OracleOrConst::Oracle(id)))?;
 
 	for (lookup_u, &count) in izip!(lookups_u, n_lookups) {
-		builder.send(multiplicity_channel, count, lookup_u.as_ref().iter().copied())?;
+		builder.send(multiplicity_channel, count, lookup_u.as_ref().iter().copied().map(|id| OracleOrConst::Oracle(id)))?;
 	}
 
 	for (i, bit) in bits.into_iter().enumerate() {
@@ -155,7 +155,7 @@ where
 			FlushDirection::Pull,
 			multiplicity_channel,
 			bit,
-			permuted_lookup_t.iter().copied(),
+			permuted_lookup_t.iter().copied().map(|id| OracleOrConst::Oracle(id)),
 			1 << i,
 		)?
 	}

--- a/crates/core/src/constraint_system/mod.rs
+++ b/crates/core/src/constraint_system/mod.rs
@@ -30,7 +30,7 @@ pub struct ConstraintSystem<F: TowerField> {
 	pub oracles: MultilinearOracleSet<F>,
 	pub table_constraints: Vec<ConstraintSet<F>>,
 	pub non_zero_oracle_ids: Vec<OracleId>,
-	pub flushes: Vec<Flush>,
+	pub flushes: Vec<Flush<F>>,
 	pub exponents: Vec<Exp<F>>,
 	pub max_channel_id: ChannelId,
 }

--- a/crates/core/src/constraint_system/verify.rs
+++ b/crates/core/src/constraint_system/verify.rs
@@ -11,7 +11,7 @@ use itertools::{izip, multiunzip, Itertools};
 use tracing::instrument;
 
 use super::{
-	channel::Boundary,
+	channel::{Boundary, OracleOrConst},
 	error::{Error, VerificationError},
 	exp, ConstraintSystem, Proof,
 };
@@ -458,6 +458,7 @@ pub fn make_flush_oracles<F: TowerField>(
 ) -> Result<Vec<OracleId>, Error> {
 	let mut mixing_powers = vec![F::ONE];
 	let mut flush_iter = flushes.iter();
+	
 	permutation_challenges
 		.iter()
 		.enumerate()
@@ -466,9 +467,14 @@ pub fn make_flush_oracles<F: TowerField>(
 				.peeking_take_while(|flush| flush.channel_id == channel_id)
 				.map(|flush| {
 					// Check that all flushed oracles have the same number of variables
-					let first_oracle = flush.oracles.first().ok_or(Error::EmptyFlushOracles)?;
-					let n_vars = oracles.n_vars(*first_oracle);
-					for &oracle_id in flush.oracles.iter().skip(1) {
+					let mut non_const_oracles  = flush.oracles.iter().copied().filter_map(|id|match id {
+						OracleOrConst::Oracle(oracle_id)	=> Some(oracle_id),
+						OracleOrConst::Const{ base, tower_level} => None
+					});
+
+					let first_oracle = non_const_oracles.nth(0).ok_or(Error::EmptyFlushOracles)?;
+					let n_vars = oracles.n_vars(first_oracle);
+					for oracle_id in non_const_oracles.skip(1) {
 						let oracle_n_vars = oracles.n_vars(oracle_id);
 						if oracle_n_vars != n_vars {
 							return Err(Error::ChannelFlushNvarsMismatch {
@@ -478,8 +484,13 @@ pub fn make_flush_oracles<F: TowerField>(
 						}
 					}
 
+					let mut non_const_oracles:Vec<usize>  = flush.oracles.iter().copied().filter_map(|id|match id {
+						OracleOrConst::Oracle(oracle_id)	=> Some(oracle_id),
+						OracleOrConst::Const{ base, tower_level} => None
+					}).collect();
+					
 					// Compute powers of the mixing challenge
-					while mixing_powers.len() < flush.oracles.len() {
+					while mixing_powers.len() < non_const_oracles.len() {
 						let last_power = *mixing_powers.last().expect(
 							"mixing_powers is initialized with one element; \
 								mixing_powers never shrinks; \
@@ -488,15 +499,13 @@ pub fn make_flush_oracles<F: TowerField>(
 						mixing_powers.push(last_power * mixing_challenge);
 					}
 
+					
 					let id = oracles
 						.add_named(format!("flush channel_id={channel_id}"))
 						.linear_combination_with_offset(
 							n_vars,
 							*permutation_challenge,
-							flush
-								.oracles
-								.iter()
-								.copied()
+								non_const_oracles.iter().copied()
 								.zip(mixing_powers.iter().copied()),
 						)?;
 					Ok(id)

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -4,7 +4,7 @@ pub use binius_core::constraint_system::channel::{
 	Boundary, Flush as CompiledFlush, FlushDirection,
 };
 use binius_core::{
-	constraint_system::{channel::ChannelId, ConstraintSystem as CompiledConstraintSystem},
+	constraint_system::{channel::{ChannelId, OracleOrConst}, ConstraintSystem as CompiledConstraintSystem},
 	oracle::{
 		Constraint, ConstraintPredicate, ConstraintSet, MultilinearOracleSet, OracleId,
 		ProjectionVariant,
@@ -256,7 +256,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 				{
 					let flush_oracles = column_indices
 						.iter()
-						.map(|&column_index| oracle_lookup[column_index])
+						.map(|&column_index| OracleOrConst::Oracle(oracle_lookup[column_index]))
 						.collect::<Vec<_>>();
 					compiled_flushes.push(CompiledFlush {
 						oracles: flush_oracles,


### PR DESCRIPTION
Added support to allow flushing tuples with constant values without declaring an OracleId.