### PR TITLE
[fix] remove recursive BufMut and Buf coercion

### DIFF
--- a/crates/circuits/src/builder/constraint_system.rs
+++ b/crates/circuits/src/builder/constraint_system.rs
@@ -485,3 +485,34 @@ impl<'arena> ConstraintSystemBuilder<'arena> {
 		Ok(log_rows)
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use binius_core::constraint_system::ConstraintSystem;
+	use binius_utils::{DeserializeBytes, SerializationMode, SerializeBytes};
+
+	use super::ConstraintSystemBuilder;
+	use crate::u32fib::u32fib;
+
+	#[test]
+	fn test_serialize_roundtrip() {
+		let mut builder = ConstraintSystemBuilder::new();
+		let log_size_1b = 14;
+		let _ = u32fib(&mut builder, "u32fib", log_size_1b).unwrap();
+
+		let prover_constraint_system = builder.build().unwrap();
+		let mut write_buf = vec![];
+		prover_constraint_system
+			.serialize(&mut write_buf, SerializationMode::Native)
+			.unwrap();
+		let constraint_system =
+			ConstraintSystem::deserialize(&mut write_buf.as_slice(), SerializationMode::Native)
+				.unwrap();
+		assert_eq!(constraint_system.exponents.len(), 0);
+		assert_eq!(constraint_system.flushes.len(), 0);
+		assert_eq!(constraint_system.max_channel_id, 0);
+		assert_eq!(constraint_system.non_zero_oracle_ids.len(), 0);
+		assert_eq!(constraint_system.table_constraints.len(), 2);
+		assert_eq!(constraint_system.oracles.size(), 9);
+	}
+}

--- a/crates/core/src/constraint_system/mod.rs
+++ b/crates/core/src/constraint_system/mod.rs
@@ -37,19 +37,19 @@ pub struct ConstraintSystem<F: TowerField> {
 
 impl DeserializeBytes for ConstraintSystem<BinaryField128b> {
 	fn deserialize(
-		mut read_buf: impl bytes::Buf,
+		read_buf: &mut dyn bytes::Buf,
 		mode: SerializationMode,
 	) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
 		Ok(Self {
-			oracles: DeserializeBytes::deserialize(&mut read_buf, mode)?,
-			table_constraints: DeserializeBytes::deserialize(&mut read_buf, mode)?,
-			non_zero_oracle_ids: DeserializeBytes::deserialize(&mut read_buf, mode)?,
-			flushes: DeserializeBytes::deserialize(&mut read_buf, mode)?,
-			exponents: DeserializeBytes::deserialize(&mut read_buf, mode)?,
-			max_channel_id: DeserializeBytes::deserialize(&mut read_buf, mode)?,
+			oracles: DeserializeBytes::deserialize(read_buf, mode)?,
+			table_constraints: DeserializeBytes::deserialize(read_buf, mode)?,
+			non_zero_oracle_ids: DeserializeBytes::deserialize(read_buf, mode)?,
+			flushes: DeserializeBytes::deserialize(read_buf, mode)?,
+			exponents: DeserializeBytes::deserialize(read_buf, mode)?,
+			max_channel_id: DeserializeBytes::deserialize(read_buf, mode)?,
 		})
 	}
 }

--- a/crates/core/src/oracle/multilinear.rs
+++ b/crates/core/src/oracle/multilinear.rs
@@ -361,7 +361,10 @@ pub struct MultilinearOracleSet<F: TowerField> {
 }
 
 impl DeserializeBytes for MultilinearOracleSet<BinaryField128b> {
-	fn deserialize(read_buf: impl Buf, mode: SerializationMode) -> Result<Self, SerializationError>
+	fn deserialize(
+		read_buf: &mut dyn Buf,
+		mode: SerializationMode,
+	) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
@@ -553,18 +556,18 @@ pub struct MultilinearPolyOracle<F: TowerField> {
 
 impl DeserializeBytes for MultilinearPolyOracle<BinaryField128b> {
 	fn deserialize(
-		mut read_buf: impl bytes::Buf,
+		read_buf: &mut dyn bytes::Buf,
 		mode: SerializationMode,
 	) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
 		Ok(Self {
-			id: DeserializeBytes::deserialize(&mut read_buf, mode)?,
-			name: DeserializeBytes::deserialize(&mut read_buf, mode)?,
-			n_vars: DeserializeBytes::deserialize(&mut read_buf, mode)?,
-			tower_level: DeserializeBytes::deserialize(&mut read_buf, mode)?,
-			variant: DeserializeBytes::deserialize(&mut read_buf, mode)?,
+			id: DeserializeBytes::deserialize(read_buf, mode)?,
+			name: DeserializeBytes::deserialize(read_buf, mode)?,
+			n_vars: DeserializeBytes::deserialize(read_buf, mode)?,
+			tower_level: DeserializeBytes::deserialize(read_buf, mode)?,
+			variant: DeserializeBytes::deserialize(read_buf, mode)?,
 		})
 	}
 }
@@ -584,17 +587,17 @@ pub enum MultilinearPolyVariant<F: TowerField> {
 
 impl DeserializeBytes for MultilinearPolyVariant<BinaryField128b> {
 	fn deserialize(
-		mut buf: impl bytes::Buf,
+		buf: &mut dyn bytes::Buf,
 		mode: SerializationMode,
 	) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
-		Ok(match u8::deserialize(&mut buf, mode)? {
+		Ok(match u8::deserialize(buf, mode)? {
 			0 => Self::Committed,
 			1 => Self::Transparent(DeserializeBytes::deserialize(buf, mode)?),
 			2 => Self::Repeating {
-				id: DeserializeBytes::deserialize(&mut buf, mode)?,
+				id: DeserializeBytes::deserialize(buf, mode)?,
 				log_count: DeserializeBytes::deserialize(buf, mode)?,
 			},
 			3 => Self::Projected(DeserializeBytes::deserialize(buf, mode)?),
@@ -624,16 +627,16 @@ pub struct TransparentPolyOracle<F: Field> {
 impl<F: TowerField> SerializeBytes for TransparentPolyOracle<F> {
 	fn serialize(
 		&self,
-		mut write_buf: impl bytes::BufMut,
+		write_buf: &mut dyn bytes::BufMut,
 		mode: SerializationMode,
 	) -> Result<(), SerializationError> {
-		self.poly.erased_serialize(&mut write_buf, mode)
+		self.poly.erased_serialize(write_buf, mode)
 	}
 }
 
 impl DeserializeBytes for TransparentPolyOracle<BinaryField128b> {
 	fn deserialize(
-		read_buf: impl bytes::Buf,
+		read_buf: &mut dyn bytes::Buf,
 		mode: SerializationMode,
 	) -> Result<Self, SerializationError>
 	where

--- a/crates/core/src/polynomial/arith_circuit.rs
+++ b/crates/core/src/polynomial/arith_circuit.rs
@@ -144,16 +144,16 @@ impl<F: Field> Eq for ArithCircuitPoly<F> {}
 impl<F: TowerField> SerializeBytes for ArithCircuitPoly<F> {
 	fn serialize(
 		&self,
-		mut write_buf: impl bytes::BufMut,
+		write_buf: &mut dyn bytes::BufMut,
 		mode: SerializationMode,
 	) -> Result<(), SerializationError> {
-		(&self.expr, self.n_vars).serialize(&mut write_buf, mode)
+		(&self.expr, self.n_vars).serialize(write_buf, mode)
 	}
 }
 
 impl<F: TowerField> DeserializeBytes for ArithCircuitPoly<F> {
 	fn deserialize(
-		read_buf: impl bytes::Buf,
+		read_buf: &mut dyn bytes::Buf,
 		mode: SerializationMode,
 	) -> Result<Self, SerializationError>
 	where

--- a/crates/core/src/transparent/multilinear_extension.rs
+++ b/crates/core/src/transparent/multilinear_extension.rs
@@ -41,7 +41,7 @@ where
 {
 	fn serialize(
 		&self,
-		write_buf: impl bytes::BufMut,
+		write_buf: &mut dyn bytes::BufMut,
 		mode: SerializationMode,
 	) -> Result<(), SerializationError> {
 		let elems = PE::iter_slice(

--- a/crates/core/src/transparent/serialization.rs
+++ b/crates/core/src/transparent/serialization.rs
@@ -18,24 +18,24 @@ use crate::polynomial::MultivariatePoly;
 impl<F: TowerField> SerializeBytes for Box<dyn MultivariatePoly<F>> {
 	fn serialize(
 		&self,
-		mut write_buf: impl bytes::BufMut,
+		write_buf: &mut dyn bytes::BufMut,
 		mode: SerializationMode,
 	) -> Result<(), SerializationError> {
-		self.erased_serialize(&mut write_buf, mode)
+		self.erased_serialize(write_buf, mode)
 	}
 }
 
 impl DeserializeBytes for Box<dyn MultivariatePoly<BinaryField128b>> {
 	fn deserialize(
-		mut read_buf: impl bytes::Buf,
+		read_buf: &mut dyn bytes::Buf,
 		mode: SerializationMode,
 	) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
-		let name = String::deserialize(&mut read_buf, mode)?;
+		let name = String::deserialize(read_buf, mode)?;
 		match REGISTRY.get(name.as_str()) {
-			Some(Some(erased_deserialize)) => erased_deserialize(&mut read_buf, mode),
+			Some(Some(erased_deserialize)) => erased_deserialize(read_buf, mode),
 			Some(None) => Err(SerializationError::DeserializerNameConflict { name }),
 			None => Err(SerializationError::DeserializerNotImplented),
 		}

--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -307,7 +307,7 @@ macro_rules! serialize_deserialize_non_canonical {
 		impl SerializeBytes for $field {
 			fn serialize(
 				&self,
-				write_buf: impl BufMut,
+				write_buf: &mut dyn BufMut,
 				mode: SerializationMode,
 			) -> Result<(), SerializationError> {
 				match mode {
@@ -321,7 +321,7 @@ macro_rules! serialize_deserialize_non_canonical {
 
 		impl DeserializeBytes for $field {
 			fn deserialize(
-				read_buf: impl Buf,
+				read_buf: &mut dyn Buf,
 				mode: SerializationMode,
 			) -> Result<Self, SerializationError>
 			where

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -769,7 +769,7 @@ macro_rules! serialize_deserialize {
 		impl SerializeBytes for $bin_type {
 			fn serialize(
 				&self,
-				write_buf: impl BufMut,
+				write_buf: &mut dyn BufMut,
 				mode: SerializationMode,
 			) -> Result<(), SerializationError> {
 				self.0.serialize(write_buf, mode)
@@ -778,7 +778,7 @@ macro_rules! serialize_deserialize {
 
 		impl DeserializeBytes for $bin_type {
 			fn deserialize(
-				read_buf: impl Buf,
+				read_buf: &mut dyn Buf,
 				mode: SerializationMode,
 			) -> Result<Self, SerializationError> {
 				Ok(Self(DeserializeBytes::deserialize(read_buf, mode)?))

--- a/crates/field/src/polyval.rs
+++ b/crates/field/src/polyval.rs
@@ -466,7 +466,7 @@ impl ExtensionField<BinaryField1b> for BinaryField128bPolyval {
 impl SerializeBytes for BinaryField128bPolyval {
 	fn serialize(
 		&self,
-		write_buf: impl BufMut,
+		write_buf: &mut dyn BufMut,
 		mode: SerializationMode,
 	) -> Result<(), SerializationError> {
 		match mode {
@@ -479,7 +479,10 @@ impl SerializeBytes for BinaryField128bPolyval {
 }
 
 impl DeserializeBytes for BinaryField128bPolyval {
-	fn deserialize(read_buf: impl Buf, mode: SerializationMode) -> Result<Self, SerializationError>
+	fn deserialize(
+		read_buf: &mut dyn Buf,
+		mode: SerializationMode,
+	) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{

--- a/crates/field/src/underlier/small_uint.rs
+++ b/crates/field/src/underlier/small_uint.rs
@@ -251,7 +251,7 @@ impl From<U1> for bool {
 impl<const N: usize> SerializeBytes for SmallU<N> {
 	fn serialize(
 		&self,
-		write_buf: impl BufMut,
+		write_buf: &mut dyn BufMut,
 		mode: SerializationMode,
 	) -> Result<(), SerializationError> {
 		self.val().serialize(write_buf, mode)
@@ -259,7 +259,10 @@ impl<const N: usize> SerializeBytes for SmallU<N> {
 }
 
 impl<const N: usize> DeserializeBytes for SmallU<N> {
-	fn deserialize(read_buf: impl Buf, mode: SerializationMode) -> Result<Self, SerializationError>
+	fn deserialize(
+		read_buf: &mut dyn Buf,
+		mode: SerializationMode,
+	) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{

--- a/crates/utils/src/serialization.rs
+++ b/crates/utils/src/serialization.rs
@@ -9,14 +9,17 @@ use thiserror::Error;
 pub trait SerializeBytes {
 	fn serialize(
 		&self,
-		write_buf: impl BufMut,
+		write_buf: &mut dyn BufMut,
 		mode: SerializationMode,
 	) -> Result<(), SerializationError>;
 }
 
 /// Deserialize data according to Mode param
 pub trait DeserializeBytes {
-	fn deserialize(read_buf: impl Buf, mode: SerializationMode) -> Result<Self, SerializationError>
+	fn deserialize(
+		read_buf: &mut dyn Buf,
+		mode: SerializationMode,
+	) -> Result<Self, SerializationError>
 	where
 		Self: Sized;
 }
@@ -55,7 +58,10 @@ pub enum SerializationError {
 use generic_array::{ArrayLength, GenericArray};
 
 impl<T: DeserializeBytes> DeserializeBytes for Box<T> {
-	fn deserialize(read_buf: impl Buf, mode: SerializationMode) -> Result<Self, SerializationError>
+	fn deserialize(
+		read_buf: &mut dyn Buf,
+		mode: SerializationMode,
+	) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
@@ -66,22 +72,22 @@ impl<T: DeserializeBytes> DeserializeBytes for Box<T> {
 impl SerializeBytes for usize {
 	fn serialize(
 		&self,
-		mut write_buf: impl BufMut,
+		write_buf: &mut dyn BufMut,
 		mode: SerializationMode,
 	) -> Result<(), SerializationError> {
-		SerializeBytes::serialize(&(*self as u64), &mut write_buf, mode)
+		SerializeBytes::serialize(&(*self as u64), write_buf, mode)
 	}
 }
 
 impl DeserializeBytes for usize {
 	fn deserialize(
-		mut read_buf: impl Buf,
+		read_buf: &mut dyn Buf,
 		mode: SerializationMode,
 	) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
-		let value: u64 = DeserializeBytes::deserialize(&mut read_buf, mode)?;
+		let value: u64 = DeserializeBytes::deserialize(read_buf, mode)?;
 		Ok(value as Self)
 	}
 }
@@ -89,7 +95,7 @@ impl DeserializeBytes for usize {
 impl SerializeBytes for u128 {
 	fn serialize(
 		&self,
-		mut write_buf: impl BufMut,
+		write_buf: &mut dyn BufMut,
 		_mode: SerializationMode,
 	) -> Result<(), SerializationError> {
 		assert_enough_space_for(&write_buf, std::mem::size_of::<Self>())?;
@@ -100,7 +106,7 @@ impl SerializeBytes for u128 {
 
 impl DeserializeBytes for u128 {
 	fn deserialize(
-		mut read_buf: impl Buf,
+		read_buf: &mut dyn Buf,
 		_mode: SerializationMode,
 	) -> Result<Self, SerializationError>
 	where
@@ -114,7 +120,7 @@ impl DeserializeBytes for u128 {
 impl SerializeBytes for u64 {
 	fn serialize(
 		&self,
-		mut write_buf: impl BufMut,
+		write_buf: &mut dyn BufMut,
 		_mode: SerializationMode,
 	) -> Result<(), SerializationError> {
 		assert_enough_space_for(&write_buf, std::mem::size_of::<Self>())?;
@@ -125,7 +131,7 @@ impl SerializeBytes for u64 {
 
 impl DeserializeBytes for u64 {
 	fn deserialize(
-		mut read_buf: impl Buf,
+		read_buf: &mut dyn Buf,
 		_mode: SerializationMode,
 	) -> Result<Self, SerializationError>
 	where
@@ -139,7 +145,7 @@ impl DeserializeBytes for u64 {
 impl SerializeBytes for u32 {
 	fn serialize(
 		&self,
-		mut write_buf: impl BufMut,
+		write_buf: &mut dyn BufMut,
 		_mode: SerializationMode,
 	) -> Result<(), SerializationError> {
 		assert_enough_space_for(&write_buf, std::mem::size_of::<Self>())?;
@@ -150,7 +156,7 @@ impl SerializeBytes for u32 {
 
 impl DeserializeBytes for u32 {
 	fn deserialize(
-		mut read_buf: impl Buf,
+		read_buf: &mut dyn Buf,
 		_mode: SerializationMode,
 	) -> Result<Self, SerializationError>
 	where
@@ -164,7 +170,7 @@ impl DeserializeBytes for u32 {
 impl SerializeBytes for u16 {
 	fn serialize(
 		&self,
-		mut write_buf: impl BufMut,
+		write_buf: &mut dyn BufMut,
 		_mode: SerializationMode,
 	) -> Result<(), SerializationError> {
 		assert_enough_space_for(&write_buf, std::mem::size_of::<Self>())?;
@@ -175,7 +181,7 @@ impl SerializeBytes for u16 {
 
 impl DeserializeBytes for u16 {
 	fn deserialize(
-		mut read_buf: impl Buf,
+		read_buf: &mut dyn Buf,
 		_mode: SerializationMode,
 	) -> Result<Self, SerializationError>
 	where
@@ -189,7 +195,7 @@ impl DeserializeBytes for u16 {
 impl SerializeBytes for u8 {
 	fn serialize(
 		&self,
-		mut write_buf: impl BufMut,
+		write_buf: &mut dyn BufMut,
 		_mode: SerializationMode,
 	) -> Result<(), SerializationError> {
 		assert_enough_space_for(&write_buf, std::mem::size_of::<Self>())?;
@@ -200,7 +206,7 @@ impl SerializeBytes for u8 {
 
 impl DeserializeBytes for u8 {
 	fn deserialize(
-		mut read_buf: impl Buf,
+		read_buf: &mut dyn Buf,
 		_mode: SerializationMode,
 	) -> Result<Self, SerializationError>
 	where
@@ -214,7 +220,7 @@ impl DeserializeBytes for u8 {
 impl SerializeBytes for bool {
 	fn serialize(
 		&self,
-		write_buf: impl BufMut,
+		write_buf: &mut dyn BufMut,
 		mode: SerializationMode,
 	) -> Result<(), SerializationError> {
 		u8::serialize(&(*self as u8), write_buf, mode)
@@ -222,7 +228,10 @@ impl SerializeBytes for bool {
 }
 
 impl DeserializeBytes for bool {
-	fn deserialize(read_buf: impl Buf, mode: SerializationMode) -> Result<Self, SerializationError>
+	fn deserialize(
+		read_buf: &mut dyn Buf,
+		mode: SerializationMode,
+	) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
@@ -233,7 +242,7 @@ impl DeserializeBytes for bool {
 impl<T> SerializeBytes for std::marker::PhantomData<T> {
 	fn serialize(
 		&self,
-		_write_buf: impl BufMut,
+		_write_buf: &mut dyn BufMut,
 		_mode: SerializationMode,
 	) -> Result<(), SerializationError> {
 		Ok(())
@@ -242,7 +251,7 @@ impl<T> SerializeBytes for std::marker::PhantomData<T> {
 
 impl<T> DeserializeBytes for std::marker::PhantomData<T> {
 	fn deserialize(
-		_read_buf: impl Buf,
+		_read_buf: &mut dyn Buf,
 		_mode: SerializationMode,
 	) -> Result<Self, SerializationError>
 	where
@@ -255,11 +264,11 @@ impl<T> DeserializeBytes for std::marker::PhantomData<T> {
 impl SerializeBytes for &str {
 	fn serialize(
 		&self,
-		mut write_buf: impl BufMut,
+		write_buf: &mut dyn BufMut,
 		mode: SerializationMode,
 	) -> Result<(), SerializationError> {
 		let bytes = self.as_bytes();
-		SerializeBytes::serialize(&bytes.len(), &mut write_buf, mode)?;
+		SerializeBytes::serialize(&bytes.len(), write_buf, mode)?;
 		assert_enough_space_for(&write_buf, bytes.len())?;
 		write_buf.put_slice(bytes);
 		Ok(())
@@ -269,22 +278,22 @@ impl SerializeBytes for &str {
 impl SerializeBytes for String {
 	fn serialize(
 		&self,
-		mut write_buf: impl BufMut,
+		write_buf: &mut dyn BufMut,
 		mode: SerializationMode,
 	) -> Result<(), SerializationError> {
-		SerializeBytes::serialize(&self.as_str(), &mut write_buf, mode)
+		SerializeBytes::serialize(&self.as_str(), write_buf, mode)
 	}
 }
 
 impl DeserializeBytes for String {
 	fn deserialize(
-		mut read_buf: impl Buf,
+		read_buf: &mut dyn Buf,
 		mode: SerializationMode,
 	) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
-		let len = DeserializeBytes::deserialize(&mut read_buf, mode)?;
+		let len = DeserializeBytes::deserialize(read_buf, mode)?;
 		assert_enough_data_for(&read_buf, len)?;
 		Ok(Self::from_utf8(read_buf.copy_to_bytes(len).to_vec())?)
 	}
@@ -293,26 +302,26 @@ impl DeserializeBytes for String {
 impl<T: SerializeBytes> SerializeBytes for Vec<T> {
 	fn serialize(
 		&self,
-		mut write_buf: impl BufMut,
+		write_buf: &mut dyn BufMut,
 		mode: SerializationMode,
 	) -> Result<(), SerializationError> {
-		SerializeBytes::serialize(&self.len(), &mut write_buf, mode)?;
+		SerializeBytes::serialize(&self.len(), write_buf, mode)?;
 		self.iter()
-			.try_for_each(|item| SerializeBytes::serialize(item, &mut write_buf, mode))
+			.try_for_each(|item| SerializeBytes::serialize(item, write_buf, mode))
 	}
 }
 
 impl<T: DeserializeBytes> DeserializeBytes for Vec<T> {
 	fn deserialize(
-		mut read_buf: impl Buf,
+		read_buf: &mut dyn Buf,
 		mode: SerializationMode,
 	) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
-		let len: usize = DeserializeBytes::deserialize(&mut read_buf, mode)?;
+		let len: usize = DeserializeBytes::deserialize(read_buf, mode)?;
 		(0..len)
-			.map(|_| DeserializeBytes::deserialize(&mut read_buf, mode))
+			.map(|_| DeserializeBytes::deserialize(read_buf, mode))
 			.collect()
 	}
 }
@@ -320,13 +329,13 @@ impl<T: DeserializeBytes> DeserializeBytes for Vec<T> {
 impl<T: SerializeBytes> SerializeBytes for Option<T> {
 	fn serialize(
 		&self,
-		mut write_buf: impl BufMut,
+		write_buf: &mut dyn BufMut,
 		mode: SerializationMode,
 	) -> Result<(), SerializationError> {
 		match self {
 			Some(value) => {
-				SerializeBytes::serialize(&true, &mut write_buf, mode)?;
-				SerializeBytes::serialize(value, &mut write_buf, mode)?;
+				SerializeBytes::serialize(&true, write_buf, mode)?;
+				SerializeBytes::serialize(value, write_buf, mode)?;
 			}
 			None => {
 				SerializeBytes::serialize(&false, write_buf, mode)?;
@@ -338,14 +347,14 @@ impl<T: SerializeBytes> SerializeBytes for Option<T> {
 
 impl<T: DeserializeBytes> DeserializeBytes for Option<T> {
 	fn deserialize(
-		mut read_buf: impl Buf,
+		read_buf: &mut dyn Buf,
 		mode: SerializationMode,
 	) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
-		Ok(match bool::deserialize(&mut read_buf, mode)? {
-			true => Some(T::deserialize(&mut read_buf, mode)?),
+		Ok(match bool::deserialize(read_buf, mode)? {
+			true => Some(T::deserialize(read_buf, mode)?),
 			false => None,
 		})
 	}
@@ -354,30 +363,30 @@ impl<T: DeserializeBytes> DeserializeBytes for Option<T> {
 impl<U: SerializeBytes, V: SerializeBytes> SerializeBytes for (U, V) {
 	fn serialize(
 		&self,
-		mut write_buf: impl BufMut,
+		write_buf: &mut dyn BufMut,
 		mode: SerializationMode,
 	) -> Result<(), SerializationError> {
-		U::serialize(&self.0, &mut write_buf, mode)?;
+		U::serialize(&self.0, write_buf, mode)?;
 		V::serialize(&self.1, write_buf, mode)
 	}
 }
 
 impl<U: DeserializeBytes, V: DeserializeBytes> DeserializeBytes for (U, V) {
 	fn deserialize(
-		mut read_buf: impl Buf,
+		read_buf: &mut dyn Buf,
 		mode: SerializationMode,
 	) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
-		Ok((U::deserialize(&mut read_buf, mode)?, V::deserialize(read_buf, mode)?))
+		Ok((U::deserialize(read_buf, mode)?, V::deserialize(read_buf, mode)?))
 	}
 }
 
 impl<N: ArrayLength<u8>> SerializeBytes for GenericArray<u8, N> {
 	fn serialize(
 		&self,
-		mut write_buf: impl BufMut,
+		write_buf: &mut dyn BufMut,
 		_mode: SerializationMode,
 	) -> Result<(), SerializationError> {
 		assert_enough_space_for(&write_buf, N::USIZE)?;
@@ -388,7 +397,7 @@ impl<N: ArrayLength<u8>> SerializeBytes for GenericArray<u8, N> {
 
 impl<N: ArrayLength<u8>> DeserializeBytes for GenericArray<u8, N> {
 	fn deserialize(
-		mut read_buf: impl Buf,
+		read_buf: &mut dyn Buf,
 		_mode: SerializationMode,
 	) -> Result<Self, SerializationError> {
 		assert_enough_data_for(&read_buf, N::USIZE)?;


### PR DESCRIPTION
## Issue
There was a trait resolution overflow caused by recursive `&mut` coercions when `BufMut` and `Buf` were taken as `impl Trait` and then re-borrowed in macro-derived `serialize()` and `deserialize()` methods.

## Steps To Reproduce
Try to compile the following unit test:
```
#[cfg(test)]
mod tests {
	use generic_array::typenum::U32;
	use rand::{rngs::StdRng, RngCore, SeedableRng};

	use super::*;

	#[test]
	fn test_generic_array_serialize_deserialize() {
		let mut rng = StdRng::seed_from_u64(0);

		let mut data = GenericArray::<u8, U32>::default();
		rng.fill_bytes(&mut data);

		let mut buf = Vec::new();
		data.serialize(&mut buf, SerializationMode::Native).unwrap();

		let data_deserialized =
			GenericArray::<u8, U32>::deserialize(&mut buf.as_slice(), SerializationMode::Native)
				.unwrap();
		assert_eq!(data_deserialized, data);
	}
}
```
The compilation would fail with a message similar to the following:
```
error[E0275]: overflow evaluating the requirement &mut BytesMut: BufMut
  |
  = help: consider increasing the recursion limit by adding a #![recursion_limit = "256"] attribute to your crate (...)
  = note: required for &mut &mut BytesMut to implement BufMut
  = note: 128 redundant requirements hidden
  = note: required for &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut ... to implement BufMut
```

## Fix
The derive macro and trait impls were updated to avoid moves and use a single borrow.
The corresponding implementations were updated accordingly.
Added a unit test for `ConstraintSystem` serialization/deserialization where the issue originally manifested.