### PR TITLE
New transparents added for lookups.

### DIFF
--- a/crates/core/src/transparent/add_with_carry.rs
+++ b/crates/core/src/transparent/add_with_carry.rs
@@ -1,3 +1,4 @@
+// Copyright 2024-2025 Irreducible Inc.
 use binius_field::{BinaryField1b, BinaryField32b, ExtensionField, TowerField};
 use binius_macros::{DeserializeBytes, SerializeBytes};
 use binius_utils::bail;

--- a/crates/core/src/transparent/add_with_carry.rs
+++ b/crates/core/src/transparent/add_with_carry.rs
@@ -82,7 +82,7 @@ mod tests {
 		//Covers the possibility of a = 255 and cin = 1
 		let (mut res_int, mut c_out_int) = a_int.overflowing_add(cin_int);
 
-		if c_out_int{
+		if c_out_int {
 			res_int += b_int
 		} else {
 			(res_int, c_out_int) = res_int.overflowing_add(b_int)

--- a/crates/core/src/transparent/add_with_carry.rs
+++ b/crates/core/src/transparent/add_with_carry.rs
@@ -66,7 +66,7 @@ mod tests {
 		let mut query = vec![];
 		for i in 0..8 {
 			let bit = (int >> i) & 1;
-			query.push(BinaryField32b::from(bit as u32));
+			query.push(BinaryField32b::from(bit));
 		}
 		query
 	}
@@ -82,7 +82,7 @@ mod tests {
 		//Covers the possibility of a = 255 and cin = 1
 		let (mut res_int, mut c_out_int) = a_int.overflowing_add(cin_int);
 
-		if c_out_int == true {
+		if c_out_int{
 			res_int += b_int
 		} else {
 			(res_int, c_out_int) = res_int.overflowing_add(b_int)
@@ -95,7 +95,7 @@ mod tests {
 		let a = int_to_query(a_int);
 		let b = int_to_query(b_int);
 		let cin = vec![BinaryField32b::from(cin_int)];
-		let query = vec![cin.clone(), a.clone(), b.clone()].concat();
+		let query = [cin, a, b].concat();
 
 		let add_with_carry = AddWithCarry;
 		let result = add_with_carry.evaluate(&query).unwrap();

--- a/crates/core/src/transparent/add_with_carry.rs
+++ b/crates/core/src/transparent/add_with_carry.rs
@@ -1,0 +1,104 @@
+use binius_field::{BinaryField1b, BinaryField32b, ExtensionField, TowerField};
+use binius_macros::{DeserializeBytes, SerializeBytes};
+use binius_utils::bail;
+
+use crate::polynomial::{Error, MultivariatePoly};
+
+///Given a query of size 17, of the form (cin || i || j) the multivariate polynomial returns
+///a B32 element whose representation is of the form:
+///(cout || cin ||(i+j added as 8 bit integers without the overflow)|| i || j )
+///where cin and cout represent carry in and carry out of bitwise addition of integers  
+
+#[derive(Debug, Copy, Clone, SerializeBytes, DeserializeBytes)]
+pub struct AddWithCarry;
+
+impl<F: TowerField + ExtensionField<BinaryField32b>> MultivariatePoly<F> for AddWithCarry {
+	fn degree(&self) -> usize {
+		2
+	}
+
+	fn n_vars(&self) -> usize {
+		17
+	}
+
+	//Given a query of size n_vars, split it into two halves and evaluates the polynomial
+
+	fn evaluate(&self, query: &[F]) -> Result<F, Error> {
+		if query.len() != 17 {
+			bail!(Error::IncorrectQuerySize { expected: 17 });
+		}
+
+		let (mut cin, a, b) = (query[0], &query[1..9], &query[9..17]);
+
+		let mut result = cin * <BinaryField32b as ExtensionField<BinaryField1b>>::basis(1);
+
+		for i in 0..8 {
+			//Computing the sum of a and b as integers with bitwise add and carry logic
+			result += (a[i] + b[i] + cin)
+				* <BinaryField32b as ExtensionField<BinaryField1b>>::basis(i + 2);
+			cin = (a[i] + cin) * (b[i] + cin) + cin;
+
+			//Computing the latter part of the output, which is the concatenation of a and b
+			result += a[i] * <BinaryField32b as ExtensionField<BinaryField1b>>::basis(i + 10);
+			result += b[i] * <BinaryField32b as ExtensionField<BinaryField1b>>::basis(i + 18);
+		}
+
+		//Final value of cin is the carry out
+		result += cin;
+
+		Ok(result)
+	}
+
+	fn binary_tower_level(&self) -> usize {
+		5
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::BinaryField32b;
+	use rand::{thread_rng, Rng};
+
+	use super::*;
+
+	fn int_to_query(int: u32) -> Vec<BinaryField32b> {
+		let mut query = vec![];
+		for i in 0..8 {
+			let bit = (int >> i) & 1;
+			query.push(BinaryField32b::from(bit as u32));
+		}
+		query
+	}
+
+	//We compare the result of the polynomial with the result of bitwise addition as integers.
+	#[test]
+	fn test_add_with_carry() {
+		let mut rng = thread_rng();
+		let a_int = rng.gen::<u8>();
+		let b_int = rng.gen::<u8>();
+		let cin_int = rng.gen::<bool>() as u8;
+
+		//Covers the possibility of a = 255 and cin = 1
+		let (mut res_int, mut c_out_int) = a_int.overflowing_add(cin_int);
+
+		if c_out_int == true {
+			res_int += b_int
+		} else {
+			(res_int, c_out_int) = res_int.overflowing_add(b_int)
+		}
+
+		let (a_int, b_int, cin_int, res_int) =
+			(a_int as u32, b_int as u32, cin_int as u32, res_int as u32);
+		let result_int =
+			(c_out_int as u32) + (cin_int << 1) + (res_int << 2) + (a_int << 10) + (b_int << 18);
+		let a = int_to_query(a_int);
+		let b = int_to_query(b_int);
+		let cin = vec![BinaryField32b::from(cin_int)];
+		let query = vec![cin.clone(), a.clone(), b.clone()].concat();
+
+		let add_with_carry = AddWithCarry;
+		let result = add_with_carry.evaluate(&query).unwrap();
+
+		assert_eq!(result_int, result.val())
+	}
+}

--- a/crates/core/src/transparent/add_with_carry.rs
+++ b/crates/core/src/transparent/add_with_carry.rs
@@ -34,7 +34,6 @@ impl<F: TowerField + ExtensionField<BinaryField32b>> MultivariatePoly<F> for Add
 	///
 	///The polynomial can then be defined as:
 	///$$P(x; y; cin) =  cin.b_{24} + carry_8(x; y; cin).b_{25} + \sum_{i=0}^{7} x_ib_i + y_ib_{i+8} + \left(x_i + y_i + carry_i(x;y;cin)\right)b_{i+16} $$
-
 	fn evaluate(&self, query: &[F]) -> Result<F, Error> {
 		if query.len() != 17 {
 			bail!(Error::IncorrectQuerySize { expected: 17 });

--- a/crates/core/src/transparent/and.rs
+++ b/crates/core/src/transparent/and.rs
@@ -1,3 +1,4 @@
+// Copyright 2024-2025 Irreducible Inc.
 use binius_field::{BinaryField1b, BinaryField32b, ExtensionField, TowerField};
 use binius_macros::{DeserializeBytes, SerializeBytes};
 use binius_utils::bail;

--- a/crates/core/src/transparent/and.rs
+++ b/crates/core/src/transparent/and.rs
@@ -67,7 +67,7 @@ mod tests {
 		let mut query = vec![];
 		for i in 0..8 {
 			let bit = (int >> i) & 1;
-			query.push(BinaryField32b::from(bit as u32));
+			query.push(BinaryField32b::from(bit));
 		}
 		query
 	}
@@ -82,7 +82,7 @@ mod tests {
 		let result_int = a_int + (b_int << 8) + (c_int << 16);
 		let a = int_to_query(a_int);
 		let b = int_to_query(b_int);
-		let query = vec![a.clone(), b.clone()].concat();
+		let query = [a, b].concat();
 
 		let and = And::new(16);
 		let result = and.evaluate(&query).unwrap();

--- a/crates/core/src/transparent/and.rs
+++ b/crates/core/src/transparent/and.rs
@@ -90,7 +90,7 @@ mod tests {
 		let b = int_to_query(b_int);
 		let query = [a, b].concat();
 
-		let and = And::new(16);
+		let and = And::new(8);
 		let result = and.evaluate(&query).unwrap();
 
 		assert_eq!(result_int, result.val())

--- a/crates/core/src/transparent/and.rs
+++ b/crates/core/src/transparent/and.rs
@@ -1,0 +1,92 @@
+use binius_field::{BinaryField1b, BinaryField32b, ExtensionField, TowerField};
+use binius_macros::{DeserializeBytes, SerializeBytes};
+use binius_utils::bail;
+
+use crate::polynomial::{Error, MultivariatePoly};
+
+#[derive(Debug, Copy, Clone, SerializeBytes, DeserializeBytes)]
+pub struct And {
+	n_vars: usize,
+}
+
+impl And {
+	pub fn new(n_vars: usize) -> Self {
+		assert!(n_vars > 0, "n_vars must be greater than 0");
+		assert!(n_vars <= 16, "n_vars must be less than or equal to 16");
+		assert!(n_vars % 2 == 0, "n_vars must be even");
+		Self { n_vars }
+	}
+}
+
+impl<F: TowerField + ExtensionField<BinaryField32b>> MultivariatePoly<F> for And {
+	fn degree(&self) -> usize {
+		2
+	}
+
+	fn n_vars(&self) -> usize {
+		self.n_vars
+	}
+
+	///Given a query of size n even, of the form (i || j) the multivariate polynomial returns
+	///a B32 element whose representation is of the form (i||j||(i & j))
+
+	fn evaluate(&self, query: &[F]) -> Result<F, Error> {
+		if query.len() & 1 != 0 {
+			bail!(Error::IncorrectQuerySize {
+				expected: self.n_vars
+			});
+		}
+		let (a, b) = query.split_at(query.len() / 2);
+
+		let mut result = F::ZERO;
+		for i in 0..query.len() / 2 {
+			result += a[i] * <BinaryField32b as ExtensionField<BinaryField1b>>::basis(i);
+			result += b[i]
+				* <BinaryField32b as ExtensionField<BinaryField1b>>::basis(i + query.len() / 2);
+			result +=
+				a[i] * b[i]
+					* <BinaryField32b as ExtensionField<BinaryField1b>>::basis(i + query.len());
+		}
+		Ok(result)
+	}
+
+	#[doc = " Returns the maximum binary tower level of all constants in the arithmetic expression."]
+	fn binary_tower_level(&self) -> usize {
+		5
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::BinaryField32b;
+	use rand::{thread_rng, Rng};
+
+	use super::*;
+
+	fn int_to_query(int: u32) -> Vec<BinaryField32b> {
+		let mut query = vec![];
+		for i in 0..8 {
+			let bit = (int >> i) & 1;
+			query.push(BinaryField32b::from(bit as u32));
+		}
+		query
+	}
+
+	//We compare the result of the polynomial with the result of bitwise addition as integers.
+	#[test]
+	fn test_and() {
+		let mut rng = thread_rng();
+		let a_int = rng.gen::<u8>() as u32;
+		let b_int = rng.gen::<u8>() as u32;
+		let c_int = a_int & b_int;
+		let result_int = a_int + (b_int << 8) + (c_int << 16);
+		let a = int_to_query(a_int);
+		let b = int_to_query(b_int);
+		let query = vec![a.clone(), b.clone()].concat();
+
+		let and = And::new(16);
+		let result = and.evaluate(&query).unwrap();
+
+		assert_eq!(result_int, result.val())
+	}
+}

--- a/crates/core/src/transparent/and.rs
+++ b/crates/core/src/transparent/and.rs
@@ -30,7 +30,6 @@ impl<F: TowerField + ExtensionField<BinaryField32b>> MultivariatePoly<F> for And
 
 	///Given a query of size n even, of the form (i || j) the multivariate polynomial returns
 	///a B32 element whose representation is of the form (i||j||(i & j))
-
 	fn evaluate(&self, query: &[F]) -> Result<F, Error> {
 		if query.len() & 1 != 0 {
 			bail!(Error::IncorrectQuerySize {

--- a/crates/core/src/transparent/boolean.rs
+++ b/crates/core/src/transparent/boolean.rs
@@ -24,7 +24,10 @@ impl<F: TowerField + ExtensionField<BinaryField32b>> MultivariatePoly<F> for Boo
 	fn n_vars(&self) -> usize {
 		self.n_vars
 	}
-
+	///Let $b_i$ be the enumeration of the basis of B32 over B1 and let (x) denote the query.
+	///let $\mu$ = n_vars
+	///   
+	///$P(x) = \sum_{i=0}^{\mu - 1} x_ib_i$
 	fn evaluate(&self, query: &[F]) -> Result<F, Error> {
 		if query.len() > 32 {
 			bail!(Error::IncorrectQuerySize { expected: 32 });
@@ -46,7 +49,7 @@ impl<F: TowerField + ExtensionField<BinaryField32b>> MultivariatePoly<F> for Boo
 #[cfg(test)]
 mod tests {
 	use binius_field::BinaryField32b;
-	use rand::{thread_rng, Rng};
+	use rand::{rngs::StdRng, Rng, SeedableRng};
 
 	use super::*;
 
@@ -59,10 +62,10 @@ mod tests {
 		query
 	}
 
-	//We compare the result of the polynomial with the result of bitwise addition as integers.
+	//We compare the result of the polynomial with the integer that represents the hypercube point.
 	#[test]
 	fn test_hypercube() {
-		let mut rng = thread_rng();
+		let mut rng = StdRng::seed_from_u64(0);
 		let n_vars = 21;
 		let index = rng.gen_range(0..1 << n_vars);
 		let query = int_to_query(index, n_vars);

--- a/crates/core/src/transparent/boolean.rs
+++ b/crates/core/src/transparent/boolean.rs
@@ -1,0 +1,76 @@
+//Multivariate polynomial that maps points in the hypercube to the corresponding B32 element.
+
+use binius_field::{BinaryField1b, BinaryField32b, ExtensionField, TowerField};
+use binius_macros::{DeserializeBytes, SerializeBytes};
+use binius_utils::bail;
+
+use crate::polynomial::{Error, MultivariatePoly};
+
+#[derive(Debug, Copy, Clone, SerializeBytes, DeserializeBytes)]
+pub struct Boolean {
+	n_vars: usize,
+}
+
+impl Boolean {
+	pub fn new(n_vars: usize) -> Boolean {
+		Boolean { n_vars }
+	}
+}
+
+impl<F: TowerField + ExtensionField<BinaryField32b>> MultivariatePoly<F> for Boolean {
+	fn degree(&self) -> usize {
+		self.n_vars
+	}
+
+	fn n_vars(&self) -> usize {
+		self.n_vars
+	}
+
+	fn evaluate(&self, query: &[F]) -> Result<F, Error> {
+		if query.len() > 32 {
+			bail!(Error::IncorrectQuerySize { expected: 32 });
+		}
+		let mut result = F::ZERO;
+
+		for i in 0..query.len() {
+			result += query[i] * <BinaryField32b as ExtensionField<BinaryField1b>>::basis(i)
+		}
+
+		Ok(result)
+	}
+
+	fn binary_tower_level(&self) -> usize {
+		5
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::BinaryField32b;
+	use rand::{thread_rng, Rng};
+
+	use super::*;
+
+	fn int_to_query(int: u32, n_vars: usize) -> Vec<BinaryField32b> {
+		let mut query = vec![];
+		for i in 0..n_vars {
+			let bit = (int >> i) & 1;
+			query.push(BinaryField32b::from(bit as u32));
+		}
+		query
+	}
+
+	//We compare the result of the polynomial with the result of bitwise addition as integers.
+	#[test]
+	fn test_hypercube() {
+		let mut rng = thread_rng();
+		let n_vars = 21;
+		let index = rng.gen_range(0..1 << n_vars);
+		let query = int_to_query(index, n_vars);
+
+		let hypercube = Boolean::new(n_vars);
+		let result = and.evaluate(&query).unwrap();
+
+		assert_eq!(index, result.val())
+	}
+}

--- a/crates/core/src/transparent/boolean.rs
+++ b/crates/core/src/transparent/boolean.rs
@@ -54,7 +54,7 @@ mod tests {
 		let mut query = vec![];
 		for i in 0..n_vars {
 			let bit = (int >> i) & 1;
-			query.push(BinaryField32b::from(bit as u32));
+			query.push(BinaryField32b::from(bit));
 		}
 		query
 	}

--- a/crates/core/src/transparent/boolean.rs
+++ b/crates/core/src/transparent/boolean.rs
@@ -68,8 +68,8 @@ mod tests {
 		let index = rng.gen_range(0..1 << n_vars);
 		let query = int_to_query(index, n_vars);
 
-		let hypercube = Boolean::new(n_vars);
-		let result = and.evaluate(&query).unwrap();
+		let boolean = Boolean::new(n_vars);
+		let result = boolean.evaluate(&query).unwrap();
 
 		assert_eq!(index, result.val())
 	}

--- a/crates/core/src/transparent/boolean.rs
+++ b/crates/core/src/transparent/boolean.rs
@@ -11,8 +11,8 @@ pub struct Boolean {
 }
 
 impl Boolean {
-	pub fn new(n_vars: usize) -> Boolean {
-		Boolean { n_vars }
+	pub fn new(n_vars: usize) -> Self {
+		Self { n_vars }
 	}
 }
 //Multivariate polynomial that maps points in the hypercube to the corresponding B32 element.
@@ -31,8 +31,8 @@ impl<F: TowerField + ExtensionField<BinaryField32b>> MultivariatePoly<F> for Boo
 		}
 		let mut result = F::ZERO;
 
-		for i in 0..query.len() {
-			result += query[i] * <BinaryField32b as ExtensionField<BinaryField1b>>::basis(i)
+		for (i, &var) in query.iter().enumerate() {
+			result += var * <BinaryField32b as ExtensionField<BinaryField1b>>::basis(i)
 		}
 
 		Ok(result)

--- a/crates/core/src/transparent/boolean.rs
+++ b/crates/core/src/transparent/boolean.rs
@@ -1,5 +1,4 @@
-//Multivariate polynomial that maps points in the hypercube to the corresponding B32 element.
-
+// Copyright 2024-2025 Irreducible Inc.
 use binius_field::{BinaryField1b, BinaryField32b, ExtensionField, TowerField};
 use binius_macros::{DeserializeBytes, SerializeBytes};
 use binius_utils::bail;
@@ -16,7 +15,7 @@ impl Boolean {
 		Boolean { n_vars }
 	}
 }
-
+//Multivariate polynomial that maps points in the hypercube to the corresponding B32 element.
 impl<F: TowerField + ExtensionField<BinaryField32b>> MultivariatePoly<F> for Boolean {
 	fn degree(&self) -> usize {
 		self.n_vars

--- a/crates/core/src/transparent/mod.rs
+++ b/crates/core/src/transparent/mod.rs
@@ -2,10 +2,10 @@
 
 pub mod add_with_carry;
 pub mod and;
+pub mod boolean;
 pub mod constant;
 pub mod disjoint_product;
 pub mod eq_ind;
-pub mod boolean;
 pub mod multilinear_extension;
 pub mod powers;
 pub mod select_row;

--- a/crates/core/src/transparent/mod.rs
+++ b/crates/core/src/transparent/mod.rs
@@ -1,8 +1,11 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+pub mod add_with_carry;
+pub mod and;
 pub mod constant;
 pub mod disjoint_product;
 pub mod eq_ind;
+pub mod boolean;
 pub mod multilinear_extension;
 pub mod powers;
 pub mod select_row;


### PR DESCRIPTION
Additional transparents for:

1. Mapping a point in the boolean hypercube to the appropriate B32 element.
2. Mapping a query (i || j) in the boolean hypercube to (i || j || ( i AND j )).
3. Mapping a query (i || j || cin) in the boolean hypercube to (i || j || (i+j bits sans overflow when added as integers) || cin || cout).