### PR TITLE
[m3] Gadget to push values to a channel with multiplicity

### DIFF
--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -811,6 +811,13 @@ impl From<BinaryField1b> for u8 {
 	}
 }
 
+impl From<bool> for BinaryField1b {
+	#[inline]
+	fn from(value: bool) -> Self {
+		Self::from(U1::new_unchecked(value.into()))
+	}
+}
+
 impl BinaryField2b {
 	/// Creates value without checking that it is within valid range (0 to 3)
 	///

--- a/crates/field/src/underlier/small_uint.rs
+++ b/crates/field/src/underlier/small_uint.rs
@@ -236,6 +236,18 @@ pub type U1 = SmallU<1>;
 pub type U2 = SmallU<2>;
 pub type U4 = SmallU<4>;
 
+impl From<bool> for U1 {
+	fn from(value: bool) -> Self {
+		Self::new_unchecked(value as u8)
+	}
+}
+
+impl From<U1> for bool {
+	fn from(value: U1) -> Self {
+		value == U1::ONE
+	}
+}
+
 impl<const N: usize> SerializeBytes for SmallU<N> {
 	fn serialize(
 		&self,

--- a/crates/m3/src/builder/channel.rs
+++ b/crates/m3/src/builder/channel.rs
@@ -3,6 +3,7 @@
 use binius_core::constraint_system::channel::{ChannelId, FlushDirection};
 
 use super::column::ColumnIndex;
+use crate::builder::{Col, B1};
 
 /// A flushing rule within a table.
 #[derive(Debug)]
@@ -10,7 +11,36 @@ pub struct Flush {
 	pub column_indices: Vec<ColumnIndex>,
 	pub channel_id: ChannelId,
 	pub direction: FlushDirection,
+	/// The number of times the values are flushed to the channel.
+	pub multiplicity: u32,
+	/// An optional reference to a column to select which values to flush.
+	///
+	/// The referenced selector column must hold 1-bit values and contain only zeros after the
+	/// index that is the height of the table. If the selector is `None`, all values up to the
+	/// table height are flushed.
 	pub selector: Option<ColumnIndex>,
+}
+
+/// Options for a channel flush.
+#[derive(Debug)]
+pub struct FlushOpts {
+	/// The number of times the values are flushed to the channel.
+	pub multiplicity: u32,
+	/// An optional reference to a column to select which values to flush.
+	///
+	/// The referenced selector column must hold 1-bit values and contain only zeros after the
+	/// index that is the height of the table. If the selector is `None`, all values up to the
+	/// table height are flushed.
+	pub selector: Option<Col<B1>>,
+}
+
+impl Default for FlushOpts {
+	fn default() -> Self {
+		Self {
+			multiplicity: 1,
+			selector: None,
+		}
+	}
 }
 
 /// A channel.

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -251,6 +251,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 					column_indices,
 					channel_id,
 					direction,
+					multiplicity,
 					selector,
 				} in flushes
 				{
@@ -263,7 +264,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 						channel_id: *channel_id,
 						direction: *direction,
 						selector: selector.unwrap_or(step_down),
-						multiplicity: 1,
+						multiplicity: *multiplicity as u64,
 					});
 				}
 

--- a/crates/m3/src/builder/mod.rs
+++ b/crates/m3/src/builder/mod.rs
@@ -8,6 +8,7 @@ pub mod expr;
 mod multi_iter;
 pub mod statement;
 pub mod table;
+pub mod test_utils;
 pub mod types;
 pub mod witness;
 

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -20,10 +20,10 @@ use binius_utils::{
 
 use super::{
 	channel::Flush,
-	column::{upcast_col, Col, ColumnDef, ColumnInfo, ColumnShape},
+	column::{Col, ColumnDef, ColumnInfo, ColumnShape},
 	expr::{Expr, ZeroConstraint},
 	types::B128,
-	ColumnIndex,
+	upcast_col, ColumnIndex, FlushOpts,
 };
 use crate::builder::column::ColumnId;
 
@@ -253,7 +253,7 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
 	{
-		self.table.partition_mut(1).pull(channel, cols);
+		self.pull_with_opts(channel, cols, FlushOpts::default());
 	}
 
 	pub fn push<FSub>(&mut self, channel: ChannelId, cols: impl IntoIterator<Item = Col<FSub>>)
@@ -261,35 +261,41 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
 	{
-		self.table.partition_mut(1).push(channel, cols);
+		self.push_with_opts(channel, cols, FlushOpts::default());
 	}
 
-	pub fn pull_selected<FSub>(
+	pub fn pull_with_opts<FSub>(
 		&mut self,
 		channel: ChannelId,
 		cols: impl IntoIterator<Item = Col<FSub>>,
-		selector: Col<FSub>,
+		opts: FlushOpts,
 	) where
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
 	{
-		self.table
-			.partition_mut(1)
-			.pull_selected(channel, cols, selector);
+		self.table.partition_mut(1).flush(
+			channel,
+			FlushDirection::Pull,
+			cols.into_iter().map(upcast_col),
+			opts,
+		);
 	}
 
-	pub fn push_selected<FSub>(
+	pub fn push_with_opts<FSub>(
 		&mut self,
 		channel: ChannelId,
 		cols: impl IntoIterator<Item = Col<FSub>>,
-		selector: Col<FSub>,
+		opts: FlushOpts,
 	) where
 		FSub: TowerField,
 		F: ExtensionField<FSub>,
 	{
-		self.table
-			.partition_mut(1)
-			.push_selected(channel, cols, selector);
+		self.table.partition_mut(1).flush(
+			channel,
+			FlushDirection::Push,
+			cols.into_iter().map(upcast_col),
+			opts,
+		);
 	}
 
 	fn namespaced_name(&self, name: impl ToString) -> String {
@@ -331,7 +337,7 @@ pub(super) struct TablePartition<F: TowerField = B128> {
 }
 
 impl<F: TowerField> TablePartition<F> {
-	pub fn new(table_id: TableId, values_per_row: usize) -> Self {
+	fn new(table_id: TableId, values_per_row: usize) -> Self {
 		Self {
 			table_id,
 			values_per_row,
@@ -341,7 +347,7 @@ impl<F: TowerField> TablePartition<F> {
 		}
 	}
 
-	pub fn assert_zero<FSub, const VALUES_PER_ROW: usize>(
+	fn assert_zero<FSub, const VALUES_PER_ROW: usize>(
 		&mut self,
 		name: impl ToString,
 		expr: Expr<FSub, VALUES_PER_ROW>,
@@ -357,62 +363,12 @@ impl<F: TowerField> TablePartition<F> {
 		});
 	}
 
-	pub fn pull<FSub>(&mut self, channel: ChannelId, cols: impl IntoIterator<Item = Col<FSub>>)
-	where
-		FSub: TowerField,
-		F: ExtensionField<FSub>,
-	{
-		self.flush(channel, FlushDirection::Pull, cols.into_iter().map(upcast_col), None)
-	}
-
-	pub fn push<FSub>(&mut self, channel: ChannelId, cols: impl IntoIterator<Item = Col<FSub>>)
-	where
-		FSub: TowerField,
-		F: ExtensionField<FSub>,
-	{
-		self.flush(channel, FlushDirection::Push, cols.into_iter().map(upcast_col), None);
-	}
-
-	pub fn pull_selected<FSub>(
-		&mut self,
-		channel: ChannelId,
-		cols: impl IntoIterator<Item = Col<FSub>>,
-		selector: Col<FSub>,
-	) where
-		FSub: TowerField,
-		F: ExtensionField<FSub>,
-	{
-		self.flush(
-			channel,
-			FlushDirection::Pull,
-			cols.into_iter().map(upcast_col),
-			Some(upcast_col(selector)),
-		)
-	}
-
-	pub fn push_selected<FSub>(
-		&mut self,
-		channel: ChannelId,
-		cols: impl IntoIterator<Item = Col<FSub>>,
-		selector: Col<FSub>,
-	) where
-		FSub: TowerField,
-		F: ExtensionField<FSub>,
-	{
-		self.flush(
-			channel,
-			FlushDirection::Push,
-			cols.into_iter().map(upcast_col),
-			Some(upcast_col(selector)),
-		)
-	}
-
 	fn flush(
 		&mut self,
 		channel_id: ChannelId,
 		direction: FlushDirection,
 		cols: impl IntoIterator<Item = Col<F>>,
-		selector: Option<Col<F>>,
+		opts: FlushOpts,
 	) {
 		let column_indices = cols
 			.into_iter()
@@ -421,11 +377,15 @@ impl<F: TowerField> TablePartition<F> {
 				col.table_index
 			})
 			.collect();
-		let selector = selector.map(|c| c.table_index);
+		let selector = opts.selector.map(|selector| {
+			assert_eq!(selector.table_id, self.table_id);
+			selector.table_index
+		});
 		self.flushes.push(Flush {
 			column_indices,
 			channel_id,
 			direction,
+			multiplicity: opts.multiplicity,
 			selector,
 		});
 	}

--- a/crates/m3/src/builder/test_utils.rs
+++ b/crates/m3/src/builder/test_utils.rs
@@ -1,0 +1,44 @@
+// Copyright 2025 Irreducible Inc.
+
+use anyhow::Result;
+use binius_field::{underlier::UnderlierType, TowerField};
+
+use crate::builder::{TableFiller, TableId, TableWitnessSegment};
+
+///! Utilities for testing M3 constraint systems and gadgets.
+
+pub struct ClosureFiller<'a, U: UnderlierType, F: TowerField, Event> {
+	table_id: TableId,
+	fill:
+		Box<dyn for<'b> Fn(&'b [&'b Event], &'b mut TableWitnessSegment<U, F>) -> Result<()> + 'a>,
+}
+
+impl<'a, U: UnderlierType, F: TowerField, Event> ClosureFiller<'a, U, F, Event> {
+	pub fn new(
+		table_id: TableId,
+		fill: impl for<'b> Fn(&'b [&'b Event], &'b mut TableWitnessSegment<U, F>) -> Result<()> + 'a,
+	) -> Self {
+		Self {
+			table_id,
+			fill: Box::new(fill),
+		}
+	}
+}
+
+impl<'a, U: UnderlierType, F: TowerField, Event: Clone> TableFiller<U, F>
+	for ClosureFiller<'a, U, F, Event>
+{
+	type Event = Event;
+
+	fn id(&self) -> TableId {
+		self.table_id
+	}
+
+	fn fill<'b>(
+		&'b self,
+		rows: impl Iterator<Item = &'b Self::Event> + Clone,
+		witness: &'b mut TableWitnessSegment<U, F>,
+	) -> anyhow::Result<()> {
+		(*self.fill)(&rows.collect::<Vec<_>>(), witness)
+	}
+}

--- a/crates/m3/src/builder/test_utils.rs
+++ b/crates/m3/src/builder/test_utils.rs
@@ -1,12 +1,17 @@
 // Copyright 2025 Irreducible Inc.
 
+//! Utilities for testing M3 constraint systems and gadgets.
+
 use anyhow::Result;
 use binius_field::{underlier::UnderlierType, TowerField};
 
 use crate::builder::{TableFiller, TableId, TableWitnessSegment};
 
-///! Utilities for testing M3 constraint systems and gadgets.
-
+/// An easy-to-use implementation of [`TableFiller`] that is constructed with a closure.
+///
+/// Using this [`TableFiller`] implementation carries some overhead, so it is best to use it only
+/// for testing.
+#[allow(clippy::type_complexity)]
 pub struct ClosureFiller<'a, U: UnderlierType, F: TowerField, Event> {
 	table_id: TableId,
 	fill:
@@ -25,8 +30,8 @@ impl<'a, U: UnderlierType, F: TowerField, Event> ClosureFiller<'a, U, F, Event> 
 	}
 }
 
-impl<'a, U: UnderlierType, F: TowerField, Event: Clone> TableFiller<U, F>
-	for ClosureFiller<'a, U, F, Event>
+impl<U: UnderlierType, F: TowerField, Event: Clone> TableFiller<U, F>
+	for ClosureFiller<'_, U, F, Event>
 {
 	type Event = Event;
 
@@ -38,7 +43,7 @@ impl<'a, U: UnderlierType, F: TowerField, Event: Clone> TableFiller<U, F>
 		&'b self,
 		rows: impl Iterator<Item = &'b Self::Event> + Clone,
 		witness: &'b mut TableWitnessSegment<U, F>,
-	) -> anyhow::Result<()> {
+	) -> Result<()> {
 		(*self.fill)(&rows.collect::<Vec<_>>(), witness)
 	}
 }

--- a/crates/m3/src/gadgets/lookup.rs
+++ b/crates/m3/src/gadgets/lookup.rs
@@ -1,0 +1,238 @@
+// Copyright 2025 Irreducible Inc.
+
+use anyhow::Result;
+use binius_core::constraint_system::channel::ChannelId;
+use binius_field::{
+	as_packed_field::{PackScalar, PackedType},
+	ExtensionField, PackedField, TowerField,
+};
+use itertools::Itertools;
+
+use crate::builder::{Col, FlushOpts, TableBuilder, TableWitnessSegment, B1, B128};
+
+/// A lookup producer gadget is used to create a lookup table.
+///
+/// The lookup producer pushes the value columns to a channel with prover-chosen multiplicities.
+/// This allows consumers of the channel can read any value in the table an arbitrary number of
+/// times. Table values are given as tuples of column entries.
+#[derive(Debug)]
+pub struct LookupProducer {
+	multiplicity_bits: Vec<Col<B1>>,
+}
+
+impl LookupProducer {
+	pub fn new<FSub>(
+		table: &mut TableBuilder,
+		chan: ChannelId,
+		value_cols: &[Col<FSub>],
+		n_multiplicity_bits: usize,
+	) -> Self
+	where
+		B128: ExtensionField<FSub>,
+		FSub: TowerField,
+	{
+		let multiplicity_bits = (0..n_multiplicity_bits)
+			.map(|i| table.add_committed::<B1, 1>(format!("multiplicity_bits[{i}]")))
+			.collect::<Vec<_>>();
+
+		for (i, &multiplicity_col) in multiplicity_bits.iter().enumerate() {
+			table.push_with_opts(
+				chan,
+				value_cols.iter().copied(),
+				FlushOpts {
+					multiplicity: 1 << i,
+					selector: Some(multiplicity_col),
+				},
+			);
+		}
+
+		Self { multiplicity_bits }
+	}
+
+	/// Populate the multiplicity witness columns.
+	///
+	/// ## Pre-condition
+	///
+	/// * Multiplicities must be sorted in ascending order.
+	pub fn populate<U>(
+		&self,
+		index: &mut TableWitnessSegment<U>,
+		counts: impl Iterator<Item = u32> + Clone,
+	) -> Result<(), anyhow::Error>
+	where
+		U: PackScalar<B1>,
+	{
+		// TODO: Optimize the gadget for bit-transposing u32s
+		for (j, &multiplicity_col) in self.multiplicity_bits.iter().enumerate().take(32) {
+			let mut multiplicity_col = index.get_mut(multiplicity_col)?;
+			for (packed, counts) in multiplicity_col
+				.iter_mut()
+				.zip(&counts.clone().chunks(<PackedType<U, B1>>::WIDTH))
+			{
+				for (i, count) in counts.enumerate() {
+					packed.set(i, B1::from((count >> j) & 1 == 1))
+				}
+			}
+		}
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{cmp::Reverse, iter, iter::repeat_with};
+
+	use binius_field::{arch::OptimalUnderlier128b, underlier::UnderlierType};
+	use bumpalo::Bump;
+	use rand::{rngs::StdRng, Rng, SeedableRng};
+
+	use super::*;
+	use crate::builder::{ConstraintSystem, Statement, TableFiller, TableId};
+
+	struct ClosureFiller<'a, U: UnderlierType, F: TowerField, Event> {
+		table_id: TableId,
+		fill: Box<
+			dyn for<'b> Fn(&'b [&'b Event], &'b mut TableWitnessSegment<U, F>) -> Result<()> + 'a,
+		>,
+	}
+
+	impl<'a, U: UnderlierType, F: TowerField, Event> ClosureFiller<'a, U, F, Event> {
+		fn new(
+			table_id: TableId,
+			fill: impl for<'b> Fn(&'b [&'b Event], &'b mut TableWitnessSegment<U, F>) -> Result<()> + 'a,
+		) -> Self {
+			Self {
+				table_id,
+				fill: Box::new(fill),
+			}
+		}
+	}
+
+	impl<'a, U: UnderlierType, F: TowerField, Event: Clone> TableFiller<U, F>
+		for ClosureFiller<'a, U, F, Event>
+	{
+		type Event = Event;
+
+		fn id(&self) -> TableId {
+			self.table_id
+		}
+
+		fn fill<'b>(
+			&'b self,
+			rows: impl Iterator<Item = &'b Self::Event> + Clone,
+			witness: &'b mut TableWitnessSegment<U, F>,
+		) -> Result<()> {
+			(*self.fill)(&rows.collect::<Vec<_>>(), witness)
+		}
+	}
+
+	#[test]
+	fn test_basic_lookup_producer() {
+		let mut cs = ConstraintSystem::new();
+		let chan = cs.add_channel("values");
+
+		let mut lookup_table = cs.add_table("lookup");
+		let lookup_table_id = lookup_table.id();
+		let values_col = lookup_table.add_committed::<B128, 1>("values");
+		let lookup_producer = LookupProducer::new(&mut lookup_table, chan, &[values_col], 8);
+
+		let mut looker_1 = cs.add_table("looker 1");
+		let looker_1_id = looker_1.id();
+		let looker_1_vals = looker_1.add_committed::<B128, 1>("values");
+		looker_1.pull(chan, [looker_1_vals]);
+
+		let mut looker_2 = cs.add_table("looker 2");
+		let looker_2_id = looker_2.id();
+		let looker_2_vals = looker_2.add_committed::<B128, 1>("values");
+		looker_2.pull(chan, [looker_2_vals]);
+
+		let lookup_table_size = 45;
+		let mut rng = StdRng::seed_from_u64(0);
+		let values = repeat_with(|| B128::random(&mut rng))
+			.take(lookup_table_size)
+			.collect::<Vec<_>>();
+
+		let mut counts = vec![0u32; lookup_table_size];
+
+		let looker_1_size = 56;
+		let inputs_1 = repeat_with(|| {
+			let index = rng.gen_range(0..lookup_table_size);
+			counts[index] += 1;
+			values[index]
+		})
+		.take(looker_1_size)
+		.collect::<Vec<_>>();
+
+		let looker_2_size = 67;
+		let inputs_2 = repeat_with(|| {
+			let index = rng.gen_range(0..lookup_table_size);
+			counts[index] += 1;
+			values[index]
+		})
+		.take(looker_2_size)
+		.collect::<Vec<_>>();
+
+		let values_and_counts = iter::zip(values, counts)
+			.sorted_unstable_by_key(|&(_val, count)| Reverse(count))
+			.collect::<Vec<_>>();
+
+		let statement = Statement {
+			boundaries: vec![],
+			table_sizes: vec![lookup_table_size, looker_1_size, looker_2_size],
+		};
+		let allocator = Bump::new();
+		let mut witness = cs
+			.build_witness::<OptimalUnderlier128b>(&allocator, &statement)
+			.unwrap();
+
+		// Fill the lookup table
+		witness
+			.fill_table_sequential(
+				&ClosureFiller::new(lookup_table_id, |values_and_counts, witness| {
+					{
+						let mut values_col = witness.get_scalars_mut(values_col)?;
+						for (dst, (val, _)) in iter::zip(&mut *values_col, values_and_counts) {
+							*dst = *val;
+						}
+					}
+					lookup_producer
+						.populate(witness, values_and_counts.iter().map(|(_, count)| *count))?;
+					Ok(())
+				}),
+				&values_and_counts,
+			)
+			.unwrap();
+
+		// Fill looker tables
+		witness
+			.fill_table_sequential(
+				&ClosureFiller::new(looker_1_id, |inputs_1, witness| {
+					let mut looker_1_vals = witness.get_scalars_mut(looker_1_vals)?;
+					for (dst, src) in iter::zip(&mut *looker_1_vals, inputs_1) {
+						*dst = **src;
+					}
+					Ok(())
+				}),
+				&inputs_1,
+			)
+			.unwrap();
+
+		witness
+			.fill_table_sequential(
+				&ClosureFiller::new(looker_2_id, |inputs_2, witness| {
+					let mut looker_2_vals = witness.get_scalars_mut(looker_2_vals)?;
+					for (dst, src) in iter::zip(&mut *looker_2_vals, inputs_2) {
+						*dst = **src;
+					}
+					Ok(())
+				}),
+				&inputs_2,
+			)
+			.unwrap();
+
+		let ccs = cs.compile(&statement).unwrap();
+		let witness = witness.into_multilinear_extension_index();
+
+		binius_core::constraint_system::validate::validate_witness(&ccs, &[], &witness).unwrap();
+	}
+}

--- a/crates/m3/src/gadgets/lookup.rs
+++ b/crates/m3/src/gadgets/lookup.rs
@@ -82,49 +82,12 @@ impl LookupProducer {
 mod tests {
 	use std::{cmp::Reverse, iter, iter::repeat_with};
 
-	use binius_field::{arch::OptimalUnderlier128b, underlier::UnderlierType};
+	use binius_field::arch::OptimalUnderlier128b;
 	use bumpalo::Bump;
 	use rand::{rngs::StdRng, Rng, SeedableRng};
 
 	use super::*;
-	use crate::builder::{ConstraintSystem, Statement, TableFiller, TableId};
-
-	struct ClosureFiller<'a, U: UnderlierType, F: TowerField, Event> {
-		table_id: TableId,
-		fill: Box<
-			dyn for<'b> Fn(&'b [&'b Event], &'b mut TableWitnessSegment<U, F>) -> Result<()> + 'a,
-		>,
-	}
-
-	impl<'a, U: UnderlierType, F: TowerField, Event> ClosureFiller<'a, U, F, Event> {
-		fn new(
-			table_id: TableId,
-			fill: impl for<'b> Fn(&'b [&'b Event], &'b mut TableWitnessSegment<U, F>) -> Result<()> + 'a,
-		) -> Self {
-			Self {
-				table_id,
-				fill: Box::new(fill),
-			}
-		}
-	}
-
-	impl<'a, U: UnderlierType, F: TowerField, Event: Clone> TableFiller<U, F>
-		for ClosureFiller<'a, U, F, Event>
-	{
-		type Event = Event;
-
-		fn id(&self) -> TableId {
-			self.table_id
-		}
-
-		fn fill<'b>(
-			&'b self,
-			rows: impl Iterator<Item = &'b Self::Event> + Clone,
-			witness: &'b mut TableWitnessSegment<U, F>,
-		) -> Result<()> {
-			(*self.fill)(&rows.collect::<Vec<_>>(), witness)
-		}
-	}
+	use crate::builder::{test_utils::ClosureFiller, ConstraintSystem, Statement};
 
 	#[test]
 	fn test_basic_lookup_producer() {

--- a/crates/m3/src/gadgets/mod.rs
+++ b/crates/m3/src/gadgets/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
 
 pub mod hash;
+pub mod lookup;
 pub mod u32;


### PR DESCRIPTION
This is a port of the "plain" lookup argument. In future PRs, we will

1. Optimize the grand product argument prover computations by leveraging the zero-extended structure of the multiplicity bit columns.
2. Create a mechanism for computing multiplicities into indexed lookup tables without requiring the emulation phase to count multiplicities itself.