### PR TITLE
[evalcheck] evalcheck deduplication of claims

### DIFF
--- a/crates/core/src/oracle/multilinear.rs
+++ b/crates/core/src/oracle/multilinear.rs
@@ -779,7 +779,7 @@ impl<F: TowerField> LinearCombination<F> {
 		inner: impl IntoIterator<Item = (MultilinearPolyOracle<F>, F)>,
 	) -> Result<Self, Error> {
 		let mut inner_dedup = Vec::new();
-		for (oracle, value) in inner.into_iter() {
+		for (oracle, value) in inner {
 			if oracle.n_vars() == n_vars {
 				match inner_dedup
 					.iter()

--- a/crates/core/src/protocols/evalcheck/error.rs
+++ b/crates/core/src/protocols/evalcheck/error.rs
@@ -41,6 +41,16 @@ pub enum VerificationError {
 	IncorrectCompositePolyEvaluation(String),
 	#[error("subproof type or shape does not match the claim")]
 	SubproofMismatch,
+	#[error("Not all evalcheck proof claims were verified")]
+	NotAllProofsVerified,
+	#[error("The claim index {index} into evalcheck is out of range; length: {length}")]
+	ClaimIndexOutOfRange { index: usize, length: usize },
+	#[error("The referenced duplicate claim is different from expected")]
+	DuplicateClaimMismatch,
+	#[error("Duplicate claim index is smaller than current index")]
+	DuplicateClaimIndexTooSmall,
+	#[error("Existing claim index is the same as current index")]
+	ExistingClaimEqCurrentClaim,
 }
 
 impl VerificationError {

--- a/crates/core/src/protocols/evalcheck/error.rs
+++ b/crates/core/src/protocols/evalcheck/error.rs
@@ -51,6 +51,8 @@ pub enum VerificationError {
 	DuplicateClaimIndexTooSmall,
 	#[error("Existing claim index is the same as current index")]
 	ExistingClaimEqCurrentClaim,
+	#[error("The number of proofs is greater than the initial claims")]
+	NotAllClaimsProcessed,
 }
 
 impl VerificationError {

--- a/crates/core/src/protocols/evalcheck/error.rs
+++ b/crates/core/src/protocols/evalcheck/error.rs
@@ -51,8 +51,8 @@ pub enum VerificationError {
 	DuplicateClaimIndexTooSmall,
 	#[error("Existing claim index is the same as current index")]
 	ExistingClaimEqCurrentClaim,
-	#[error("The number of proofs is greater than the initial claims")]
-	NotAllClaimsProcessed,
+	#[error("Out of advices")]
+	OutOfAdvices,
 }
 
 impl VerificationError {

--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -1,5 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+use std::ops::Range;
+
 use binius_field::{Field, PackedFieldIndexable, TowerField};
 use binius_hal::ComputationBackend;
 use binius_math::MultilinearExtension;

--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -460,11 +460,10 @@ where
 						let subclaims = linear_combination
 							.polys()
 							.map(|suboracle_id| {
-								let window = self.all_claims.len();
 								let subclaim_idx = self
 									.claims_to_index
 									.get(suboracle_id, &eval_point)
-									.and_then(|idxs| idxs.iter().find(|&&idx| idx < window))
+									.and_then(|idxs| idxs.first())
 									.copied();
 								match subclaim_idx {
 									Some(idx) => {

--- a/crates/core/src/protocols/evalcheck/subclaims.rs
+++ b/crates/core/src/protocols/evalcheck/subclaims.rs
@@ -495,7 +495,8 @@ impl<'a, P: PackedField, Backend: ComputationBackend> MemoizedData<'a, P, Backen
 						.get_multilin_poly(projected_id)
 						.expect("witness_index contains projected if projected_id exist");
 
-					self.partial_evals.insert(inner_id, eval_point, projected);
+					self.partial_evals
+						.insert_with_duplication(inner_id, eval_point, projected);
 				}
 			});
 	}

--- a/crates/core/src/protocols/evalcheck/tests.rs
+++ b/crates/core/src/protocols/evalcheck/tests.rs
@@ -615,7 +615,7 @@ fn test_evalcheck_duplicate_claims() {
 		},
 		EvalcheckMultilinearClaim {
 			id: transp1_id,
-			eval_point: eval_point.clone().into(),
+			eval_point: eval_point.into(),
 			eval: eval_stepdown1,
 		},
 	];
@@ -735,7 +735,7 @@ fn test_evalcheck_existing_claims() {
 		},
 		EvalcheckMultilinearClaim {
 			id: lin_comb1_id,
-			eval_point: eval_point.clone().into(),
+			eval_point: eval_point.into(),
 			eval: eval_lin_comb1,
 		},
 	];

--- a/crates/core/src/protocols/evalcheck/tests.rs
+++ b/crates/core/src/protocols/evalcheck/tests.rs
@@ -620,7 +620,7 @@ fn test_evalcheck_duplicate_claims() {
 		},
 	];
 
-	let mut witness_index = MultilinearExtensionIndex::<U, FExtension>::new();
+	let mut witness_index = MultilinearExtensionIndex::<PackedType<U, FExtension>>::new();
 	witness_index
 		.update_multilin_poly(vec![
 			(transp1_id, stepdown1_witness.specialize_arc_dyn()),
@@ -740,7 +740,7 @@ fn test_evalcheck_existing_claims() {
 		},
 	];
 
-	let mut witness_index = MultilinearExtensionIndex::<U, FExtension>::new();
+	let mut witness_index = MultilinearExtensionIndex::<PackedType<U, FExtension>>::new();
 	witness_index
 		.update_multilin_poly(vec![
 			(transp1_id, stepdown1_witness.specialize_arc_dyn()),

--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -115,6 +115,10 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 			return Err(Error::Verification(VerificationError::NotAllProofsVerified));
 		}
 
+		if proof_idx == 0 && !evalcheck_claims.is_empty() {
+			return Err(Error::Verification(VerificationError::NotAllClaimsProcessed));
+		}
+
 		Ok(())
 	}
 
@@ -249,6 +253,11 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 									length: self.round_claims.len(),
 								});
 							}
+							if self.round_claims[*index].id != sub_oracle_id
+								|| self.round_claims[*index].eval_point != eval_point
+							{
+								return Err(VerificationError::DuplicateClaimMismatch);
+							}
 							Ok(self.round_claims[*index].eval)
 						}
 						Subclaim::NewClaim(claim) => {
@@ -265,7 +274,7 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 				// Verify the evaluation of the linear combination over the claimed evaluations
 				let actual_eval = linear_combination.offset()
 					+ inner_product_unchecked::<F, F>(
-						inner_evals.into_iter(),
+						inner_evals,
 						linear_combination.coefficients(),
 					);
 

--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -78,7 +78,7 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 		self.round_claims.extend(evalcheck_claims.clone());
 
 		let mut proof_idx = 0;
-		// proof_len <= total_claim_len == advice_len
+		// proof_len <= len(self.round_claims) == advice_len
 		for (current_claim_idx, advice) in advices.into_iter().enumerate() {
 			if self.round_claims.len() <= current_claim_idx {
 				return Err(VerificationError::ClaimIndexOutOfRange {

--- a/crates/core/src/protocols/greedy_evalcheck/prove.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/prove.rs
@@ -13,8 +13,8 @@ use crate::{
 	oracle::MultilinearOracleSet,
 	protocols::evalcheck::{
 		serialize_advice, serialize_evalcheck_proof,
-		subclaims::{prove_bivariate_sumchecks_with_switchover, MemoizedData}, EvalcheckMultilinearClaim,
-		EvalcheckProver,
+		subclaims::{prove_bivariate_sumchecks_with_switchover, MemoizedData},
+		EvalcheckMultilinearClaim, EvalcheckProver,
 	},
 	transcript::{write_u64, ProverTranscript},
 	witness::MultilinearExtensionIndex,

--- a/crates/core/src/protocols/greedy_evalcheck/prove.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/prove.rs
@@ -12,9 +12,9 @@ use crate::{
 	fiat_shamir::Challenger,
 	oracle::MultilinearOracleSet,
 	protocols::evalcheck::{
-		serialize_evalcheck_proof,
-		subclaims::{prove_bivariate_sumchecks_with_switchover, MemoizedData},
-		EvalcheckMultilinearClaim, EvalcheckProver,
+		serialize_advice, serialize_evalcheck_proof,
+		subclaims::{prove_bivariate_sumchecks_with_switchover, MemoizedData}, EvalcheckMultilinearClaim,
+		EvalcheckProver,
 	},
 	transcript::{write_u64, ProverTranscript},
 	witness::MultilinearExtensionIndex,
@@ -51,11 +51,15 @@ where
 	let claims: Vec<_> = claims.into_iter().collect();
 
 	// Prove the initial evalcheck claims
-	let evalcheck_proofs = evalcheck_prover.prove(claims)?;
+	let (evalcheck_proofs, advices) = evalcheck_prover.prove(claims)?;
 	write_u64(&mut transcript.decommitment(), evalcheck_proofs.len() as u64);
+	write_u64(&mut transcript.decommitment(), advices.len() as u64);
 	let mut writer = transcript.message();
 	for evalcheck_proof in &evalcheck_proofs {
 		serialize_evalcheck_proof(&mut writer, evalcheck_proof)
+	}
+	for advice in &advices {
+		serialize_advice(&mut writer, advice);
 	}
 
 	loop {
@@ -75,11 +79,16 @@ where
 				backend,
 			)?;
 
-		let new_evalcheck_proofs = evalcheck_prover.prove(new_evalcheck_claims)?;
+		let (new_evalcheck_proofs, new_advices) = evalcheck_prover.prove(new_evalcheck_claims)?;
 
+		write_u64(&mut transcript.decommitment(), new_evalcheck_proofs.len() as u64);
+		write_u64(&mut transcript.decommitment(), new_advices.len() as u64);
 		let mut writer = transcript.message();
 		for evalcheck_proof in &new_evalcheck_proofs {
 			serialize_evalcheck_proof(&mut writer, evalcheck_proof);
+		}
+		for advice in &new_advices {
+			serialize_advice(&mut writer, advice);
 		}
 	}
 

--- a/crates/core/src/protocols/greedy_evalcheck/verify.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/verify.rs
@@ -9,7 +9,10 @@ use crate::{
 	fiat_shamir::Challenger,
 	oracle::MultilinearOracleSet,
 	protocols::{
-		evalcheck::{deserialize_evalcheck_proof, EvalcheckMultilinearClaim, EvalcheckVerifier},
+		evalcheck::{
+			deserialize_advice, deserialize_evalcheck_proof, EvalcheckMultilinearClaim,
+			EvalcheckVerifier,
+		},
 		sumcheck::{self, batch_verify, constraint_set_sumcheck_claims, SumcheckClaimsWithMeta},
 	},
 	transcript::{read_u64, VerifierTranscript},
@@ -30,14 +33,20 @@ where
 	let claims = claims.into_iter().collect::<Vec<_>>();
 
 	let len_initial_evalcheck_proofs = read_u64(&mut transcript.decommitment())? as usize;
+	let len_initial_advices = read_u64(&mut transcript.decommitment())? as usize;
 	let mut initial_evalcheck_proofs = Vec::with_capacity(len_initial_evalcheck_proofs);
+	let mut initial_advices = Vec::with_capacity(len_initial_advices);
 	let mut reader = transcript.message();
 	for _ in 0..len_initial_evalcheck_proofs {
 		let eval_check_proof = deserialize_evalcheck_proof(&mut reader)?;
 		initial_evalcheck_proofs.push(eval_check_proof);
 	}
+	for _ in 0..len_initial_advices {
+		let advice = deserialize_advice(&mut reader)?;
+		initial_advices.push(advice);
+	}
 
-	evalcheck_verifier.verify(claims, initial_evalcheck_proofs)?;
+	evalcheck_verifier.verify(claims, initial_evalcheck_proofs, initial_advices)?;
 
 	loop {
 		let SumcheckClaimsWithMeta { claims, metas } = constraint_set_sumcheck_claims(
@@ -54,14 +63,21 @@ where
 		let new_evalcheck_claims =
 			sumcheck::make_eval_claims(EvaluationOrder::HighToLow, metas, sumcheck_output)?;
 
-		let mut evalcheck_proofs = Vec::with_capacity(new_evalcheck_claims.len());
+		let len_new_evalcheck_proofs = read_u64(&mut transcript.decommitment())? as usize;
+		let len_new_advices = read_u64(&mut transcript.decommitment())? as usize;
+		let mut evalcheck_proofs = Vec::with_capacity(len_new_evalcheck_proofs);
+		let mut advices = Vec::with_capacity(len_new_advices);
 		let mut reader = transcript.message();
-		for _ in 0..new_evalcheck_claims.len() {
+		for _ in 0..len_new_evalcheck_proofs {
 			let evalcheck_proof = deserialize_evalcheck_proof(&mut reader)?;
 			evalcheck_proofs.push(evalcheck_proof)
 		}
+		for _ in 0..len_new_advices {
+			let advice = deserialize_advice(&mut reader)?;
+			advices.push(advice);
+		}
 
-		evalcheck_verifier.verify(new_evalcheck_claims, evalcheck_proofs)?;
+		evalcheck_verifier.verify(new_evalcheck_claims, evalcheck_proofs, advices)?;
 	}
 
 	let new_sumchecks = evalcheck_verifier.take_new_sumcheck_constraints().unwrap();


### PR DESCRIPTION
This MR changes the Evalcheck prove and verify to deduplicate proofs by claims and changes the Proof from a recursive DAG into a vector of Enums. Note also that the prover and verifier steps through the claim in modified BFS as opposed to the verifier doing a DFS to verify new claims.

- TODO: Add documentation

# Performance improvement
- Main branch (M3 Pro)
  - Groestl (16384 perms)
    - Proving time: 1.64 s
    - Verification time: 1.35 s
    - Proof size: 840.6 KB
  - Keccakf (8192 perms)
    - Proving time: 3.74 s
    - Verification time: 255 ms
    - Proof size:  575.1 KB
    
- My branch (M3 Pro)
  - Groestl (16384 perms)
    - Proving time: 0.703 s
    - Verification time: 219 ms
    - Proof size: 511.6 KB
  - Keccakf (8192 perms)
    - Proving time: 2.72 s
    - Verification time: 76 ms
    - Proof size: 538.4 KB