### PR TITLE
[compute] Initial memory interface

### DIFF
--- a/crates/compute/Cargo.toml
+++ b/crates/compute/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "binius_compute"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+thiserror.workspace = true
+
+[dev-dependencies]
+assert_matches.workspace = true

--- a/crates/compute/src/alloc.rs
+++ b/crates/compute/src/alloc.rs
@@ -1,0 +1,82 @@
+// Copyright 2025 Irreducible Inc.
+
+use std::cell::Cell;
+
+use super::memory::{ComputeMemory, DevSlice};
+
+/// Basic bump allocator that allocates slices from an underlying memory buffer provided at
+/// construction.
+pub struct BumpAllocator<'a, F, Mem: ComputeMemory<F>> {
+	buffer: Cell<Option<Mem::FSliceMut<'a>>>,
+}
+
+impl<'a, F, Mem> BumpAllocator<'a, F, Mem>
+where
+	F: 'static,
+	Mem: ComputeMemory<F> + 'a,
+{
+	pub fn new(buffer: Mem::FSliceMut<'a>) -> Self {
+		Self {
+			buffer: Cell::new(Some(buffer)),
+		}
+	}
+
+	/// Allocates a slice of elements.
+	///
+	/// This method operates on an immutable self reference so that multiple allocator references
+	/// can co-exist. This follows how the `bumpalo` crate's `Bump` interface works. It may not be
+	/// necessary actually (since this partitions a borrowed slice, whereas `Bump` owns its memory).
+	///
+	/// ## Pre-conditions
+	///
+	/// - `n` must be a multiple of `Mem::MIN_SLICE_LEN`
+	pub fn alloc(&self, n: usize) -> Result<Mem::FSliceMut<'a>, Error> {
+		let buffer = self
+			.buffer
+			.take()
+			.expect("buffer is always Some by invariant");
+		// buffer temporarily contains None
+		if buffer.len() < n {
+			self.buffer.set(Some(buffer));
+			// buffer contains Some, invariant restored
+			Err(Error::OutOfMemory)
+		} else {
+			let (lhs, rhs) = Mem::split_at_mut(buffer, n.max(Mem::MIN_SLICE_LEN));
+			self.buffer.set(Some(rhs));
+			// buffer contains Some, invariant restored
+			Ok(lhs)
+		}
+	}
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	#[error("allocator is out of memory")]
+	OutOfMemory,
+}
+
+#[cfg(test)]
+mod tests {
+	use assert_matches::assert_matches;
+
+	use super::*;
+	use crate::cpu::memory::CpuMemory;
+
+	#[test]
+	fn test_alloc() {
+		let mut data = (0..256u128).collect::<Vec<_>>();
+
+		{
+			let bump = BumpAllocator::<u128, CpuMemory>::new(&mut data);
+			assert_eq!(bump.alloc(100).unwrap().len(), 100);
+			assert_eq!(bump.alloc(100).unwrap().len(), 100);
+			assert_matches!(bump.alloc(100), Err(Error::OutOfMemory));
+			// Release memory all at once.
+		}
+
+		// Reuse memory
+		let bump = BumpAllocator::<u128, CpuMemory>::new(&mut data);
+		let data = bump.alloc(100).unwrap();
+		assert_eq!(data.len(), 100);
+	}
+}

--- a/crates/compute/src/cpu/memory.rs
+++ b/crates/compute/src/cpu/memory.rs
@@ -1,0 +1,88 @@
+// Copyright 2025 Irreducible Inc.
+
+use std::{collections::Bound, ops::RangeBounds};
+
+use crate::memory::ComputeMemory;
+
+#[derive(Debug)]
+pub struct CpuMemory;
+
+impl<F: 'static> ComputeMemory<F> for CpuMemory {
+	const MIN_SLICE_LEN: usize = 1;
+
+	type FSlice<'a> = &'a [F];
+	type FSliceMut<'a> = &'a mut [F];
+
+	fn as_const<'a>(data: &'a &mut [F]) -> &'a [F] {
+		data
+	}
+
+	fn slice(data: Self::FSlice<'_>, range: impl RangeBounds<usize>) -> Self::FSlice<'_> {
+		let start = match range.start_bound() {
+			Bound::Included(&start) => start,
+			Bound::Excluded(&start) => start + 1,
+			Bound::Unbounded => 0,
+		};
+		let end = match range.end_bound() {
+			Bound::Included(&end) => end + 1,
+			Bound::Excluded(&end) => end,
+			Bound::Unbounded => data.len(),
+		};
+		&data[start..end]
+	}
+
+	fn slice_mut<'a>(data: &'a mut &mut [F], range: impl RangeBounds<usize>) -> &'a mut [F] {
+		let start = match range.start_bound() {
+			Bound::Included(&start) => start,
+			Bound::Excluded(&start) => start + 1,
+			Bound::Unbounded => 0,
+		};
+		let end = match range.end_bound() {
+			Bound::Included(&end) => end + 1,
+			Bound::Excluded(&end) => end,
+			Bound::Unbounded => data.len(),
+		};
+		&mut data[start..end]
+	}
+
+	fn split_at_mut(
+		data: Self::FSliceMut<'_>,
+		mid: usize,
+	) -> (Self::FSliceMut<'_>, Self::FSliceMut<'_>) {
+		data.split_at_mut(mid)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_try_slice_on_mem_slice() {
+		let data = [4, 5, 6];
+		assert_eq!(CpuMemory::slice(&data, 0..2), &data[0..2]);
+		assert_eq!(CpuMemory::slice(&data, ..2), &data[..2]);
+		assert_eq!(CpuMemory::slice(&data, 1..), &data[1..]);
+		assert_eq!(CpuMemory::slice(&data, ..), &data[..]);
+	}
+
+	#[test]
+	fn test_convert_mut_mem_slice_to_const() {
+		let mut data = [4, 5, 6];
+		let data_clone = data;
+		let data = &mut data[..];
+		let data = CpuMemory::as_const(&data);
+		assert_eq!(data, &data_clone);
+	}
+
+	#[test]
+	fn test_try_slice_on_mut_mem_slice() {
+		let mut data = [4, 5, 6];
+		let mut data_clone = data;
+		let mut data = &mut data[..];
+		assert_eq!(CpuMemory::slice_mut(&mut data, 0..2), &mut data_clone[0..2]);
+		assert_eq!(CpuMemory::slice_mut(&mut data, ..2), &mut data_clone[..2]);
+		assert_eq!(CpuMemory::slice_mut(&mut data, 1..), &mut data_clone[1..]);
+		assert_eq!(CpuMemory::slice_mut(&mut data, ..), &mut data_clone[..]);
+	}
+}

--- a/crates/compute/src/cpu/mod.rs
+++ b/crates/compute/src/cpu/mod.rs
@@ -1,0 +1,9 @@
+// Copyright 2025 Irreducible Inc.
+
+//! Reference CPU implementation of a compute layer.
+//!
+//! This implementation is not optimized to use multi-threading or SIMD arithmetic. It is optimized
+//! for readability, used to validate the abstract interfaces and provide algorithmic references
+//! for optimized implementations.
+
+pub mod memory;

--- a/crates/compute/src/lib.rs
+++ b/crates/compute/src/lib.rs
@@ -1,0 +1,11 @@
+// Copyright 2025 Irreducible Inc.
+
+//! Compute layer abstractions for the Binius prover.
+//!
+//! This crate defines a Hardware Abstraction Layer (HAL) for the Binius prover, and a reference
+//! CPU implementation. The goal of this layer is to cleanly separate the compute-intensive
+//! operations from complex cryptographic and control flow logic required in the prover.
+
+pub mod alloc;
+pub mod cpu;
+pub mod memory;

--- a/crates/compute/src/memory.rs
+++ b/crates/compute/src/memory.rs
@@ -1,0 +1,74 @@
+// Copyright 2025 Irreducible Inc.
+
+use std::ops::RangeBounds;
+
+pub trait DevSlice<T> {
+	fn is_empty(&self) -> bool {
+		self.len() == 0
+	}
+
+	fn len(&self) -> usize;
+}
+
+impl<T> DevSlice<T> for &[T] {
+	fn len(&self) -> usize {
+		(**self).len()
+	}
+}
+
+impl<T> DevSlice<T> for &mut [T] {
+	fn len(&self) -> usize {
+		(**self).len()
+	}
+}
+
+/// Interface for manipulating handles to memory in a compute device.
+pub trait ComputeMemory<F> {
+	const MIN_SLICE_LEN: usize;
+
+	/// An opaque handle to an immutable slice of elements stored in a compute memory.
+	type FSlice<'a>: Copy + DevSlice<F>;
+
+	/// An opaque handle to a mutable slice of elements stored in a compute memory.
+	type FSliceMut<'a>: DevSlice<F>;
+
+	/// Borrows a mutable memory slice as immutable.
+	///
+	/// This allows the immutable reference to be copied.
+	fn as_const<'a>(data: &'a Self::FSliceMut<'_>) -> Self::FSlice<'a>;
+
+	/// Borrows a subslice of an immutable memory slice.
+	///
+	/// ## Preconditions
+	///
+	/// - the range bounds must be multiples of [`Self::MIN_SLICE_LEN`]
+	fn slice(data: Self::FSlice<'_>, range: impl RangeBounds<usize>) -> Self::FSlice<'_>;
+
+	/// Borrows a subslice of a mutable memory slice.
+	///
+	/// ## Preconditions
+	///
+	/// - the range bounds must be multiples of [`Self::MIN_SLICE_LEN`]
+	fn slice_mut<'a>(
+		data: &'a mut Self::FSliceMut<'_>,
+		range: impl RangeBounds<usize>,
+	) -> Self::FSliceMut<'a>;
+
+	/// Splits a mutable slice into two disjoint subslices.
+	///
+	/// ## Preconditions
+	///
+	/// - `mid` must be a multiple of [`Self::MIN_SLICE_LEN`]
+	fn split_at_mut(
+		data: Self::FSliceMut<'_>,
+		mid: usize,
+	) -> (Self::FSliceMut<'_>, Self::FSliceMut<'_>);
+
+	fn split_at_mut_borrowed<'a>(
+		data: &'a mut Self::FSliceMut<'_>,
+		mid: usize,
+	) -> (Self::FSliceMut<'a>, Self::FSliceMut<'a>) {
+		let borrowed = Self::slice_mut(data, ..);
+		Self::split_at_mut(borrowed, mid)
+	}
+}


### PR DESCRIPTION
@alsrdn and I learned in the course of pair programming that having `FSlice` traits that can subslice themselves is problematic. (It's complicated to explain: the subslices have a different type than the parent because they are parameterized by another lifetime (a subscope), and they're no way to additionally indicate to the type system the relationship at an abstract level).

Instead I made a `ComputeMemory` trait for manipulating memory references & slices. The eventual `ComputeLayer` trait will either have a `ComputeMemory` as a parent trait or associated type.

This also includes a dead-simple bump allocator implementation that is generic over `ComputeMemory`.