### PR TITLE
Implement optimized initialization and iteration for byte sliced fields using transposition

### DIFF
--- a/crates/field/benches/packed_field_init.rs
+++ b/crates/field/benches/packed_field_init.rs
@@ -80,6 +80,7 @@ fn byte_sliced_128(c: &mut Criterion) {
 	benchmark_from_fn!(ByteSlicedAES8x16x16b, group);
 	benchmark_from_fn!(ByteSlicedAES16x8b, group);
 	benchmark_from_fn!(ByteSlicedAES16x16x8b, group);
+	benchmark_from_fn!(ByteSliced16x128x1b, group);
 }
 
 fn byte_sliced_256(c: &mut Criterion) {
@@ -94,6 +95,7 @@ fn byte_sliced_256(c: &mut Criterion) {
 	benchmark_from_fn!(ByteSlicedAES8x32x16b, group);
 	benchmark_from_fn!(ByteSlicedAES32x8b, group);
 	benchmark_from_fn!(ByteSlicedAES16x32x8b, group);
+	benchmark_from_fn!(ByteSliced16x256x1b, group);
 }
 
 fn byte_sliced_512(c: &mut Criterion) {
@@ -108,6 +110,7 @@ fn byte_sliced_512(c: &mut Criterion) {
 	benchmark_from_fn!(ByteSlicedAES8x64x16b, group);
 	benchmark_from_fn!(ByteSlicedAES64x8b, group);
 	benchmark_from_fn!(ByteSlicedAES16x64x8b, group);
+	benchmark_from_fn!(ByteSliced16x512x1b, group);
 }
 
 criterion_group!(

--- a/crates/field/benches/packed_field_iter.rs
+++ b/crates/field/benches/packed_field_iter.rs
@@ -60,6 +60,7 @@ fn packed_512(c: &mut Criterion) {
 fn byte_sliced_128(c: &mut Criterion) {
 	let mut group = c.benchmark_group("bytes_sliced_128");
 
+	benchmark_iter!(ByteSliced16x128x1b, group);
 	benchmark_iter!(ByteSlicedAES16x8b, group);
 	benchmark_iter!(ByteSlicedAES16x16b, group);
 	benchmark_iter!(ByteSlicedAES16x32b, group);
@@ -70,6 +71,7 @@ fn byte_sliced_128(c: &mut Criterion) {
 fn byte_sliced_256(c: &mut Criterion) {
 	let mut group = c.benchmark_group("bytes_sliced_256");
 
+	benchmark_iter!(ByteSliced16x256x1b, group);
 	benchmark_iter!(ByteSlicedAES32x8b, group);
 	benchmark_iter!(ByteSlicedAES32x16b, group);
 	benchmark_iter!(ByteSlicedAES32x32b, group);
@@ -80,6 +82,7 @@ fn byte_sliced_256(c: &mut Criterion) {
 fn byte_sliced_512(c: &mut Criterion) {
 	let mut group = c.benchmark_group("bytes_sliced_512");
 
+	benchmark_iter!(ByteSliced16x512x1b, group);
 	benchmark_iter!(ByteSlicedAES64x8b, group);
 	benchmark_iter!(ByteSlicedAES64x16b, group);
 	benchmark_iter!(ByteSlicedAES64x32b, group);

--- a/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
+++ b/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
@@ -184,17 +184,32 @@ macro_rules! define_byte_sliced_3d {
 				Self { data }
 			}
 
+			impl_init_with_transpose!($packed_storage, $scalar_type, $storage_tower_level);
+
+			// Transposing values first is faster. Also we know that the scalar is at least 8b,
+			// so we can cast the transposed array to the array of scalars.
 			#[inline]
-			fn from_fn(mut f: impl FnMut(usize) -> Self::Scalar) -> Self {
-				let mut result = Self::default();
+			fn iter(&self) -> impl Iterator<Item = Self::Scalar> + Clone + Send + '_ {
+				type TransposePacked = <<$packed_storage as WithUnderlier>::Underlier as PackScalar<$scalar_type>>::Packed;
 
-				// TODO: use transposition here as soon as implemented
-				for i in 0..Self::WIDTH {
-					//SAFETY: i doesn't exceed Self::WIDTH
-					unsafe { result.set_unchecked(i, f(i)) };
-				}
+				let mut data: [TransposePacked; Self::HEIGHT_BYTES] = bytemuck::must_cast(self.data);
+				let mut underliers = WithUnderlier::to_underliers_arr_ref_mut(&mut data);
+				UnderlierWithBitOps::transpose_bytes_from_byte_sliced::<$storage_tower_level>(&mut underliers);
 
-				result
+				let data: [Self::Scalar; {Self::WIDTH}] = bytemuck::must_cast(data);
+				data.into_iter()
+			}
+
+			#[inline]
+			fn into_iter(self) -> impl Iterator<Item = Self::Scalar> + Clone + Send {
+				type TransposePacked = <<$packed_storage as WithUnderlier>::Underlier as PackScalar<$scalar_type>>::Packed;
+
+				let mut data: [TransposePacked; Self::HEIGHT_BYTES] = bytemuck::must_cast(self.data);
+				let mut underliers = WithUnderlier::to_underliers_arr_ref_mut(&mut data);
+				UnderlierWithBitOps::transpose_bytes_from_byte_sliced::<$storage_tower_level>(&mut underliers);
+
+				let data: [Self::Scalar; {Self::WIDTH}] = bytemuck::must_cast(data);
+				data.into_iter()
 			}
 
 			#[inline]
@@ -342,6 +357,51 @@ macro_rules! define_byte_sliced_3d {
 				});
 
 				TransformationWrapperNxN(transformations_8b)
+			}
+		}
+	};
+}
+
+/// This macro implements the `from_fn` and `from_scalars` methods for byte-sliced packed fields
+/// using transpose operations. This is faster both for 1b and non-1b scalars.
+macro_rules! impl_init_with_transpose {
+	($packed_storage:ty, $scalar_type:ty, $storage_tower_level:ty) => {
+		#[inline]
+		fn from_fn(mut f: impl FnMut(usize) -> Self::Scalar) -> Self {
+			type TransposePacked =
+				<<$packed_storage as WithUnderlier>::Underlier as PackScalar<$scalar_type>>::Packed;
+
+			let mut data: [TransposePacked; Self::HEIGHT_BYTES] = array::from_fn(|i| {
+				PackedField::from_fn(|j| f((i << TransposePacked::LOG_WIDTH) + j))
+			});
+			let mut underliers = WithUnderlier::to_underliers_arr_ref_mut(&mut data);
+			UnderlierWithBitOps::transpose_bytes_to_byte_sliced::<$storage_tower_level>(
+				&mut underliers,
+			);
+
+			Self {
+				data: bytemuck::must_cast(data),
+			}
+		}
+
+		#[inline]
+		fn from_scalars(scalars: impl IntoIterator<Item = Self::Scalar>) -> Self {
+			type TransposePacked =
+				<<$packed_storage as WithUnderlier>::Underlier as PackScalar<$scalar_type>>::Packed;
+
+			let mut data = [TransposePacked::default(); Self::HEIGHT_BYTES];
+			let mut iter = scalars.into_iter();
+			for v in data.iter_mut() {
+				*v = TransposePacked::from_scalars(&mut iter);
+			}
+
+			let mut underliers = WithUnderlier::to_underliers_arr_ref_mut(&mut data);
+			UnderlierWithBitOps::transpose_bytes_to_byte_sliced::<$storage_tower_level>(
+				&mut underliers,
+			);
+
+			Self {
+				data: bytemuck::must_cast(data),
 			}
 		}
 	};
@@ -618,6 +678,11 @@ macro_rules! define_byte_sliced_3d_1b {
 				Self { data }
 			}
 
+			impl_init_with_transpose!($packed_storage, BinaryField1b, $storage_tower_level);
+
+			// Benchmarks show that transposing before the iteration makes it slower for 1b case,
+			// so do not override the default implementations of `iter` and `into_iter`.
+
 			#[allow(unreachable_patterns)]
 			#[inline]
 			fn broadcast(scalar: Self::Scalar) -> Self {
@@ -627,17 +692,6 @@ macro_rules! define_byte_sliced_3d_1b {
 				Self {
 					data: array::from_fn(|_| WithUnderlier::from_underlier(underlier)),
 				}
-			}
-
-			#[inline]
-			fn from_fn(mut f: impl FnMut(usize) -> Self::Scalar) -> Self {
-				let data = array::from_fn(|row| {
-					<$packed_storage>::from_fn(|col| {
-						f(row * 8 + 8 * Self::HEIGHT_BYTES * (col / 8) + col % 8)
-					})
-				});
-
-				Self { data }
 			}
 
 			#[inline]


### PR DESCRIPTION
This gives 2-10x speedup depending on the scalar size and width