### PR TITLE
Support for no switchover in sumchecks

### DIFF
--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -771,16 +771,21 @@ where
 			nonzero_scalars_prefixes.push(entry.nonzero_scalars_prefix);
 		}
 
-		let prover = EqIndSumcheckProverBuilder::new(backend)
-			.with_nonzero_scalars_prefixes(&nonzero_scalars_prefixes)
-			.build(
-				EvaluationOrder::LowToHigh,
-				multilinears,
-				&eval_point,
-				composite_sum_claims,
-				domain_factory.clone(),
-				immediate_switchover_heuristic,
-			)?;
+		// REVIEW: we extract a type erased multilin from the witness index here,
+		//         but we can do better and move the large-field evals (potentially truncated)
+		//         directly into this sumcheck, as those are not shared
+		let prover = EqIndSumcheckProverBuilder::with_switchover(
+			multilinears,
+			immediate_switchover_heuristic,
+			backend,
+		)?
+		.with_nonzero_scalars_prefixes(&nonzero_scalars_prefixes)?
+		.build(
+			EvaluationOrder::LowToHigh,
+			&eval_point,
+			composite_sum_claims,
+			domain_factory.clone(),
+		)?;
 
 		provers.push(prover);
 		flush_oracle_ids_by_claim.push(flush_oracle_ids);

--- a/crates/core/src/protocols/gkr_exp/batch_prove.rs
+++ b/crates/core/src/protocols/gkr_exp/batch_prove.rs
@@ -171,13 +171,16 @@ where
 
 	izip!(composite_claims, multilinears, eval_points)
 		.map(|(composite_claims, multilinears, eval_point)| {
-			GKRExpProverBuilder::<'a, P, Backend>::new(backend).build(
-				evaluation_order,
+			GKRExpProverBuilder::<'a, P, _, Backend>::with_switchover(
 				multilinears,
+				immediate_switchover_heuristic,
+				backend,
+			)?
+			.build(
+				evaluation_order,
 				&eval_point,
 				composite_claims,
 				evaluation_domain_factory.clone(),
-				immediate_switchover_heuristic,
 			)
 		})
 		.collect::<Result<Vec<_>, _>>()

--- a/crates/core/src/protocols/gkr_exp/common.rs
+++ b/crates/core/src/protocols/gkr_exp/common.rs
@@ -105,7 +105,7 @@ impl<F: Field> BaseExpReductionOutput<F> {
 	}
 }
 
-pub type GKRExpProverBuilder<'a, P, Backend> = EqIndSumcheckProverBuilder<'a, P, Backend>;
+pub type GKRExpProverBuilder<'a, P, M, Backend> = EqIndSumcheckProverBuilder<'a, P, M, Backend>;
 
 pub type GKRExpProver<'a, FDomain, P, Composition, M, Backend> =
 	EqIndSumcheckProver<'a, FDomain, P, Composition, M, Backend>;

--- a/crates/core/src/protocols/gkr_gpa/prove.rs
+++ b/crates/core/src/protocols/gkr_gpa/prove.rs
@@ -314,18 +314,20 @@ where
 			&eq_ind_partial_evals,
 		)?;
 
-		let prover = EqIndSumcheckProverBuilder::new(&first_prover.backend)
-			.with_first_round_eval_1s(&first_round_eval_1s)
-			.with_eq_ind_partial_evals(eq_ind_partial_evals)
-			.build(
-				evaluation_order,
-				multilinears,
-				eq_ind_challenges,
-				composite_claims,
-				evaluation_domain_factory,
-				// We use GPA protocol only for big fields, which is why switchover is trivial
-				immediate_switchover_heuristic,
-			)?;
+		// REVIEW: GPA is only ever used for big fields, we can avoid the switchover
+		let prover = EqIndSumcheckProverBuilder::with_switchover(
+			multilinears,
+			immediate_switchover_heuristic,
+			&first_prover.backend,
+		)?
+		.with_first_round_eval_1s(&first_round_eval_1s)
+		.with_eq_ind_partial_evals(eq_ind_partial_evals)
+		.build(
+			evaluation_order,
+			eq_ind_challenges,
+			composite_claims,
+			evaluation_domain_factory,
+		)?;
 
 		Ok(prover)
 	}

--- a/crates/core/src/protocols/sumcheck/eq_ind.rs
+++ b/crates/core/src/protocols/sumcheck/eq_ind.rs
@@ -324,17 +324,21 @@ mod tests {
 
 		let composite_claim = CompositeSumClaim { sum, composition };
 
-		let prover = EqIndSumcheckProverBuilder::new(&backend)
-			.with_nonzero_scalars_prefixes(&[nonzero_prefix, 1 << n_vars])
-			.build(
-				evaluation_order,
-				vec![a_mle, b_mle],
-				&eq_ind_challenges,
-				[composite_claim.clone()],
-				evaluation_domain_factory,
-				immediate_switchover_heuristic,
-			)
-			.unwrap();
+		let prover = EqIndSumcheckProverBuilder::with_switchover(
+			vec![a_mle, b_mle],
+			immediate_switchover_heuristic,
+			&backend,
+		)
+		.unwrap()
+		.with_nonzero_scalars_prefixes(&[nonzero_prefix, 1 << n_vars])
+		.unwrap()
+		.build(
+			evaluation_order,
+			&eq_ind_challenges,
+			[composite_claim.clone()],
+			evaluation_domain_factory,
+		)
+		.unwrap();
 
 		let (_, const_eval_suffix) = prover.compositions().first().unwrap();
 		assert_eq!(

--- a/crates/core/src/protocols/sumcheck/prove/mod.rs
+++ b/crates/core/src/protocols/sumcheck/prove/mod.rs
@@ -18,7 +18,7 @@ pub use batch_prove_univariate_zerocheck::{
 pub use oracles::{
 	constraint_set_sumcheck_prover, constraint_set_zerocheck_prover, split_constraint_set,
 };
-pub use prover_state::{MultilinearInput, ProverState, SumcheckInterpolator};
+pub use prover_state::{ProverState, SumcheckInterpolator};
 pub use regular_sumcheck::RegularSumcheckProver;
 pub use univariate::{reduce_to_skipped_projection, univariatizing_reduction_prover};
 pub use zerocheck::UnivariateZerocheck;

--- a/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
@@ -3,7 +3,7 @@
 use std::{marker::PhantomData, ops::Range};
 
 use binius_field::{ExtensionField, Field, PackedExtension, PackedField, TowerField};
-use binius_hal::{ComputationBackend, SumcheckEvaluator};
+use binius_hal::{ComputationBackend, SumcheckEvaluator, SumcheckMultilinear};
 use binius_math::{
 	CompositionPoly, EvaluationDomainFactory, EvaluationOrder, InterpolationDomain,
 	MultilinearPoly, RowsBatchRef,
@@ -18,11 +18,11 @@ use crate::{
 	polynomial::{ArithCircuitPoly, Error as PolynomialError, MultilinearComposite},
 	protocols::sumcheck::{
 		common::{
-			get_nontrivial_evaluation_points, interpolation_domains_for_composition_degrees,
-			CompositeSumClaim, RoundCoeffs,
+			equal_n_vars_check, get_nontrivial_evaluation_points,
+			interpolation_domains_for_composition_degrees, CompositeSumClaim, RoundCoeffs,
 		},
 		error::Error,
-		prove::{MultilinearInput, ProverState, SumcheckInterpolator, SumcheckProver},
+		prove::{ProverState, SumcheckInterpolator, SumcheckProver},
 	},
 };
 
@@ -101,6 +101,7 @@ where
 		switchover_fn: impl Fn(usize) -> usize,
 		backend: &'a Backend,
 	) -> Result<Self, Error> {
+		let n_vars = equal_n_vars_check(&multilinears)?;
 		let composite_claims = composite_claims.into_iter().collect::<Vec<_>>();
 
 		#[cfg(feature = "debug_validate_sumcheck")]
@@ -143,23 +144,19 @@ where
 
 		let nontrivial_evaluation_points = get_nontrivial_evaluation_points(&domains)?;
 
-		let multilinears_input = multilinears
+		let multilinears = multilinears
 			.into_iter()
-			.map(|multilinear| MultilinearInput {
-				multilinear,
-				zero_scalars_suffix: 0,
-			})
+			.map(|multilinear| SumcheckMultilinear::transparent(multilinear, &switchover_fn))
 			.collect();
 
 		let state = ProverState::new(
 			evaluation_order,
-			multilinears_input,
+			n_vars,
+			multilinears,
 			claimed_sums,
 			nontrivial_evaluation_points,
-			switchover_fn,
 			backend,
 		)?;
-		let n_vars = state.n_vars();
 
 		Ok(Self {
 			n_vars,

--- a/crates/hal/src/sumcheck_multilinear.rs
+++ b/crates/hal/src/sumcheck_multilinear.rs
@@ -19,3 +19,51 @@ where
 	/// Large field multilinear - halved in size each round
 	Folded { large_field_folded_evals: Vec<P> },
 }
+
+impl<P: PackedField, M: MultilinearPoly<P>> SumcheckMultilinear<P, M> {
+	pub fn transparent(multilinear: M, switchover_fn: &impl Fn(usize) -> usize) -> Self {
+		let switchover_round = (*switchover_fn)(1 << multilinear.log_extension_degree());
+
+		Self::Transparent {
+			multilinear,
+			switchover_round,
+			zero_scalars_suffix: 0,
+		}
+	}
+
+	pub fn folded(large_field_folded_evals: Vec<P>) -> Self {
+		Self::Folded {
+			large_field_folded_evals,
+		}
+	}
+
+	pub fn zero_scalars_suffix(&self, n_vars: usize) -> usize {
+		match self {
+			Self::Transparent {
+				zero_scalars_suffix,
+				..
+			} => *zero_scalars_suffix,
+			Self::Folded {
+				large_field_folded_evals,
+			} => (1usize << n_vars).saturating_sub(large_field_folded_evals.len() << P::LOG_WIDTH),
+		}
+	}
+
+	pub fn update_zero_scalars_suffix(&mut self, n_vars: usize, new_zero_scalars_suffix: usize) {
+		match self {
+			Self::Transparent {
+				zero_scalars_suffix,
+				..
+			} => {
+				*zero_scalars_suffix = new_zero_scalars_suffix;
+			}
+
+			Self::Folded {
+				large_field_folded_evals,
+			} => {
+				large_field_folded_evals
+					.truncate(((1 << n_vars) - new_zero_scalars_suffix).div_ceil(P::WIDTH));
+			}
+		}
+	}
+}


### PR DESCRIPTION
* Instead of always taking an `M: MultilinearPoly` transparent, `ProverState` ingests `SumcheckMultilinear` directly
* `EqIndSumcheckProverBuilder` was augmented with `no_switchover` constructor, which allows specifying folded `Vec<P>` large field representations by value

Rationale:
* GPA sumchecks operate on large field _unique_ witnesses; using `immediate_switchover_heuristic` still allocates 1.5x witness data, which is totally avoidable when witness is passed by value
* (continuation of the above) Shorter-than-power-of-two folded multilinears are explicitly supported by the HAL, which is useful for optimizing GPAs coming from plain lookups
* In zerocheck univariate round we currently skip at most 7 rounds, which results in folded multilinear still being larger than witness column for 1-bit oracles; this change unlocks potential optimization of passing the Lagrange interpolation inner product query to the follow up `EqIndSumcheck` for pre-switchover usage.