### PR TITLE
Arbitrary multilinear const suffix in sumcheck

### DIFF
--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -763,12 +763,13 @@ where
 		let mut multilinears =
 			Vec::with_capacity(flush_selectors_unique.len() + flush_oracle_ids.len());
 
-		let mut nonzero_scalars_prefixes = Vec::with_capacity(multilinears.len());
+		let mut const_suffixes = Vec::with_capacity(multilinears.len());
 
 		for &oracle_id in chain!(&flush_selectors_unique, &flush_oracle_ids) {
 			let entry = witness.get_index_entry(oracle_id)?;
+			let suffix_len = (1 << entry.multilin_poly.n_vars()) - entry.nonzero_scalars_prefix;
 			multilinears.push(entry.multilin_poly);
-			nonzero_scalars_prefixes.push(entry.nonzero_scalars_prefix);
+			const_suffixes.push((Field::ZERO, suffix_len));
 		}
 
 		// REVIEW: we extract a type erased multilin from the witness index here,
@@ -779,7 +780,7 @@ where
 			immediate_switchover_heuristic,
 			backend,
 		)?
-		.with_nonzero_scalars_prefixes(&nonzero_scalars_prefixes)?
+		.with_const_suffixes(&const_suffixes)?
 		.build(
 			EvaluationOrder::LowToHigh,
 			&eval_point,

--- a/crates/core/src/protocols/sumcheck/eq_ind.rs
+++ b/crates/core/src/protocols/sumcheck/eq_ind.rs
@@ -330,7 +330,7 @@ mod tests {
 			&backend,
 		)
 		.unwrap()
-		.with_nonzero_scalars_prefixes(&[nonzero_prefix, 1 << n_vars])
+		.with_const_suffixes(&[(F::ZERO, (1 << n_vars) - nonzero_prefix), (F::ZERO, 0)])
 		.unwrap()
 		.build(
 			evaluation_order,

--- a/crates/core/src/protocols/sumcheck/error.rs
+++ b/crates/core/src/protocols/sumcheck/error.rs
@@ -63,8 +63,8 @@ pub enum Error {
 	IncorrectEqIndChallengesLength,
 	#[error("zerocheck challenges number does not equal number of variables")]
 	IncorrectZerocheckChallengesLength,
-	#[error("zero scalars suffixes length does not equal multilinear count, or suffix is longer than multilinear")]
-	IncorrectZeroScalarsSuffixes,
+	#[error("suffixes count not equal to multilinear count, const suffix longer than multilinear, or not const")]
+	IncorrectConstSuffixes,
 	#[error("incorrect size of the equality indicator expansion in eq_ind sumcheck")]
 	IncorrectEqIndPartialEvalsSize,
 	#[error("incorrect size of the partially evaluated zerocheck equality indicator")]

--- a/crates/core/src/protocols/sumcheck/prove/eq_ind.rs
+++ b/crates/core/src/protocols/sumcheck/prove/eq_ind.rs
@@ -48,8 +48,8 @@ where
 	}
 
 	for multilinear in multilinears {
-		match multilinear {
-			&SumcheckMultilinear::Transparent {
+		match *multilinear {
+			SumcheckMultilinear::Transparent {
 				ref multilinear,
 				const_suffix: (suffix_eval, suffix_len),
 				..
@@ -69,7 +69,7 @@ where
 				}
 			}
 
-			&SumcheckMultilinear::Folded {
+			SumcheckMultilinear::Folded {
 				large_field_folded_evals: ref evals,
 				..
 			} => {

--- a/crates/core/src/protocols/sumcheck/prove/eq_ind.rs
+++ b/crates/core/src/protocols/sumcheck/prove/eq_ind.rs
@@ -479,7 +479,10 @@ where
 
 			for &(var_index, (suffix_eval, suffix)) in &const_suffixes {
 				expr = expr.const_subst(var_index, suffix_eval).optimize();
-				expr_at_inf = expr_at_inf.const_subst(var_index, suffix_eval).optimize();
+				// NB: infinity point has a different interpolation result; in characteristic 2, it's always zero.
+				expr_at_inf = expr_at_inf
+					.const_subst(var_index, suffix_eval + suffix_eval)
+					.optimize();
 
 				if let Some((value, value_at_inf)) = expr.constant().zip(expr_at_inf.constant()) {
 					const_eval_suffix = ConstEvalSuffix {

--- a/crates/core/src/protocols/sumcheck/prove/prover_state.rs
+++ b/crates/core/src/protocols/sumcheck/prove/prover_state.rs
@@ -80,8 +80,8 @@ where
 		backend: &'a Backend,
 	) -> Result<Self, Error> {
 		for multilinear in &multilinears {
-			match multilinear {
-				&SumcheckMultilinear::Transparent {
+			match *multilinear {
+				SumcheckMultilinear::Transparent {
 					ref multilinear,
 					const_suffix: (_, suffix_len),
 					..
@@ -95,7 +95,7 @@ where
 					}
 				}
 
-				&SumcheckMultilinear::Folded {
+				SumcheckMultilinear::Folded {
 					large_field_folded_evals: ref evals,
 					..
 				} => {

--- a/crates/core/src/protocols/sumcheck/prove/prover_state.rs
+++ b/crates/core/src/protocols/sumcheck/prove/prover_state.rs
@@ -81,25 +81,26 @@ where
 	) -> Result<Self, Error> {
 		for multilinear in &multilinears {
 			match multilinear {
-				SumcheckMultilinear::Transparent {
-					multilinear,
-					zero_scalars_suffix,
+				&SumcheckMultilinear::Transparent {
+					ref multilinear,
+					const_suffix: (_, suffix_len),
 					..
 				} => {
 					if multilinear.n_vars() != n_vars {
 						bail!(Error::NumberOfVariablesMismatch);
 					}
 
-					if *zero_scalars_suffix > 1 << n_vars {
-						bail!(Error::IncorrectZeroScalarsSuffixes);
+					if suffix_len > 1 << n_vars {
+						bail!(Error::IncorrectConstSuffixes);
 					}
 				}
 
-				SumcheckMultilinear::Folded {
-					large_field_folded_evals,
+				&SumcheckMultilinear::Folded {
+					large_field_folded_evals: ref evals,
+					..
 				} => {
-					if large_field_folded_evals.len() > 1 << n_vars.saturating_sub(P::LOG_WIDTH) {
-						bail!(Error::IncorrectZeroScalarsSuffixes);
+					if evals.len() > 1 << n_vars.saturating_sub(P::LOG_WIDTH) {
+						bail!(Error::IncorrectConstSuffixes);
 					}
 				}
 			}
@@ -209,9 +210,10 @@ where
 					}
 					SumcheckMultilinear::Folded {
 						large_field_folded_evals,
+						suffix_eval,
 					} => Ok(large_field_folded_evals
 						.first()
-						.map_or(F::ZERO, |packed| packed.get(0))
+						.map_or(suffix_eval, |packed| packed.get(0))
 						.get(0)),
 				}
 				.map_err(Error::MathError)

--- a/crates/hal/src/sumcheck_folding.rs
+++ b/crates/hal/src/sumcheck_folding.rs
@@ -46,8 +46,8 @@ where
 {
 	assert!(n_vars > 0);
 	parallel_map(multilinears, |sumcheck_multilinear| -> Result<_, Error> {
-		match sumcheck_multilinear {
-			&mut SumcheckMultilinear::Transparent {
+		match *sumcheck_multilinear {
+			SumcheckMultilinear::Transparent {
 				ref multilinear,
 				ref mut switchover_round,
 				const_suffix: (suffix_eval, suffix_len),
@@ -109,7 +109,7 @@ where
 				}
 			}
 
-			&mut SumcheckMultilinear::Folded {
+			SumcheckMultilinear::Folded {
 				large_field_folded_evals: ref mut evals,
 				suffix_eval,
 			} => {
@@ -145,8 +145,8 @@ where
 	M: MultilinearPoly<P> + Send + Sync,
 {
 	parallel_map(multilinears, |sumcheck_multilinear| -> Result<_, Error> {
-		match sumcheck_multilinear {
-			&mut SumcheckMultilinear::Transparent {
+		match *sumcheck_multilinear {
+			SumcheckMultilinear::Transparent {
 				ref multilinear,
 				ref mut switchover_round,
 				const_suffix: (suffix_eval, suffix_len),
@@ -207,7 +207,7 @@ where
 				}
 			}
 
-			&mut SumcheckMultilinear::Folded {
+			SumcheckMultilinear::Folded {
 				large_field_folded_evals: ref mut evals,
 				suffix_eval,
 			} => {

--- a/crates/hal/src/sumcheck_multilinear.rs
+++ b/crates/hal/src/sumcheck_multilinear.rs
@@ -11,13 +11,18 @@ where
 	M: MultilinearPoly<P>,
 {
 	/// Small field multilinear - to be folded into large field at `switchover` round
+	/// A suffix of constant scalars at the end is provided via `const_suffix` hint.
 	Transparent {
 		multilinear: M,
 		switchover_round: usize,
-		zero_scalars_suffix: usize,
+		const_suffix: (P::Scalar, usize),
 	},
 	/// Large field multilinear - halved in size each round
-	Folded { large_field_folded_evals: Vec<P> },
+	/// If length is less than expected one for the current round, pad with `suffix_eval` scalars.
+	Folded {
+		large_field_folded_evals: Vec<P>,
+		suffix_eval: P::Scalar,
+	},
 }
 
 impl<P: PackedField, M: MultilinearPoly<P>> SumcheckMultilinear<P, M> {
@@ -27,42 +32,44 @@ impl<P: PackedField, M: MultilinearPoly<P>> SumcheckMultilinear<P, M> {
 		Self::Transparent {
 			multilinear,
 			switchover_round,
-			zero_scalars_suffix: 0,
+			const_suffix: Default::default(),
 		}
 	}
 
 	pub fn folded(large_field_folded_evals: Vec<P>) -> Self {
 		Self::Folded {
 			large_field_folded_evals,
+			suffix_eval: Default::default(),
 		}
 	}
 
-	pub fn zero_scalars_suffix(&self, n_vars: usize) -> usize {
+	pub fn const_suffix(&self, n_vars: usize) -> (P::Scalar, usize) {
 		match self {
-			Self::Transparent {
-				zero_scalars_suffix,
-				..
-			} => *zero_scalars_suffix,
+			Self::Transparent { const_suffix, .. } => *const_suffix,
 			Self::Folded {
 				large_field_folded_evals,
-			} => (1usize << n_vars).saturating_sub(large_field_folded_evals.len() << P::LOG_WIDTH),
+				suffix_eval,
+			} => (
+				*suffix_eval,
+				(1usize << n_vars).saturating_sub(large_field_folded_evals.len() << P::LOG_WIDTH),
+			),
 		}
 	}
 
-	pub fn update_zero_scalars_suffix(&mut self, n_vars: usize, new_zero_scalars_suffix: usize) {
+	pub fn update_const_suffix(&mut self, n_vars: usize, new_const_suffix: (P::Scalar, usize)) {
 		match self {
-			Self::Transparent {
-				zero_scalars_suffix,
-				..
-			} => {
-				*zero_scalars_suffix = new_zero_scalars_suffix;
+			Self::Transparent { const_suffix, .. } => {
+				*const_suffix = new_const_suffix;
 			}
 
 			Self::Folded {
 				large_field_folded_evals,
+				suffix_eval,
 			} => {
+				let (new_suffix_eval, new_suffix_len) = new_const_suffix;
+				*suffix_eval = new_suffix_eval;
 				large_field_folded_evals
-					.truncate(((1 << n_vars) - new_zero_scalars_suffix).div_ceil(P::WIDTH));
+					.truncate(((1 << n_vars) - new_suffix_len).div_ceil(P::WIDTH));
 			}
 		}
 	}

--- a/crates/hal/src/sumcheck_round_calculation.rs
+++ b/crates/hal/src/sumcheck_round_calculation.rs
@@ -447,6 +447,7 @@ impl<P: PackedField> SumcheckMultilinearAccess<P> for LowToHighAccess {
 
 			SumcheckMultilinear::Folded {
 				large_field_folded_evals: evals,
+				suffix_eval,
 			} => {
 				if subcube_vars + 1 >= P::LOG_WIDTH {
 					let packed_log_size = subcube_vars + 1 - P::LOG_WIDTH;
@@ -456,16 +457,14 @@ impl<P: PackedField> SumcheckMultilinearAccess<P> for LowToHighAccess {
 						scratch_space[..packed_len]
 							.copy_from_slice(&evals[offset..offset + packed_len]);
 					}
-					scratch_space[packed_len..].fill(P::zero());
+					scratch_space[packed_len..].fill(P::broadcast(*suffix_eval));
 				} else {
 					let mut only_packed = P::zero();
 
 					for i in 0..1 << (subcube_vars + 1) {
 						let index = subcube_index << (subcube_vars + 1) | i;
-						only_packed.set(
-							i,
-							get_packed_slice_checked(evals, index).unwrap_or(P::Scalar::ZERO),
-						);
+						only_packed
+							.set(i, get_packed_slice_checked(evals, index).unwrap_or(*suffix_eval));
 					}
 
 					*scratch_space.first_mut().expect("non-empty scratch space") = only_packed;
@@ -552,6 +551,7 @@ impl<P: PackedField> SumcheckMultilinearAccess<P> for HighToLowAccess {
 
 			SumcheckMultilinear::Folded {
 				large_field_folded_evals: evals,
+				suffix_eval,
 			} => {
 				if subcube_vars >= P::LOG_WIDTH {
 					let packed_log_size = subcube_vars - P::LOG_WIDTH;
@@ -570,8 +570,8 @@ impl<P: PackedField> SumcheckMultilinearAccess<P> for HighToLowAccess {
 						evals_1[..packed_len_1].copy_from_slice(&evals[offset_1..][..packed_len_1]);
 					}
 
-					evals_0[packed_len_0..].fill(P::zero());
-					evals_1[packed_len_1..].fill(P::zero());
+					evals_0[packed_len_0..].fill(P::broadcast(*suffix_eval));
+					evals_1[packed_len_1..].fill(P::broadcast(*suffix_eval));
 				} else {
 					let mut evals_0_packed = P::zero();
 					let mut evals_1_packed = P::zero();
@@ -581,11 +581,11 @@ impl<P: PackedField> SumcheckMultilinearAccess<P> for HighToLowAccess {
 						let index_1 = index_0 | 1 << (index_vars + subcube_vars);
 						evals_0_packed.set(
 							i,
-							get_packed_slice_checked(evals, index_0).unwrap_or(P::Scalar::ZERO),
+							get_packed_slice_checked(evals, index_0).unwrap_or(*suffix_eval),
 						);
 						evals_1_packed.set(
 							i,
-							get_packed_slice_checked(evals, index_1).unwrap_or(P::Scalar::ZERO),
+							get_packed_slice_checked(evals, index_1).unwrap_or(*suffix_eval),
 						);
 					}
 

--- a/crates/math/src/fold.rs
+++ b/crates/math/src/fold.rs
@@ -57,7 +57,7 @@ where
 
 	if is_lerp {
 		let lerp_query = get_packed_slice(query, 1);
-		fold_right_lerp(evals, 1 << log_evals_size, lerp_query, out)?;
+		fold_right_lerp(evals, 1 << log_evals_size, lerp_query, P::Scalar::ZERO, out)?;
 	} else {
 		fold_right_fallback(evals, log_evals_size, query, log_query_size, out);
 	}
@@ -109,7 +109,14 @@ where
 			unsafe { std::mem::transmute::<&mut [MaybeUninit<PE>], &mut [MaybeUninit<P>]>(out) };
 
 		let lerp_query_p = lerp_query.try_into().ok().expect("P == PE");
-		fold_left_lerp(evals, 1 << log_evals_size, log_evals_size, lerp_query_p, out_p)?;
+		fold_left_lerp(
+			evals,
+			1 << log_evals_size,
+			P::Scalar::ZERO,
+			log_evals_size,
+			lerp_query_p,
+			out_p,
+		)?;
 	} else {
 		fold_left_fallback(evals, log_evals_size, query, log_query_size, out);
 	}
@@ -253,7 +260,7 @@ where
 #[inline]
 fn check_left_lerp_fold_arguments<P, PE, POut>(
 	evals: &[P],
-	nonzero_scalars_prefix: usize,
+	non_const_prefix: usize,
 	log_evals_size: usize,
 	out: &[POut],
 ) -> Result<(), Error>
@@ -265,24 +272,24 @@ where
 		bail!(Error::IncorrectQuerySize { expected: 1 });
 	}
 
-	if nonzero_scalars_prefix > 1 << log_evals_size {
+	if non_const_prefix > 1 << log_evals_size {
 		bail!(Error::IncorrectNonzeroScalarPrefix {
 			expected: 1 << log_evals_size,
 		});
 	}
 
-	if P::WIDTH * evals.len() < nonzero_scalars_prefix {
+	if P::WIDTH * evals.len() < non_const_prefix {
 		bail!(Error::IncorrectArgumentLength {
 			arg: "evals".into(),
-			expected: nonzero_scalars_prefix,
+			expected: non_const_prefix,
 		});
 	}
 
-	let folded_nonzero_scalars_prefix = nonzero_scalars_prefix.min(1 << (log_evals_size - 1));
+	let folded_non_const_prefix = non_const_prefix.min(1 << (log_evals_size - 1));
 
-	if PE::WIDTH * out.len() < folded_nonzero_scalars_prefix {
+	if PE::WIDTH * out.len() < folded_non_const_prefix {
 		bail!(Error::IncorrectOutputPolynomialSize {
-			expected: folded_nonzero_scalars_prefix,
+			expected: folded_non_const_prefix,
 		});
 	}
 
@@ -467,6 +474,7 @@ pub fn fold_right_lerp<P, PE>(
 	evals: &[P],
 	evals_size: usize,
 	lerp_query: PE::Scalar,
+	suffix_eval: P::Scalar,
 	out: &mut [PE],
 ) -> Result<(), Error>
 where
@@ -501,11 +509,11 @@ where
 		});
 
 	if evals_size % 2 == 1 {
+		let eval0 = get_packed_slice(evals, folded_evals_size << 1);
 		set_packed_slice(
 			out,
 			folded_evals_size,
-			PE::Scalar::from(get_packed_slice(evals, folded_evals_size << 1))
-				* (PE::Scalar::ONE - lerp_query),
+			PE::Scalar::from(suffix_eval - eval0) * lerp_query + PE::Scalar::from(eval0),
 		);
 	}
 
@@ -526,7 +534,8 @@ where
 /// a lerp query of its scalar (and not a nontrivial extension field!).
 pub fn fold_left_lerp<P>(
 	evals: &[P],
-	nonzero_scalars_prefix: usize,
+	non_const_prefix: usize,
+	suffix_eval: P::Scalar,
 	log_evals_size: usize,
 	lerp_query: P::Scalar,
 	out: &mut [MaybeUninit<P>],
@@ -534,15 +543,15 @@ pub fn fold_left_lerp<P>(
 where
 	P: PackedField,
 {
-	check_left_lerp_fold_arguments::<_, P, _>(evals, nonzero_scalars_prefix, log_evals_size, out)?;
+	check_left_lerp_fold_arguments::<_, P, _>(evals, non_const_prefix, log_evals_size, out)?;
 
 	if log_evals_size > P::LOG_WIDTH {
-		let pivot = nonzero_scalars_prefix
+		let pivot = non_const_prefix
 			.saturating_sub(1 << (log_evals_size - 1))
 			.div_ceil(P::WIDTH);
 
 		let packed_len = 1 << (log_evals_size - 1 - P::LOG_WIDTH);
-		let upper_bound = nonzero_scalars_prefix.div_ceil(P::WIDTH).min(packed_len);
+		let upper_bound = non_const_prefix.div_ceil(P::WIDTH).min(packed_len);
 
 		if pivot > 0 {
 			let (evals_0, evals_1) = evals.split_at(packed_len);
@@ -551,14 +560,15 @@ where
 			}
 		}
 
+		let broadcast_suffix_eval = P::broadcast(suffix_eval);
 		for (out, eval) in izip!(&mut out[pivot..upper_bound], &evals[pivot..]) {
-			out.write(*eval * (P::Scalar::ONE - lerp_query));
+			out.write(*eval + (broadcast_suffix_eval - *eval) * lerp_query);
 		}
 
 		for out in &mut out[upper_bound..] {
 			out.write(P::zero());
 		}
-	} else if nonzero_scalars_prefix > 0 {
+	} else if non_const_prefix > 0 {
 		let only_packed = *evals.first().expect("log_evals_size > 0");
 		let mut folded = P::zero();
 
@@ -582,27 +592,23 @@ where
 /// function, we can implement it separately.
 pub fn fold_left_lerp_inplace<P>(
 	evals: &mut Vec<P>,
-	nonzero_scalars_prefix: usize,
+	non_const_prefix: usize,
+	suffix_eval: P::Scalar,
 	log_evals_size: usize,
 	lerp_query: P::Scalar,
 ) -> Result<(), Error>
 where
 	P: PackedField,
 {
-	check_left_lerp_fold_arguments::<_, P, _>(
-		evals,
-		nonzero_scalars_prefix,
-		log_evals_size,
-		evals,
-	)?;
+	check_left_lerp_fold_arguments::<_, P, _>(evals, non_const_prefix, log_evals_size, evals)?;
 
 	if log_evals_size > P::LOG_WIDTH {
-		let pivot = nonzero_scalars_prefix
+		let pivot = non_const_prefix
 			.saturating_sub(1 << (log_evals_size - 1))
 			.div_ceil(P::WIDTH);
 
 		let packed_len = 1 << (log_evals_size - 1 - P::LOG_WIDTH);
-		let upper_bound = nonzero_scalars_prefix.div_ceil(P::WIDTH).min(packed_len);
+		let upper_bound = non_const_prefix.div_ceil(P::WIDTH).min(packed_len);
 
 		if pivot > 0 {
 			let (evals_0, evals_1) = evals.split_at_mut(packed_len);
@@ -611,12 +617,13 @@ where
 			}
 		}
 
+		let broadcast_suffix_eval = P::broadcast(suffix_eval);
 		for eval in &mut evals[pivot..upper_bound] {
-			*eval *= P::Scalar::ONE - lerp_query;
+			*eval += (broadcast_suffix_eval - *eval) * lerp_query;
 		}
 
 		evals.truncate(upper_bound);
-	} else if nonzero_scalars_prefix > 0 {
+	} else if non_const_prefix > 0 {
 		let only_packed = evals.first_mut().expect("log_evals_size > 0");
 		let mut folded = P::zero();
 		let half_size = 1 << (log_evals_size - 1);
@@ -1241,8 +1248,14 @@ mod tests {
 				1 << log_evals_size.saturating_sub(B128bOptimal::LOG_WIDTH + 1)
 			];
 			fold_left(&evals, log_evals_size, &query, 1, &mut out).unwrap();
-			fold_left_lerp_inplace(&mut evals, 1 << log_evals_size, log_evals_size, lerp_query)
-				.unwrap();
+			fold_left_lerp_inplace(
+				&mut evals,
+				1 << log_evals_size,
+				Field::ZERO,
+				log_evals_size,
+				lerp_query,
+			)
+			.unwrap();
 
 			for (out, &inplace) in izip!(&out, &evals) {
 				unsafe {


### PR DESCRIPTION
> Depends on #188 

Attempts to implement more efficient GPA sumchecks for plain lookups proved that existing zero extend multilinear support in sumcheck is inadequate - things like "offset bivariate products" of the form `(a+offset)*(b+offset)-offset` pollute too much verifier code for what is essentially a prover optimization.

Hence this PR replaces `nonzero_scalars_suffix` params with `const_suffix`, which is a pair `(F, usize)`. Sumcheck folding/round calculation and `EqIndSumcheck` const eval suffix determination are augmented to support this functionality.