### PR TITLE
[m3] Ability to define power-of-two-sized tables

### DIFF
--- a/crates/circuits/src/builder/constraint_system.rs
+++ b/crates/circuits/src/builder/constraint_system.rs
@@ -178,7 +178,7 @@ impl<'arena> ConstraintSystemBuilder<'arena> {
 		self.flushes.push(Flush {
 			channel_id,
 			direction,
-			selector,
+			selector: Some(selector),
 			oracles,
 			multiplicity,
 		});

--- a/crates/core/src/constraint_system/channel.rs
+++ b/crates/core/src/constraint_system/channel.rs
@@ -180,6 +180,7 @@ where
 
 		for i in 0..1 << n_vars {
 			let selector_off = selector_poly
+				.as_ref()
 				.map(|selector_poly| {
 					selector_poly
 						.evaluate_on_hypercube(i)

--- a/crates/core/src/constraint_system/verify.rs
+++ b/crates/core/src/constraint_system/verify.rs
@@ -170,7 +170,7 @@ where
 		reorder_for_flushing_by_n_vars(
 			&oracles,
 			&flush_oracle_ids,
-			flush_selectors,
+			&flush_selectors,
 			flush_final_layer_claims,
 		);
 
@@ -544,7 +544,7 @@ pub struct FlushSumcheckMeta<F: TowerField> {
 pub fn get_flush_dedup_sumcheck_metas<F: TowerField>(
 	oracles: &MultilinearOracleSet<F>,
 	flush_oracle_ids: &[OracleId],
-	flush_selectors: &[OracleId],
+	flush_selectors: &[Option<OracleId>],
 	final_layer_claims: &[LayerClaim<F>],
 ) -> Result<Vec<FlushSumcheckMeta<F>>, Error> {
 	let total_flushes = flush_oracle_ids.len();
@@ -742,12 +742,12 @@ pub fn get_flush_dedup_eq_ind_sumcheck_claims<F: TowerField>(
 pub fn reorder_for_flushing_by_n_vars<F: TowerField>(
 	oracles: &MultilinearOracleSet<F>,
 	flush_oracle_ids: &[OracleId],
-	flush_selectors: Vec<OracleId>,
+	flush_selectors: &[Option<OracleId>],
 	flush_final_layer_claims: Vec<LayerClaim<F>>,
-) -> (Vec<OracleId>, Vec<usize>, Vec<LayerClaim<F>>) {
+) -> (Vec<OracleId>, Vec<Option<OracleId>>, Vec<LayerClaim<F>>) {
 	let mut zipped: Vec<_> =
 		izip!(flush_oracle_ids.iter().copied(), flush_selectors, flush_final_layer_claims)
 			.collect();
-	zipped.sort_by_key(|&(id, flush_selector, _)| Reverse((oracles.n_vars(id), flush_selector)));
+	zipped.sort_by_key(|&(id, flush_selector, _)| Reverse(oracles.n_vars(id)));
 	multiunzip(zipped)
 }

--- a/crates/core/src/protocols/evalcheck/evalcheck.rs
+++ b/crates/core/src/protocols/evalcheck/evalcheck.rs
@@ -40,10 +40,10 @@ enum EvalcheckNumerics {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EvalcheckProof<F: Field> {
-	Transparent,
-	Committed,
-	Shifted,
-	Packed,
+	Transparent, // Resolve
+	Committed,   // Emit
+	Shifted,     // Sumcheck
+	Packed,      // Sumcheck
 	Repeating(Box<EvalcheckProof<F>>),
 	LinearCombination {
 		subproofs: Vec<(F, EvalcheckProof<F>)>,

--- a/crates/core/src/protocols/evalcheck/evalcheck.rs
+++ b/crates/core/src/protocols/evalcheck/evalcheck.rs
@@ -40,10 +40,10 @@ enum EvalcheckNumerics {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EvalcheckProof<F: Field> {
-	Transparent, // Resolve
-	Committed,   // Emit
-	Shifted,     // Sumcheck
-	Packed,      // Sumcheck
+	Transparent,
+	Committed,
+	Shifted,
+	Packed,
 	Repeating(Box<EvalcheckProof<F>>),
 	LinearCombination {
 		subproofs: Vec<(F, EvalcheckProof<F>)>,

--- a/crates/m3/src/builder/channel.rs
+++ b/crates/m3/src/builder/channel.rs
@@ -15,9 +15,7 @@ pub struct Flush {
 	pub multiplicity: u32,
 	/// An optional reference to a column to select which values to flush.
 	///
-	/// The referenced selector column must hold 1-bit values and contain only zeros after the
-	/// index that is the height of the table. If the selector is `None`, all values up to the
-	/// table height are flushed.
+	/// The referenced selector column must hold 1-bit values.
 	pub selector: Option<ColumnIndex>,
 }
 

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -200,7 +200,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 			if count == 0 {
 				continue;
 			}
-			if table.po2_sized && !count.is_power_of_two() {
+			if table.power_of_two_sized && !count.is_power_of_two() {
 				return Err(Error::TableSizePowerOfTwoRequired {
 					table_id: table.id,
 					size: count,
@@ -253,7 +253,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 					.collect::<Vec<_>>();
 
 				// StepDown witness data is populated in WitnessIndex::into_multilinear_extension_index
-				let step_down = (!table.po2_sized)
+				let step_down = (!table.power_of_two_sized)
 					.then(|| {
 						let step_down_poly = StepDown::new(n_vars, count * values_per_row)?;
 						oracles.add_transparent(step_down_poly)

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -18,6 +18,7 @@ use binius_field::{PackedField, TowerField};
 use binius_math::LinearNormalForm;
 use binius_utils::checked_arithmetics::log2_strict_usize;
 use bumpalo::Bump;
+use itertools::chain;
 
 use super::{
 	channel::{Channel, Flush},
@@ -253,8 +254,12 @@ impl<F: TowerField> ConstraintSystem<F> {
 					.collect::<Vec<_>>();
 
 				// StepDown witness data is populated in WitnessIndex::into_multilinear_extension_index
-				let step_down =
-					oracles.add_transparent(StepDown::new(n_vars, count * values_per_row)?)?;
+				let step_down = (!table.po2_sized)
+					.then(|| {
+						let step_down_poly = StepDown::new(n_vars, count * values_per_row)?;
+						oracles.add_transparent(step_down_poly)
+					})
+					.transpose()?;
 
 				// Translate flushes for the compiled constraint system.
 				for Flush {
@@ -269,11 +274,14 @@ impl<F: TowerField> ConstraintSystem<F> {
 						.iter()
 						.map(|&column_index| OracleOrConst::Oracle(oracle_lookup[column_index]))
 						.collect::<Vec<_>>();
+					let selectors =
+						chain!(selector.map(|column_idx| oracle_lookup[column_idx]), step_down)
+							.collect::<Vec<_>>();
 					compiled_flushes.push(CompiledFlush {
 						oracles: flush_oracles,
 						channel_id: *channel_id,
 						direction: *direction,
-						selector: selector.unwrap_or(step_down),
+						selectors,
 						multiplicity: *multiplicity as u64,
 					});
 				}

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -274,14 +274,21 @@ impl<F: TowerField> ConstraintSystem<F> {
 						.iter()
 						.map(|&column_index| OracleOrConst::Oracle(oracle_lookup[column_index]))
 						.collect::<Vec<_>>();
-					let selectors =
+					let mut selectors =
 						chain!(selector.map(|column_idx| oracle_lookup[column_idx]), step_down)
 							.collect::<Vec<_>>();
+					if selectors.len() > 1 {
+						unimplemented!(
+							"Multiple selectors are not supported yet. \
+							Custom selectors are only allowed on tables with power-of-two size."
+						);
+					}
+					let selector = selectors.pop();
 					compiled_flushes.push(CompiledFlush {
 						oracles: flush_oracles,
 						channel_id: *channel_id,
 						direction: *direction,
-						selectors,
+						selector,
 						multiplicity: *multiplicity as u64,
 					});
 				}

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -191,7 +191,6 @@ impl<F: TowerField> ConstraintSystem<F> {
 			});
 		}
 
-		// TODO: new -> with_capacity
 		let mut oracles = MultilinearOracleSet::new();
 		let mut table_constraints = Vec::new();
 		let mut compiled_flushes = Vec::new();
@@ -408,4 +407,24 @@ fn add_oracle_for_column<F: TowerField>(
 		)?,
 	};
 	Ok(oracle_id)
+}
+
+#[cfg(test)]
+mod tests {
+	use assert_matches::assert_matches;
+
+	use super::*;
+
+	#[test]
+	fn test_unsatisfied_po2_requirement() {
+		let mut cs = ConstraintSystem::<B128>::new();
+		let mut table_builder = cs.add_table("fibonacci");
+		table_builder.require_power_of_two_size();
+
+		let statement = Statement {
+			boundaries: vec![],
+			table_sizes: vec![15],
+		};
+		assert_matches!(cs.compile(&statement), Err(Error::TableSizePowerOfTwoRequired { .. }));
+	}
 }

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -200,6 +200,13 @@ impl<F: TowerField> ConstraintSystem<F> {
 			if count == 0 {
 				continue;
 			}
+			if table.po2_sized && !count.is_power_of_two() {
+				return Err(Error::TableSizePowerOfTwoRequired {
+					table_id: table.id,
+					size: count,
+				});
+			}
+
 			let mut oracle_lookup = Vec::new();
 
 			let mut transparent_single = vec![None; table.columns.len()];

--- a/crates/m3/src/builder/error.rs
+++ b/crates/m3/src/builder/error.rs
@@ -27,6 +27,8 @@ pub enum Error {
 		column_table_id: TableId,
 		witness_table_id: TableId,
 	},
+	#[error("table {table_id} is required to have a power-of-two size, instead got {size}")]
+	TableSizePowerOfTwoRequired { table_id: TableId, size: usize },
 	// TODO: These should have column IDs
 	#[error("witness borrow error: {0}. Note that packed columns are aliases for the unpacked column when accessing witness data")]
 	WitnessBorrow(#[source] BorrowError),

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -43,6 +43,10 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		}
 	}
 
+	pub fn require_power_of_two_size(&mut self) {
+		self.table.po2_sized = true;
+	}
+
 	pub fn with_namespace(&mut self, namespace: impl ToString) -> TableBuilder<'_, F> {
 		TableBuilder {
 			namespace: Some(self.namespaced_name(namespace)),
@@ -320,6 +324,8 @@ pub struct Table<F: TowerField = B128> {
 	pub id: TableId,
 	pub name: String,
 	pub columns: Vec<ColumnInfo<F>>,
+	/// Whether the table size is required to be a power of two.
+	pub po2_sized: bool,
 	pub(super) partitions: SparseIndex<TablePartition<F>>,
 }
 
@@ -397,6 +403,7 @@ impl<F: TowerField> Table<F> {
 			id,
 			name: name.to_string(),
 			columns: Vec::new(),
+			po2_sized: false,
 			partitions: SparseIndex::new(),
 		}
 	}

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -44,7 +44,7 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 	}
 
 	pub fn require_power_of_two_size(&mut self) {
-		self.table.po2_sized = true;
+		self.table.power_of_two_sized = true;
 	}
 
 	pub fn with_namespace(&mut self, namespace: impl ToString) -> TableBuilder<'_, F> {
@@ -325,7 +325,7 @@ pub struct Table<F: TowerField = B128> {
 	pub name: String,
 	pub columns: Vec<ColumnInfo<F>>,
 	/// Whether the table size is required to be a power of two.
-	pub po2_sized: bool,
+	pub power_of_two_sized: bool,
 	pub(super) partitions: SparseIndex<TablePartition<F>>,
 }
 
@@ -403,7 +403,7 @@ impl<F: TowerField> Table<F> {
 			id,
 			name: name.to_string(),
 			columns: Vec::new(),
-			po2_sized: false,
+			power_of_two_sized: false,
 			partitions: SparseIndex::new(),
 		}
 	}

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -124,19 +124,21 @@ impl<'cs, 'alloc, F: TowerField, P: PackedField<Scalar = F>> WitnessIndex<'cs, '
 				count += 1;
 			}
 
-			// Every table partition has a step_down appended to the end of the table to support
-			// non-power of two height tables.
-			for log_values_per_row in table.partitions.keys() {
-				let oracle_id = first_oracle_id_in_table + count;
-				let size = table_witness.size << log_values_per_row;
-				let log_size = table_witness.log_capacity + log_values_per_row;
-				let witness = StepDown::new(log_size, size)
-					.unwrap()
-					.multilinear_extension::<PackedSubfield<P, B1>>()
-					.unwrap()
-					.specialize_arc_dyn();
-				index.update_multilin_poly([(oracle_id, witness)]).unwrap();
-				count += 1;
+			if !table.po2_sized {
+				// Every table partition has a step_down appended to the end of the table to support
+				// non-power of two height tables.
+				for log_values_per_row in table.partitions.keys() {
+					let oracle_id = first_oracle_id_in_table + count;
+					let size = table_witness.size << log_values_per_row;
+					let log_size = table_witness.log_capacity + log_values_per_row;
+					let witness = StepDown::new(log_size, size)
+						.unwrap()
+						.multilinear_extension::<PackedSubfield<P, B1>>()
+						.unwrap()
+						.specialize_arc_dyn();
+					index.update_multilin_poly([(oracle_id, witness)]).unwrap();
+					count += 1;
+				}
 			}
 
 			first_oracle_id_in_table += count;

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -124,7 +124,7 @@ impl<'cs, 'alloc, F: TowerField, P: PackedField<Scalar = F>> WitnessIndex<'cs, '
 				count += 1;
 			}
 
-			if !table.po2_sized {
+			if !table.power_of_two_sized {
 				// Every table partition has a step_down appended to the end of the table to support
 				// non-power of two height tables.
 				for log_values_per_row in table.partitions.keys() {

--- a/crates/m3/src/gadgets/lookup.rs
+++ b/crates/m3/src/gadgets/lookup.rs
@@ -93,6 +93,7 @@ mod tests {
 		let chan = cs.add_channel("values");
 
 		let mut lookup_table = cs.add_table("lookup");
+		lookup_table.require_power_of_two_size();
 		let lookup_table_id = lookup_table.id();
 		let values_col = lookup_table.add_committed::<B128, 1>("values");
 		let lookup_producer = LookupProducer::new(&mut lookup_table, chan, &[values_col], 8);
@@ -107,7 +108,7 @@ mod tests {
 		let looker_2_vals = looker_2.add_committed::<B128, 1>("values");
 		looker_2.pull(chan, [looker_2_vals]);
 
-		let lookup_table_size = 45;
+		let lookup_table_size = 64;
 		let mut rng = StdRng::seed_from_u64(0);
 		let values = repeat_with(|| B128::random(&mut rng))
 			.take(lookup_table_size)

--- a/crates/m3/tests/fibonacci.rs
+++ b/crates/m3/tests/fibonacci.rs
@@ -211,7 +211,7 @@ mod arithmetization {
 		statement: &Statement,
 		witness: WitnessIndex,
 	) {
-		let compiled_cs = cs.compile(&statement).unwrap();
+		let compiled_cs = cs.compile(statement).unwrap();
 		let witness = witness.into_multilinear_extension_index();
 
 		binius_core::constraint_system::validate::validate_witness(

--- a/crates/m3/tests/fibonacci.rs
+++ b/crates/m3/tests/fibonacci.rs
@@ -209,7 +209,7 @@ mod arithmetization {
 	fn compile_validate_prove_verify(
 		cs: &ConstraintSystem,
 		statement: &Statement,
-		witness: WitnessIndex,
+		witness: WitnessIndex<PackedType<OptimalUnderlier128b, B128>>,
 	) {
 		let compiled_cs = cs.compile(statement).unwrap();
 		let witness = witness.into_multilinear_extension_index();

--- a/crates/m3/tests/fibonacci.rs
+++ b/crates/m3/tests/fibonacci.rs
@@ -74,8 +74,8 @@ mod arithmetization {
 	use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 	use binius_m3::{
 		builder::{
-			Boundary, Col, ConstraintSystem, FlushDirection, Statement, TableFiller, TableId,
-			TableWitnessSegment, B1, B128, B32,
+			Boundary, Col, ConstraintSystem, FlushDirection, Statement, TableBuilder, TableFiller,
+			TableId, TableWitnessSegment, WitnessIndex, B1, B128, B32,
 		},
 		gadgets::u32::{U32Add, U32AddFlags},
 	};
@@ -96,6 +96,10 @@ mod arithmetization {
 	impl FibonacciTable {
 		pub fn new(cs: &mut ConstraintSystem, fibonacci_pairs: ChannelId) -> Self {
 			let mut table = cs.add_table("fibonacci");
+			Self::with_table_builder(&mut table, fibonacci_pairs)
+		}
+
+		pub fn with_table_builder(table: &mut TableBuilder, fibonacci_pairs: ChannelId) -> Self {
 			let f0_bits = table.add_committed("f0_bits");
 			let f1_bits = table.add_committed("f1_bits");
 			let f2_bits = U32Add::new(
@@ -202,38 +206,11 @@ mod arithmetization {
 		.unwrap();
 	}
 
-	#[test]
-	fn test_fibonacci_prove_verify_small_table() {
-		let mut cs = ConstraintSystem::new();
-		let fibonacci_pairs = cs.add_channel("fibonacci_pairs");
-		let fibonacci_table = FibonacciTable::new(&mut cs, fibonacci_pairs);
-		let trace = FibonacciTrace::generate((0, 1), 1);
-		let statement = Statement {
-			boundaries: vec![
-				Boundary {
-					values: vec![B128::new(0), B128::new(1)],
-					channel_id: fibonacci_pairs,
-					direction: FlushDirection::Push,
-					multiplicity: 1,
-				},
-				Boundary {
-					values: vec![B128::new(1), B128::new(2)],
-					channel_id: fibonacci_pairs,
-					direction: FlushDirection::Pull,
-					multiplicity: 1,
-				},
-			],
-			table_sizes: vec![trace.rows.len()],
-		};
-		let allocator = Bump::new();
-		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator, &statement)
-			.unwrap();
-
-		witness
-			.fill_table_sequential(&fibonacci_table, &trace.rows)
-			.unwrap();
-
+	fn compile_validate_prove_verify(
+		cs: &ConstraintSystem,
+		statement: &Statement,
+		witness: WitnessIndex,
+	) {
 		let compiled_cs = cs.compile(&statement).unwrap();
 		let witness = witness.into_multilinear_extension_index();
 
@@ -272,5 +249,78 @@ mod arithmetization {
 			HasherChallenger<Groestl256>,
 		>(&compiled_cs, LOG_INV_RATE, SECURITY_BITS, &statement.boundaries, proof)
 		.unwrap();
+	}
+
+	#[test]
+	fn test_fibonacci_prove_verify_small_table() {
+		let mut cs = ConstraintSystem::new();
+		let fibonacci_pairs = cs.add_channel("fibonacci_pairs");
+		let fibonacci_table = FibonacciTable::new(&mut cs, fibonacci_pairs);
+		let trace = FibonacciTrace::generate((0, 1), 1);
+		let statement = Statement {
+			boundaries: vec![
+				Boundary {
+					values: vec![B128::new(0), B128::new(1)],
+					channel_id: fibonacci_pairs,
+					direction: FlushDirection::Push,
+					multiplicity: 1,
+				},
+				Boundary {
+					values: vec![B128::new(1), B128::new(2)],
+					channel_id: fibonacci_pairs,
+					direction: FlushDirection::Pull,
+					multiplicity: 1,
+				},
+			],
+			table_sizes: vec![trace.rows.len()],
+		};
+		let allocator = Bump::new();
+		let mut witness = cs
+			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator, &statement)
+			.unwrap();
+
+		witness
+			.fill_table_sequential(&fibonacci_table, &trace.rows)
+			.unwrap();
+
+		compile_validate_prove_verify(&cs, &statement, witness);
+	}
+
+	#[test]
+	fn test_fibonacci_prove_verify_po2_sized() {
+		let mut cs = ConstraintSystem::new();
+		let fibonacci_pairs = cs.add_channel("fibonacci_pairs");
+		let mut fib_table_builder = cs.add_table("fibonacci");
+		fib_table_builder.require_power_of_two_size();
+		let fibonacci_table =
+			FibonacciTable::with_table_builder(&mut fib_table_builder, fibonacci_pairs);
+		let trace = FibonacciTrace::generate((0, 1), 31);
+		let statement = Statement {
+			boundaries: vec![
+				Boundary {
+					values: vec![B128::new(0), B128::new(1)],
+					channel_id: fibonacci_pairs,
+					direction: FlushDirection::Push,
+					multiplicity: 1,
+				},
+				Boundary {
+					values: vec![B128::new(2178309), B128::new(3524578)],
+					channel_id: fibonacci_pairs,
+					direction: FlushDirection::Pull,
+					multiplicity: 1,
+				},
+			],
+			table_sizes: vec![trace.rows.len()],
+		};
+		let allocator = Bump::new();
+		let mut witness = cs
+			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator, &statement)
+			.unwrap();
+
+		witness
+			.fill_table_sequential(&fibonacci_table, &trace.rows)
+			.unwrap();
+
+		compile_validate_prove_verify(&cs, &statement, witness);
 	}
 }


### PR DESCRIPTION
This adds the option to define tables in M3 that are required to have power-of-two size. These tables will have selectors omitted. This also modifies the constraint proving protocol to skip the selected sumcheck when the table is power-of-two-sized.

**Why not just omit selectors if the table size in the instance happens to be a power of two?** This is a reasonable alternative. However, I ultimately want the property that the oracle IDs and types in the compiled constraint system are independent of the table sizes in the instance. This is necessary for reduction planning. Also, it seems unlikely that large tables that are not statically known to be power-of-two sized will end up being power-of-two sized.