### PR TITLE
Support for non-strided batching in AdditiveNTT trait

### DIFF
--- a/crates/core/src/reed_solomon/reed_solomon.rs
+++ b/crates/core/src/reed_solomon/reed_solomon.rs
@@ -140,14 +140,14 @@ where
 				.zip(code.par_chunks_exact_mut(msgs_len))
 				.try_for_each(|(i, data)| {
 					self.ntt
-						.forward_transform(data, i, log_batch_size, self.log_dim())
+						.forward_transform(data, i, log_batch_size, 0, self.log_dim())
 				})
 		} else {
 			(0..(1 << self.log_inv_rate))
 				.zip(code.chunks_exact_mut(msgs_len))
 				.try_for_each(|(i, data)| {
 					self.ntt
-						.forward_transform(data, i, log_batch_size, self.log_dim())
+						.forward_transform(data, i, log_batch_size, 0, self.log_dim())
 				})
 		}
 	}

--- a/crates/ntt/benches/large_transform.rs
+++ b/crates/ntt/benches/large_transform.rs
@@ -14,21 +14,21 @@ use rand::thread_rng;
 fn bench_large_transform<F: TowerField, PE: PackedExtension<F>>(c: &mut Criterion, field: &str) {
 	let mut group = c.benchmark_group("NTT");
 	for log_dim in [16, 20] {
-		for log_batch_size in [1, 4] {
-			let data_len = 1 << (log_dim + log_batch_size - PE::LOG_WIDTH);
+		for log_stride_batch in [1, 4] {
+			let data_len = 1 << (log_dim + log_stride_batch - PE::LOG_WIDTH);
 			let mut rng = thread_rng();
 			let mut data = repeat_with(|| PE::random(&mut rng))
 				.take(data_len)
 				.collect::<Vec<_>>();
 
-			let params = format!("{field}/log_dim={log_dim}/log_b={log_batch_size}");
+			let params = format!("{field}/log_dim={log_dim}/log_s={log_stride_batch}");
 			group.throughput(Throughput::Bytes((data_len * size_of::<PE>()) as u64));
 
 			let ntt = SingleThreadedNTT::<F>::new(log_dim)
 				.unwrap()
 				.precompute_twiddles();
 			group.bench_function(BenchmarkId::new("single-thread/precompute", &params), |b| {
-				b.iter(|| ntt.forward_transform_ext(&mut data, 0, log_batch_size, log_dim));
+				b.iter(|| ntt.forward_transform_ext(&mut data, 0, log_stride_batch, 0, log_dim));
 			});
 
 			let ntt = SingleThreadedNTT::<F>::new(log_dim)
@@ -36,7 +36,7 @@ fn bench_large_transform<F: TowerField, PE: PackedExtension<F>>(c: &mut Criterio
 				.precompute_twiddles()
 				.multithreaded();
 			group.bench_function(BenchmarkId::new("multithread/precompute", &params), |b| {
-				b.iter(|| ntt.forward_transform_ext(&mut data, 0, log_batch_size, log_dim));
+				b.iter(|| ntt.forward_transform_ext(&mut data, 0, log_stride_batch, 0, log_dim));
 			});
 		}
 	}

--- a/crates/ntt/src/additive_ntt.rs
+++ b/crates/ntt/src/additive_ntt.rs
@@ -46,29 +46,35 @@ pub trait AdditiveNTT<F: BinaryField> {
 
 	/// Forward transformation defined in [LCH14] on a batch of inputs.
 	///
-	/// Input is the vector of polynomial coefficients in novel basis, output is in Lagrange basis.
-	/// The batched inputs are interleaved, which improves the cache-efficiency of the computation.
+	/// Given 2^(log_stride_batch + log_batch) polynomials in novel basis, transform them into Lagrange basis.
+	/// The scalars of the input, viewed in natural order, are subdivided into 2^log_batch chunks
+	/// Within each chunk 2^log_stride_batch instances of size 2^log_n are interleaved
+	/// The output adheres to the same shape.
 	///
 	/// [LCH14]: <https://arxiv.org/abs/1404.3458>
 	fn forward_transform<P: PackedField<Scalar = F>>(
 		&self,
 		data: &mut [P],
 		coset: u32,
-		log_batch_size: usize,
+		log_stride_batch: usize,
+		log_batch: usize,
 		log_n: usize,
 	) -> Result<(), Error>;
 
 	/// Inverse transformation defined in [LCH14] on a batch of inputs.
 	///
-	/// Input is the vector of polynomial coefficients in Lagrange basis, output is in novel basis.
-	/// The batched inputs are interleaved, which improves the cache-efficiency of the computation.
+	/// Given 2^(log_stride_batch + log_batch) polynomials in Lagrange basis, transform them into novel basis.
+	/// The scalars of the input, viewed in natural order, are subdivided into 2^log_batch chunks
+	/// Within each chunk 2^log_stride_batch instances of size 2^log_n are interleaved
+	/// The output adheres to the same shape.
 	///
 	/// [LCH14]: https://arxiv.org/abs/1404.3458
 	fn inverse_transform<P: PackedField<Scalar = F>>(
 		&self,
 		data: &mut [P],
 		coset: u32,
-		log_batch_size: usize,
+		log_stride_batch: usize,
+		log_batch: usize,
 		log_n: usize,
 	) -> Result<(), Error>;
 
@@ -76,13 +82,15 @@ pub trait AdditiveNTT<F: BinaryField> {
 		&self,
 		data: &mut [PE],
 		coset: u32,
-		log_batch_size: usize,
+		log_stride_batch: usize,
+		log_batch: usize,
 		log_n: usize,
 	) -> Result<(), Error> {
 		self.forward_transform(
 			PE::cast_bases_mut(data),
 			coset,
-			PE::Scalar::LOG_DEGREE + log_batch_size,
+			PE::Scalar::LOG_DEGREE + log_stride_batch,
+			log_batch,
 			log_n,
 		)
 	}
@@ -91,13 +99,15 @@ pub trait AdditiveNTT<F: BinaryField> {
 		&self,
 		data: &mut [PE],
 		coset: u32,
-		log_batch_size: usize,
+		log_stride_batch: usize,
+		log_batch: usize,
 		log_n: usize,
 	) -> Result<(), Error> {
 		self.inverse_transform(
 			PE::cast_bases_mut(data),
 			coset,
-			PE::Scalar::LOG_DEGREE + log_batch_size,
+			PE::Scalar::LOG_DEGREE + log_stride_batch,
+			log_batch,
 			log_n,
 		)
 	}

--- a/crates/ntt/src/dynamic_dispatch.rs
+++ b/crates/ntt/src/dynamic_dispatch.rs
@@ -112,17 +112,22 @@ impl<F: BinaryField> AdditiveNTT<F> for DynamicDispatchNTT<F> {
 		&self,
 		data: &mut [P],
 		coset: u32,
-		log_batch_size: usize,
+		log_stride_batch: usize,
+		log_batch: usize,
 		log_n: usize,
 	) -> Result<(), Error> {
 		match self {
-			Self::SingleThreaded(ntt) => ntt.forward_transform(data, coset, log_batch_size, log_n),
-			Self::SingleThreadedPrecompute(ntt) => {
-				ntt.forward_transform(data, coset, log_batch_size, log_n)
+			Self::SingleThreaded(ntt) => {
+				ntt.forward_transform(data, coset, log_stride_batch, log_batch, log_n)
 			}
-			Self::MultiThreaded(ntt) => ntt.forward_transform(data, coset, log_batch_size, log_n),
+			Self::SingleThreadedPrecompute(ntt) => {
+				ntt.forward_transform(data, coset, log_stride_batch, log_batch, log_n)
+			}
+			Self::MultiThreaded(ntt) => {
+				ntt.forward_transform(data, coset, log_stride_batch, log_batch, log_n)
+			}
 			Self::MultiThreadedPrecompute(ntt) => {
-				ntt.forward_transform(data, coset, log_batch_size, log_n)
+				ntt.forward_transform(data, coset, log_stride_batch, log_batch, log_n)
 			}
 		}
 	}
@@ -131,17 +136,22 @@ impl<F: BinaryField> AdditiveNTT<F> for DynamicDispatchNTT<F> {
 		&self,
 		data: &mut [P],
 		coset: u32,
-		log_batch_size: usize,
+		log_stride_batch: usize,
+		log_batch: usize,
 		log_n: usize,
 	) -> Result<(), Error> {
 		match self {
-			Self::SingleThreaded(ntt) => ntt.inverse_transform(data, coset, log_batch_size, log_n),
-			Self::SingleThreadedPrecompute(ntt) => {
-				ntt.inverse_transform(data, coset, log_batch_size, log_n)
+			Self::SingleThreaded(ntt) => {
+				ntt.inverse_transform(data, coset, log_stride_batch, log_batch, log_n)
 			}
-			Self::MultiThreaded(ntt) => ntt.inverse_transform(data, coset, log_batch_size, log_n),
+			Self::SingleThreadedPrecompute(ntt) => {
+				ntt.inverse_transform(data, coset, log_stride_batch, log_batch, log_n)
+			}
+			Self::MultiThreaded(ntt) => {
+				ntt.inverse_transform(data, coset, log_stride_batch, log_batch, log_n)
+			}
 			Self::MultiThreadedPrecompute(ntt) => {
-				ntt.inverse_transform(data, coset, log_batch_size, log_n)
+				ntt.inverse_transform(data, coset, log_stride_batch, log_batch, log_n)
 			}
 		}
 	}

--- a/crates/ntt/src/odd_interpolate.rs
+++ b/crates/ntt/src/odd_interpolate.rs
@@ -67,7 +67,7 @@ impl<F: BinaryField> OddInterpolate<F> {
 		}
 
 		for (i, chunk) in data.chunks_exact_mut(1 << ell).enumerate() {
-			ntt.inverse_transform(chunk, i as u32, 0, ell)?;
+			ntt.inverse_transform(chunk, i as u32, 0, 0, ell)?;
 		}
 
 		// Given M and a vector v, do the "strided product" M v. In more detail: we assume matrix is $d\times d$,
@@ -164,7 +164,7 @@ mod tests {
 				let next_log_n = log2_ceil_usize(expected_novel.len());
 				ntt_evals.resize(1 << next_log_n, F::ZERO);
 				// apply forward transform and then run our odd interpolation routine.
-				ntt.forward_transform(&mut ntt_evals, 0, 0, next_log_n)
+				ntt.forward_transform(&mut ntt_evals, 0, 0, 0, next_log_n)
 					.unwrap();
 
 				let odd_interpolate = OddInterpolate::new(d, ell, &ntt.s_evals).unwrap();


### PR DESCRIPTION
In addition to existing strided batching support (where NTT instances are interleaved in scalar representation) this PR adds non-strided batching support (where NTT instances are concatenated in scalar representation). Both kinds of batching are supported simultaneously, because they are useful for different purposes:
 1) Strided batching is more cache-coherent, and allows doing NTTs on field extensions via a strided batched NTT on base fields
 2) Non-strided batching avoids transpositions when doing a lot of small NTTs over wide packed fields (motivating example: low-to-high univariate skip zerocheck round on byte sliced packed fields).

When both kinds of batching are involved, NTT transforms become "3D".

In transform methods, `log_batch` parameter that used to mean strided batching width got renamed to `log_stride_batch`; a new `log_batch` parameter (with "old" name) was added to represent non-strided batching.