### PR TITLE
Optimize GKR exp protocol with packed subfield types

### DIFF
--- a/crates/core/src/constraint_system/exp.rs
+++ b/crates/core/src/constraint_system/exp.rs
@@ -84,20 +84,18 @@ where
 
 			let (exp_witness, tower_level) = match exp.base {
 				OracleOrConst::Const { base, tower_level } => {
-					let witness = gkr_exp::BaseExpWitness::new_with_static_base(
-						fast_exponent_witnesses,
-						base.into(),
-					)?;
+					let witness = gkr_exp::BaseExpWitness::new_with_static_base::<
+						PackedType<U, FFastExt<Tower>>,
+					>(fast_exponent_witnesses, base.into())?;
 					(witness, tower_level)
 				}
 				OracleOrConst::Oracle(base_id) => {
 					let fast_base_witnesses =
 						to_fast_witness::<U, Tower>(witness.get_multilin_poly(base_id)?)?;
 
-					let witness = gkr_exp::BaseExpWitness::new_with_dynamic_base(
-						fast_exponent_witnesses,
-						fast_base_witnesses,
-					)?;
+					let witness = gkr_exp::BaseExpWitness::new_with_dynamic_base::<
+						PackedType<U, FFastExt<Tower>>,
+					>(fast_exponent_witnesses, fast_base_witnesses)?;
 
 					let tower_level = oracles.tower_level(base_id);
 

--- a/crates/core/src/protocols/gkr_exp/witness.rs
+++ b/crates/core/src/protocols/gkr_exp/witness.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_field::{BinaryField, PackedField, RepackedExtension};
-use binius_math::MultilinearExtension;
+use binius_field::{BinaryField, ExtensionField, PackedExtension, PackedField, RepackedExtension};
+use binius_math::{MLEDirectAdapter, MultilinearExtension};
 use binius_maybe_rayon::{
 	iter::{IndexedParallelIterator, IntoParallelIterator},
 	prelude::ParallelIterator,
@@ -31,11 +31,11 @@ pub enum BaseWitness<'a, P: PackedField> {
 #[instrument(skip_all, name = "gkr_exp::evaluate_single_bit_output_packed")]
 fn evaluate_single_bit_output_packed<P, PExpBase>(
 	exponent_bit_witness: MultilinearWitness<P>,
-	base: Base<P, PExpBase>,
+	base: &Base<PExpBase>,
 	previous_single_bit_output: &[PExpBase],
 ) -> Vec<PExpBase>
 where
-	P: RepackedExtension<PExpBase>,
+	P: PackedField,
 	PExpBase: PackedField,
 {
 	let one = PExpBase::one();
@@ -44,15 +44,9 @@ where
 		.into_par_iter()
 		.enumerate()
 		.map(|(i, &prev_out)| {
-			let (base, prev_out) = match &base {
+			let (base, prev_out) = match base {
 				Base::Static(g) => (*g, prev_out),
-				Base::Dynamic(poly) => (
-					P::cast_bases(
-						poly.packed_evals()
-							.expect("base and exponent_bit_witness have the same width"),
-					)[i],
-					prev_out.square(),
-				),
+				Base::Dynamic(evals) => (evals[i], prev_out.square()),
 			};
 
 			let exponent_bit = PExpBase::from_fn(|j| {
@@ -72,17 +66,17 @@ where
 		.collect::<Vec<_>>()
 }
 
-enum Base<'a, P: PackedField, PExpBase: PackedField> {
+enum Base<'a, PExpBase: PackedField> {
 	Static(PExpBase),
-	Dynamic(MultilinearWitness<'a, P>),
+	Dynamic(&'a [PExpBase]),
 }
 
 fn evaluate_first_layer_output_packed<P, PExpBase>(
 	exponent_bit_witness: MultilinearWitness<P>,
-	base: Base<P, PExpBase>,
+	base: &Base<PExpBase>,
 ) -> Vec<PExpBase>
 where
-	P: RepackedExtension<PExpBase>,
+	P: PackedField,
 	PExpBase: PackedField,
 {
 	let one = PExpBase::one();
@@ -93,12 +87,9 @@ where
 			.saturating_sub(PExpBase::LOG_WIDTH))
 		.into_par_iter()
 		.map(|i| {
-			let base = match &base {
+			let base = match base {
 				Base::Static(g) => *g,
-				Base::Dynamic(poly) => P::cast_bases(
-					poly.packed_evals()
-						.expect("base and exponent_bit_witness have the same width"),
-				)[i],
+				Base::Dynamic(evals) => evals[i],
 			};
 
 			let exponent_bit = PExpBase::from_fn(|j| {
@@ -151,7 +142,7 @@ where
 
 		single_bit_output_layers_data[0] = evaluate_first_layer_output_packed(
 			exponent[0].clone(),
-			Base::Static(packed_base_power_static),
+			&Base::Static(packed_base_power_static),
 		);
 
 		for layer_idx_from_left in 1..exponent_bit_width {
@@ -159,7 +150,7 @@ where
 
 			single_bit_output_layers_data[layer_idx_from_left] = evaluate_single_bit_output_packed(
 				exponent[layer_idx_from_left].clone(),
-				Base::Static(packed_base_power_static),
+				&Base::Static(packed_base_power_static),
 				&single_bit_output_layers_data[layer_idx_from_left - 1],
 			);
 		}
@@ -182,7 +173,7 @@ where
 	/// Constructs a witness with a specified multilinear base.
 	///
 	/// # Requirements
-	/// For efficiency, the internal base witness data is required to be `PExpBase`.
+	/// * base have `packed_evals()` is Some
 	#[instrument(skip_all, name = "gkr_exp::new_with_dynamic_base")]
 	pub fn new_with_dynamic_base<PExpBase>(
 		exponent: Vec<MultilinearWitness<'a, P>>,
@@ -190,6 +181,7 @@ where
 	) -> Result<Self, Error>
 	where
 		P: RepackedExtension<PExpBase>,
+		P::Scalar: BinaryField + ExtensionField<PExpBase::Scalar>,
 		PExpBase::Scalar: BinaryField,
 		PExpBase: PackedField,
 	{
@@ -209,39 +201,86 @@ where
 			bail!(Error::NumberOfVariablesMismatch)
 		}
 
-		let base_evals: &[PExpBase] = P::cast_bases(base.packed_evals().unwrap());
-		if base_evals.len() != 1 << (exponent[0].n_vars().saturating_sub(PExpBase::LOG_WIDTH)) {
-			bail!(Error::NumberOfVariablesMismatch)
-		}
+		let single_bit_output_layers_data =
+			// If P and PExpBase are the same field, MLEDirectAdapter can be used
+			if <P::Scalar as ExtensionField<PExpBase::Scalar>>::DEGREE == 0 {
+				let single_bit_output_layers_data =
+					Self::build_dynamic_single_bit_output_layers_data::<P>(
+						&exponent,
+						base.packed_evals().expect("packed_evals required"),
+					);
 
-		let mut single_bit_output_layers_data = vec![Vec::new(); exponent_bit_width];
+				single_bit_output_layers_data
+					.into_iter()
+					.map(|single_bit_output_layers_data| {
+						MultilinearExtension::new(
+							exponent[0].n_vars(),
+							single_bit_output_layers_data,
+						)
+						.map(MLEDirectAdapter::from)
+						.map(|mle| mle.upcast_arc_dyn())
+					})
+					.collect::<Result<Vec<_>, binius_math::Error>>()?
+			} else {
+				let repacked_evals = <P as PackedExtension<PExpBase::Scalar>>::cast_bases(
+					base.packed_evals().expect("packed_evals required"),
+				);
 
-		single_bit_output_layers_data[0] = evaluate_first_layer_output_packed(
-			exponent[exponent_bit_width - 1].clone(),
-			Base::Dynamic(base.clone()),
-		);
+				if repacked_evals.len() != 1 << base.n_vars().saturating_sub(PExpBase::LOG_WIDTH) {
+					bail!(Error::NumberOfVariablesMismatch)
+				}
 
-		for layer_idx_from_left in 1..exponent_bit_width {
-			single_bit_output_layers_data[layer_idx_from_left] = evaluate_single_bit_output_packed(
-				exponent[exponent_bit_width - layer_idx_from_left - 1].clone(),
-				Base::Dynamic(base.clone()),
-				&single_bit_output_layers_data[layer_idx_from_left - 1],
-			);
-		}
+				let single_bit_output_layers_data =
+					Self::build_dynamic_single_bit_output_layers_data::<PExpBase>(
+						&exponent,
+						repacked_evals,
+					);
 
-		let single_bit_output_layers_data = single_bit_output_layers_data
-			.into_iter()
-			.map(|single_bit_output_layers_data| {
-				MultilinearExtension::new(exponent[0].n_vars(), single_bit_output_layers_data)
-					.map(|me| me.specialize_arc_dyn())
-			})
-			.collect::<Result<Vec<_>, binius_math::Error>>()?;
+				single_bit_output_layers_data
+					.into_iter()
+					.map(|single_bit_output_layers_data| {
+						MultilinearExtension::new(
+							exponent[0].n_vars(),
+							single_bit_output_layers_data,
+						)
+						.map(|me| me.specialize_arc_dyn())
+					})
+					.collect::<Result<Vec<_>, binius_math::Error>>()?
+			};
 
 		Ok(Self {
 			exponent,
 			single_bit_output_layers_data,
 			base: BaseWitness::Dynamic(base),
 		})
+	}
+
+	fn build_dynamic_single_bit_output_layers_data<PExpBase>(
+		exponent: &[MultilinearWitness<'a, P>],
+		evals: &[PExpBase],
+	) -> Vec<Vec<PExpBase>>
+	where
+		P: PackedField,
+		PExpBase::Scalar: BinaryField,
+		PExpBase: PackedField,
+	{
+		let exponent_bit_width = exponent.len();
+
+		let mut single_bit_output_layers_data = vec![Vec::new(); exponent_bit_width];
+
+		let base = Base::Dynamic(evals);
+
+		single_bit_output_layers_data[0] =
+			evaluate_first_layer_output_packed(exponent[exponent_bit_width - 1].clone(), &base);
+
+		for layer_idx_from_left in 1..exponent_bit_width {
+			single_bit_output_layers_data[layer_idx_from_left] = evaluate_single_bit_output_packed(
+				exponent[exponent_bit_width - layer_idx_from_left - 1].clone(),
+				&base,
+				&single_bit_output_layers_data[layer_idx_from_left - 1],
+			);
+		}
+		single_bit_output_layers_data
 	}
 
 	pub const fn uses_dynamic_base(&self) -> bool {


### PR DESCRIPTION
Add PExpBase to the gkr_exp witness, which allows reducing memory usage for storing it.
The witness supports all PackedField types, including Polyval.