### PR TITLE
Add underliers and arch-optimal aliases for byte-sliced fields

### DIFF
--- a/crates/core/benches/prodcheck.rs
+++ b/crates/core/benches/prodcheck.rs
@@ -8,12 +8,12 @@ use binius_core::{
 	transcript::ProverTranscript,
 };
 use binius_field::{
-	arch::OptimalUnderlier,
+	arch::{OptimalUnderlier, OptimalUnderlierByteSliced},
 	as_packed_field::{PackScalar, PackedType},
 	linear_transformation::{PackedTransformationFactory, Transformation},
-	AESTowerField8b, BinaryField, BinaryField128b, BinaryField128bPolyval, BinaryField8b,
-	ByteSlicedAES16x128b, ByteSlicedAES32x128b, ByteSlicedAES64x128b, PackedExtension, PackedField,
-	PackedFieldIndexable, TowerField, BINARY_TO_POLYVAL_TRANSFORMATION,
+	AESTowerField128b, AESTowerField8b, BinaryField, BinaryField128b, BinaryField128bPolyval,
+	BinaryField8b, PackedExtension, PackedField, PackedFieldIndexable, TowerField,
+	BINARY_TO_POLYVAL_TRANSFORMATION,
 };
 use binius_hal::{make_portable_backend, CpuBackend};
 use binius_hash::groestl::Groestl256;
@@ -204,24 +204,8 @@ fn bench_binary_128b(c: &mut Criterion) {
 }
 
 fn bench_byte_sliced_aes_128b(c: &mut Criterion) {
-	bench_gpa::<ByteSlicedAES16x128b, AESTowerField8b>(
+	bench_gpa::<PackedType<OptimalUnderlierByteSliced, AESTowerField128b>, AESTowerField8b>(
 		"gpa_byte_sliced_aes_128b",
-		EvaluationOrder::HighToLow,
-		c,
-	);
-}
-
-fn bench_byte_sliced_aes_256b(c: &mut Criterion) {
-	bench_gpa::<ByteSlicedAES32x128b, AESTowerField8b>(
-		"gpa_byte_sliced_aes_256b",
-		EvaluationOrder::HighToLow,
-		c,
-	);
-}
-
-fn bench_byte_sliced_aes_512b(c: &mut Criterion) {
-	bench_gpa::<ByteSlicedAES64x128b, AESTowerField8b>(
-		"gpa_byte_sliced_aes_512b",
 		EvaluationOrder::HighToLow,
 		c,
 	);
@@ -242,7 +226,5 @@ criterion_group!(
 	bench_polyval_high_to_low,
 	bench_binary_128b,
 	bench_byte_sliced_aes_128b,
-	bench_byte_sliced_aes_256b,
-	bench_byte_sliced_aes_512b,
 	bench_binary_128b_isomorphic
 );

--- a/crates/field/benches/main_field_binary_ops.rs
+++ b/crates/field/benches/main_field_binary_ops.rs
@@ -5,11 +5,11 @@ mod packed_field_utils;
 use std::ops::Mul;
 
 use binius_field::{
-	arch::OptimalUnderlier, as_packed_field::PackedType, AESTowerField128b, AESTowerField16b,
-	AESTowerField32b, AESTowerField64b, AESTowerField8b, BinaryField128b, BinaryField128bPolyval,
-	BinaryField16b, BinaryField1b, BinaryField32b, BinaryField64b, BinaryField8b,
-	ByteSlicedAES32x128b, ByteSlicedAES32x16b, ByteSlicedAES32x32b, ByteSlicedAES32x64b,
-	ByteSlicedAES32x8b,
+	arch::{OptimalUnderlier, OptimalUnderlierByteSliced},
+	as_packed_field::PackedType,
+	AESTowerField128b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField8b,
+	BinaryField128b, BinaryField128bPolyval, BinaryField16b, BinaryField1b, BinaryField32b,
+	BinaryField64b, BinaryField8b,
 };
 use criterion::criterion_main;
 use packed_field_utils::benchmark_packed_operation;
@@ -28,6 +28,13 @@ type OptimalPackedAES64b = PackedType<OptimalUnderlier, AESTowerField64b>;
 type OptimalPackedAES128b = PackedType<OptimalUnderlier, AESTowerField128b>;
 
 type OptimalPackedPolyval128b = PackedType<OptimalUnderlier, BinaryField128bPolyval>;
+
+type OptimalByteSliced1b = PackedType<OptimalUnderlierByteSliced, BinaryField1b>;
+type OptimalByteSlicedAES8b = PackedType<OptimalUnderlierByteSliced, AESTowerField8b>;
+type OptimalByteSlicedAES16b = PackedType<OptimalUnderlierByteSliced, AESTowerField16b>;
+type OptimalByteSlicedAES32b = PackedType<OptimalUnderlierByteSliced, AESTowerField32b>;
+type OptimalByteSlicedAES64b = PackedType<OptimalUnderlierByteSliced, AESTowerField64b>;
+type OptimalByteSlicedAES128b = PackedType<OptimalUnderlierByteSliced, AESTowerField128b>;
 
 trait SelfMul: Mul<Self, Output = Self> + Sized {}
 
@@ -63,11 +70,12 @@ benchmark_packed_operation!(
 		OptimalPackedPolyval128b
 
 		// Byte-sliced fields
-		ByteSlicedAES32x8b
-		ByteSlicedAES32x16b
-		ByteSlicedAES32x32b
-		ByteSlicedAES32x64b
-		ByteSlicedAES32x128b
+		OptimalByteSliced1b
+		OptimalByteSlicedAES8b
+		OptimalByteSlicedAES16b
+		OptimalByteSlicedAES32b
+		OptimalByteSlicedAES64b
+		OptimalByteSlicedAES128b
 	]
 );
 

--- a/crates/field/benches/main_field_unary_ops.rs
+++ b/crates/field/benches/main_field_unary_ops.rs
@@ -3,11 +3,11 @@
 mod packed_field_utils;
 
 use binius_field::{
-	arch::OptimalUnderlier, as_packed_field::PackedType, AESTowerField128b, AESTowerField16b,
-	AESTowerField32b, AESTowerField64b, AESTowerField8b, BinaryField128b, BinaryField128bPolyval,
-	BinaryField16b, BinaryField1b, BinaryField32b, BinaryField64b, BinaryField8b,
-	ByteSlicedAES32x128b, ByteSlicedAES32x16b, ByteSlicedAES32x32b, ByteSlicedAES32x64b,
-	ByteSlicedAES32x8b, PackedField,
+	arch::{OptimalUnderlier, OptimalUnderlierByteSliced},
+	as_packed_field::PackedType,
+	AESTowerField128b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField8b,
+	BinaryField128b, BinaryField128bPolyval, BinaryField16b, BinaryField1b, BinaryField32b,
+	BinaryField64b, BinaryField8b, PackedField,
 };
 use criterion::criterion_main;
 use packed_field_utils::benchmark_packed_operation;
@@ -26,6 +26,13 @@ type OptimalPackedAES64b = PackedType<OptimalUnderlier, AESTowerField64b>;
 type OptimalPackedAES128b = PackedType<OptimalUnderlier, AESTowerField128b>;
 
 type OptimalPackedPolyval128b = PackedType<OptimalUnderlier, BinaryField128bPolyval>;
+
+type OptimalByteSliced1b = PackedType<OptimalUnderlierByteSliced, BinaryField1b>;
+type OptimalByteSlicedAES8b = PackedType<OptimalUnderlierByteSliced, AESTowerField8b>;
+type OptimalByteSlicedAES16b = PackedType<OptimalUnderlierByteSliced, AESTowerField16b>;
+type OptimalByteSlicedAES32b = PackedType<OptimalUnderlierByteSliced, AESTowerField32b>;
+type OptimalByteSlicedAES64b = PackedType<OptimalUnderlierByteSliced, AESTowerField64b>;
+type OptimalByteSlicedAES128b = PackedType<OptimalUnderlierByteSliced, AESTowerField128b>;
 
 fn invert<T: PackedField>(val: T) -> T {
 	val.invert_or_zero()
@@ -62,11 +69,12 @@ benchmark_packed_operation!(
 		OptimalPackedPolyval128b
 
 		// Byte-sliced fields
-		ByteSlicedAES32x8b
-		ByteSlicedAES32x16b
-		ByteSlicedAES32x32b
-		ByteSlicedAES32x64b
-		ByteSlicedAES32x128b
+		OptimalByteSliced1b
+		OptimalByteSlicedAES8b
+		OptimalByteSlicedAES16b
+		OptimalByteSlicedAES32b
+		OptimalByteSlicedAES64b
+		OptimalByteSlicedAES128b
 	]
 );
 

--- a/crates/field/src/arch/arch_optimal.rs
+++ b/crates/field/src/arch/arch_optimal.rs
@@ -5,9 +5,10 @@ use cfg_if::cfg_if;
 use crate::{
 	as_packed_field::{PackScalar, PackedType},
 	underlier::WithUnderlier,
-	Field, PackedField,
+	ByteSlicedUnderlier, Field, PackedField,
 };
 
+/// A trait to retrieve the optimal throughput `ordinal` packed field for a given architecture.
 pub trait ArchOptimal: Field {
 	type OptimalThroughputPacked: PackedField<Scalar = Self>
 		+ WithUnderlier<Underlier = OptimalUnderlier>;
@@ -19,6 +20,20 @@ where
 	OptimalUnderlier: PackScalar<F>,
 {
 	type OptimalThroughputPacked = PackedType<OptimalUnderlier, F>;
+}
+
+/// A trait to retrieve the optimal throughput packed byte-sliced field for a given architecture
+pub trait ArchOptimalByteSliced: Field {
+	type OptimalByteSliced: PackedField<Scalar = Self>
+		+ WithUnderlier<Underlier = OptimalUnderlierByteSliced>;
+}
+
+impl<F> ArchOptimalByteSliced for F
+where
+	F: Field,
+	OptimalUnderlierByteSliced: PackScalar<F>,
+{
+	type OptimalByteSliced = PackedType<OptimalUnderlierByteSliced, F>;
 }
 
 cfg_if! {
@@ -67,3 +82,7 @@ cfg_if! {
 		pub type OptimalUnderlier = OptimalUnderlier128b;
 	}
 }
+
+/// Optimal underlier for byte-sliced packed field for the current architecture.
+/// This underlier can pack up to 128b scalars.
+pub type OptimalUnderlierByteSliced = ByteSlicedUnderlier<OptimalUnderlier, 16>;

--- a/crates/field/src/arch/portable/byte_sliced/mod.rs
+++ b/crates/field/src/arch/portable/byte_sliced/mod.rs
@@ -4,6 +4,7 @@ mod invert;
 mod multiply;
 mod packed_byte_sliced;
 mod square;
+mod underlier;
 
 pub use packed_byte_sliced::*;
 

--- a/crates/field/src/arch/portable/byte_sliced/mod.rs
+++ b/crates/field/src/arch/portable/byte_sliced/mod.rs
@@ -7,6 +7,7 @@ mod square;
 mod underlier;
 
 pub use packed_byte_sliced::*;
+pub use underlier::ByteSlicedUnderlier;
 
 #[cfg(test)]
 pub mod tests {

--- a/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
+++ b/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
@@ -12,6 +12,7 @@ use bytemuck::{Pod, Zeroable};
 
 use super::{invert::invert_or_zero, multiply::mul, square::square};
 use crate::{
+	arch::byte_sliced::underlier::ByteSlicedUnderlier,
 	as_packed_field::{PackScalar, PackedType},
 	binary_field::BinaryField,
 	linear_transformation::{
@@ -303,7 +304,7 @@ macro_rules! define_byte_sliced_3d {
 			}
 		}
 
-		byte_sliced_common!($name, $packed_storage, $scalar_type);
+		byte_sliced_common!($name, $packed_storage, $scalar_type, $storage_tower_level);
 
 		impl<Inner: Transformation<$packed_storage, $packed_storage>> Transformation<$name, $name> for TransformationWrapperNxN<Inner, {<$scalar_tower_level as TowerLevel>::WIDTH}> {
 			fn transform(&self, data: &$name) -> $name {
@@ -348,7 +349,7 @@ macro_rules! define_byte_sliced_3d {
 }
 
 macro_rules! byte_sliced_common {
-	($name:ident, $packed_storage:ty, $scalar_type:ty) => {
+	($name:ident, $packed_storage:ty, $scalar_type:ty, $storage_level:ty) => {
 		impl Add<$scalar_type> for $name {
 			type Output = Self;
 
@@ -451,58 +452,70 @@ macro_rules! byte_sliced_common {
 			}
 		}
 
-		impl PackedExtension<$scalar_type> for $name {
-			type PackedSubfield = Self;
+		unsafe impl WithUnderlier for $name {
+			type Underlier = ByteSlicedUnderlier<
+				<$packed_storage as WithUnderlier>::Underlier,
+				{ <$storage_level as TowerLevel>::WIDTH },
+			>;
 
 			#[inline(always)]
-			fn cast_bases(packed: &[Self]) -> &[Self::PackedSubfield] {
-				packed
+			fn to_underlier(self) -> Self::Underlier {
+				bytemuck::must_cast(self)
 			}
 
 			#[inline(always)]
-			fn cast_bases_mut(packed: &mut [Self]) -> &mut [Self::PackedSubfield] {
-				packed
+			fn to_underlier_ref(&self) -> &Self::Underlier {
+				bytemuck::must_cast_ref(self)
 			}
 
 			#[inline(always)]
-			fn cast_exts(packed: &[Self::PackedSubfield]) -> &[Self] {
-				packed
+			fn to_underlier_ref_mut(&mut self) -> &mut Self::Underlier {
+				bytemuck::must_cast_mut(self)
 			}
 
 			#[inline(always)]
-			fn cast_exts_mut(packed: &mut [Self::PackedSubfield]) -> &mut [Self] {
-				packed
+			fn to_underliers_ref(val: &[Self]) -> &[Self::Underlier] {
+				bytemuck::must_cast_slice(val)
 			}
 
 			#[inline(always)]
-			fn cast_base(self) -> Self::PackedSubfield {
-				self
+			fn to_underliers_ref_mut(val: &mut [Self]) -> &mut [Self::Underlier] {
+				bytemuck::must_cast_slice_mut(val)
 			}
 
 			#[inline(always)]
-			fn cast_base_ref(&self) -> &Self::PackedSubfield {
-				self
+			fn from_underlier(val: Self::Underlier) -> Self {
+				bytemuck::must_cast(val)
 			}
 
 			#[inline(always)]
-			fn cast_base_mut(&mut self) -> &mut Self::PackedSubfield {
-				self
+			fn from_underlier_ref(val: &Self::Underlier) -> &Self {
+				bytemuck::must_cast_ref(val)
 			}
 
 			#[inline(always)]
-			fn cast_ext(base: Self::PackedSubfield) -> Self {
-				base
+			fn from_underlier_ref_mut(val: &mut Self::Underlier) -> &mut Self {
+				bytemuck::must_cast_mut(val)
 			}
 
 			#[inline(always)]
-			fn cast_ext_ref(base: &Self::PackedSubfield) -> &Self {
-				base
+			fn from_underliers_ref(val: &[Self::Underlier]) -> &[Self] {
+				bytemuck::must_cast_slice(val)
 			}
 
 			#[inline(always)]
-			fn cast_ext_mut(base: &mut Self::PackedSubfield) -> &mut Self {
-				base
+			fn from_underliers_ref_mut(val: &mut [Self::Underlier]) -> &mut [Self] {
+				bytemuck::must_cast_slice_mut(val)
 			}
+		}
+
+		impl PackScalar<$scalar_type>
+			for ByteSlicedUnderlier<
+				<$packed_storage as WithUnderlier>::Underlier,
+				{ <$storage_level as TowerLevel>::WIDTH },
+			>
+		{
+			type Packed = $name;
 		}
 	};
 }
@@ -759,7 +772,7 @@ macro_rules! define_byte_sliced_3d_1b {
 			}
 		}
 
-		byte_sliced_common!($name, $packed_storage, BinaryField1b);
+		byte_sliced_common!($name, $packed_storage, BinaryField1b, $storage_tower_level);
 
 		impl PackedTransformationFactory<$name> for $name {
 			type PackedTransformation<Data: AsRef<[<$name as PackedField>::Scalar]> + Sync> =
@@ -1088,89 +1101,3 @@ define_byte_sliced_3d_1b!(ByteSliced8x512x1b, PackedBinaryField512x1b, TowerLeve
 define_byte_sliced_3d_1b!(ByteSliced4x512x1b, PackedBinaryField512x1b, TowerLevel4);
 define_byte_sliced_3d_1b!(ByteSliced2x512x1b, PackedBinaryField512x1b, TowerLevel2);
 define_byte_sliced_3d_1b!(ByteSliced1x512x1b, PackedBinaryField512x1b, TowerLevel1);
-
-macro_rules! impl_packed_extension{
-	($packed_ext:ty, $packed_base:ty,) => {
-		impl PackedExtension<<$packed_base as PackedField>::Scalar> for $packed_ext {
-			type PackedSubfield = $packed_base;
-
-			fn cast_bases(packed: &[Self]) -> &[Self::PackedSubfield] {
-				bytemuck::must_cast_slice(packed)
-			}
-
-			fn cast_bases_mut(packed: &mut [Self]) -> &mut [Self::PackedSubfield] {
-				bytemuck::must_cast_slice_mut(packed)
-			}
-
-			fn cast_exts(packed: &[Self::PackedSubfield]) -> &[Self] {
-				bytemuck::must_cast_slice(packed)
-			}
-
-			fn cast_exts_mut(packed: &mut [Self::PackedSubfield]) -> &mut [Self] {
-				bytemuck::must_cast_slice_mut(packed)
-			}
-
-			fn cast_base(self) -> Self::PackedSubfield {
-				bytemuck::must_cast(self)
-			}
-
-			fn cast_base_ref(&self) -> &Self::PackedSubfield {
-				bytemuck::must_cast_ref(self)
-			}
-
-			fn cast_base_mut(&mut self) -> &mut Self::PackedSubfield {
-				bytemuck::must_cast_mut(self)
-			}
-
-			fn cast_ext(base: Self::PackedSubfield) -> Self {
-				bytemuck::must_cast(base)
-			}
-
-			fn cast_ext_ref(base: &Self::PackedSubfield) -> &Self {
-				bytemuck::must_cast_ref(base)
-			}
-
-			fn cast_ext_mut(base: &mut Self::PackedSubfield) -> &mut Self {
-				bytemuck::must_cast_mut(base)
-			}
-		}
-	};
-	(@pairs $head:ty, $next:ty,) => {
-		impl_packed_extension!($head, $next,);
-	};
-	(@pairs $head:ty, $next:ty, $($tail:ty,)*) => {
-		impl_packed_extension!($head, $next,);
-		impl_packed_extension!(@pairs $head, $($tail,)*);
-	};
-	($head:ty, $next:ty, $($tail:ty,)*) => {
-		impl_packed_extension!(@pairs $head, $next, $($tail,)*);
-		impl_packed_extension!($next, $($tail,)*);
-	};
-}
-
-impl_packed_extension!(
-	ByteSlicedAES16x128b,
-	ByteSlicedAES2x16x64b,
-	ByteSlicedAES4x16x32b,
-	ByteSlicedAES8x16x16b,
-	ByteSlicedAES16x16x8b,
-	ByteSliced16x128x1b,
-);
-
-impl_packed_extension!(
-	ByteSlicedAES32x128b,
-	ByteSlicedAES2x32x64b,
-	ByteSlicedAES4x32x32b,
-	ByteSlicedAES8x32x16b,
-	ByteSlicedAES16x32x8b,
-	ByteSliced16x256x1b,
-);
-
-impl_packed_extension!(
-	ByteSlicedAES64x128b,
-	ByteSlicedAES2x64x64b,
-	ByteSlicedAES4x64x32b,
-	ByteSlicedAES8x64x16b,
-	ByteSlicedAES16x64x8b,
-	ByteSliced16x512x1b,
-);

--- a/crates/field/src/arch/portable/byte_sliced/underlier.rs
+++ b/crates/field/src/arch/portable/byte_sliced/underlier.rs
@@ -1,0 +1,35 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_utils::checked_arithmetics::checked_log_2;
+use bytemuck::{Pod, Zeroable};
+use rand::RngCore;
+use subtle::{Choice, ConstantTimeEq};
+
+use crate::underlier::{Random, ScaledUnderlier, UnderlierType};
+
+/// Unerlier for byte-sliced fields. Even though it may seem to be equivalent to
+/// `ScaledUnderlier<U, N>`, it is not. The difference is in order of bytes,
+/// that's why this is a separate type.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct ByteSlicedUnderlier<U, const N: usize>(ScaledUnderlier<U, N>);
+
+impl<U: Random, const N: usize> Random for ByteSlicedUnderlier<U, N> {
+	fn random(mut rng: impl RngCore) -> Self {
+		Self(Random::random(&mut rng))
+	}
+}
+
+impl<U: ConstantTimeEq, const N: usize> ConstantTimeEq for ByteSlicedUnderlier<U, N> {
+	fn ct_eq(&self, other: &Self) -> Choice {
+		self.0.ct_eq(&other.0)
+	}
+}
+
+unsafe impl<U: Zeroable, const N: usize> Zeroable for ByteSlicedUnderlier<U, N> {}
+
+unsafe impl<U: Pod, const N: usize> Pod for ByteSlicedUnderlier<U, N> {}
+
+impl<U: UnderlierType + Pod, const N: usize> UnderlierType for ByteSlicedUnderlier<U, N> {
+	const LOG_BITS: usize = U::LOG_BITS + checked_log_2(N);
+}

--- a/crates/ntt/benches/large_transform.rs
+++ b/crates/ntt/benches/large_transform.rs
@@ -3,9 +3,10 @@
 use std::iter::repeat_with;
 
 use binius_field::{
-	arch::OptimalUnderlier, as_packed_field::PackedType, AESTowerField128b, AESTowerField32b,
-	BinaryField128b, BinaryField128bPolyval, BinaryField32b, ByteSlicedAES32x128b, PackedExtension,
-	TowerField,
+	arch::{OptimalUnderlier, OptimalUnderlierByteSliced},
+	as_packed_field::PackedType,
+	AESTowerField128b, AESTowerField32b, BinaryField128b, BinaryField128bPolyval, BinaryField32b,
+	PackedExtension, TowerField,
 };
 use binius_ntt::{AdditiveNTT, SingleThreadedNTT};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
@@ -44,10 +45,10 @@ fn bench_large_transform<F: TowerField, PE: PackedExtension<F>>(c: &mut Criterio
 
 // We are ignoring the transposition associated with byte slicing
 fn bench_byte_sliced(c: &mut Criterion) {
-	bench_large_transform::<AESTowerField32b, ByteSlicedAES32x128b>(
-		c,
-		"bytesliced=ByteSlicedAES32x128b",
-	);
+	bench_large_transform::<
+		AESTowerField32b,
+		PackedType<OptimalUnderlierByteSliced, AESTowerField128b>,
+	>(c, "bytesliced=AESTowerField128b");
 }
 
 fn bench_packed128b(c: &mut Criterion) {


### PR DESCRIPTION
Add underliers (without bit operations) for the byte sliced packed fields. To my opinion this gives many pros:
1. Get rid of macros to manually define the `PackedExtension` chain.
2. Allows implementing aliases to get the architecture-optimal byte-sliced fields in a pretty easy way.
3. As constraint system needs underlier defined it allows us getting initial end-to-end proving faster no matter if we decide to leave or remove the underlier there. I would prefer doing it in parallel with performance investigation instead of being blocked by that.

Also I switched to acr-optimal byte sliced fields in the benchmarks where we compare it against arch-optimal 'ordinary' packed fields.