### PR TITLE
Removing PackedFieldIndexable from univariate skip zerocheck.

### DIFF
--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -81,19 +81,14 @@ where
 	Backend: ComputationBackend,
 	// REVIEW: Consider changing TowerFamily and associated traits to shorten/remove these bounds
 	PackedType<U, Tower::B128>: PackedTop<Tower>
-		+ PackedFieldIndexable
+		+ PackedFieldIndexable // REVIEW: remove this bound after piop::commit is adjusted
 		+ RepackedExtension<PackedType<U, Tower::B8>>
 		+ RepackedExtension<PackedType<U, Tower::B16>>
 		+ RepackedExtension<PackedType<U, Tower::B32>>
 		+ RepackedExtension<PackedType<U, Tower::B64>>
 		+ RepackedExtension<PackedType<U, Tower::B128>>
 		+ PackedTransformationFactory<PackedType<U, Tower::FastB128>>,
-	PackedType<U, Tower::FastB128>:
-		PackedFieldIndexable + PackedTransformationFactory<PackedType<U, Tower::B128>>,
-	PackedType<U, Tower::B8>: PackedFieldIndexable,
-	PackedType<U, Tower::B16>: PackedFieldIndexable,
-	PackedType<U, Tower::B32>: PackedFieldIndexable,
-	PackedType<U, Tower::B64>: PackedFieldIndexable,
+	PackedType<U, Tower::FastB128>: PackedTransformationFactory<PackedType<U, Tower::B128>>,
 {
 	tracing::debug!(
 		arch = env::consts::ARCH,
@@ -539,7 +534,7 @@ impl<'a, P, F, FDomain, DomainFactory, SwitchoverFn, Backend>
 	ZerocheckProverConstructor<'a, P, FDomain, DomainFactory, SwitchoverFn, Backend>
 where
 	F: Field,
-	P: PackedFieldIndexable<Scalar = F>,
+	P: PackedField<Scalar = F>,
 	FDomain: TowerField,
 	DomainFactory: EvaluationDomainFactory<FDomain> + 'a,
 	SwitchoverFn: Fn(usize) -> usize + Clone + 'a,
@@ -552,8 +547,8 @@ where
 	where
 		FBase: TowerField + ExtensionField<FDomain> + TryFrom<F>,
 		P: PackedExtension<F, PackedSubfield = P>
-			+ PackedExtension<FDomain, PackedSubfield: PackedFieldIndexable>
-			+ PackedExtension<FBase, PackedSubfield: PackedFieldIndexable>,
+			+ PackedExtension<FDomain>
+			+ PackedExtension<FBase>,
 		F: TowerField,
 	{
 		let univariate_prover =
@@ -756,7 +751,6 @@ where
 	FDomain: Field,
 	DomainFactory: EvaluationDomainFactory<FDomain>,
 	Backend: ComputationBackend,
-	PackedType<U, Tower::B128>: PackedFieldIndexable,
 	'a: 'b,
 {
 	let flush_sumcheck_metas =

--- a/crates/core/src/protocols/sumcheck/prove/oracles.rs
+++ b/crates/core/src/protocols/sumcheck/prove/oracles.rs
@@ -1,8 +1,6 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use binius_field::{
-	ExtensionField, Field, PackedExtension, PackedField, PackedFieldIndexable, TowerField,
-};
+use binius_field::{ExtensionField, Field, PackedExtension, PackedField, TowerField};
 use binius_hal::ComputationBackend;
 use binius_math::{EvaluationDomainFactory, EvaluationOrder};
 use binius_utils::bail;
@@ -69,10 +67,10 @@ pub fn constraint_set_zerocheck_prover<
 	Error,
 >
 where
-	P: PackedFieldIndexable<Scalar = F>
+	P: PackedField<Scalar = F>
 		+ PackedExtension<F, PackedSubfield = P>
-		+ PackedExtension<FDomain, PackedSubfield: PackedFieldIndexable>
-		+ PackedExtension<FBase, PackedSubfield: PackedFieldIndexable>,
+		+ PackedExtension<FDomain>
+		+ PackedExtension<FBase>,
 	F: TowerField,
 	FBase: TowerField + ExtensionField<FDomain> + TryFrom<P::Scalar>,
 	FDomain: Field,

--- a/crates/core/src/protocols/sumcheck/prove/univariate.rs
+++ b/crates/core/src/protocols/sumcheck/prove/univariate.rs
@@ -3,8 +3,10 @@
 use std::{collections::HashMap, iter::repeat_n};
 
 use binius_field::{
-	recast_packed_mut, util::inner_product_unchecked, BinaryField, ExtensionField, Field,
-	PackedExtension, PackedField, PackedFieldIndexable, PackedSubfield, TowerField,
+	packed::{get_packed_slice, get_packed_slice_checked},
+	recast_packed_mut,
+	util::inner_product_unchecked,
+	BinaryField, ExtensionField, Field, PackedExtension, PackedField, PackedSubfield, TowerField,
 };
 use binius_hal::{ComputationBackend, ComputationBackendExt};
 use binius_math::{
@@ -18,7 +20,6 @@ use bytemuck::zeroed_vec;
 use itertools::izip;
 use stackalloc::stackalloc_with_iter;
 use tracing::instrument;
-use transpose::transpose;
 
 use crate::{
 	composition::{BivariateProduct, IndexComposition},
@@ -44,7 +45,7 @@ pub fn reduce_to_skipped_projection<F, P, M, Backend>(
 ) -> Result<Vec<MLEDirectAdapter<P>>, Error>
 where
 	F: Field,
-	P: PackedFieldIndexable<Scalar = F>,
+	P: PackedField<Scalar = F>,
 	M: MultilinearPoly<P> + Send + Sync,
 	Backend: ComputationBackend,
 {
@@ -95,9 +96,7 @@ pub fn univariatizing_reduction_prover<'a, F, FDomain, P, Backend>(
 where
 	F: TowerField,
 	FDomain: TowerField,
-	P: PackedFieldIndexable<Scalar = F>
-		+ PackedExtension<F, PackedSubfield = P>
-		+ PackedExtension<FDomain>,
+	P: PackedField<Scalar = F> + PackedExtension<F, PackedSubfield = P> + PackedExtension<FDomain>,
 	Backend: ComputationBackend,
 {
 	let skip_rounds = equal_n_vars_check(&reduced_multilinears)?;
@@ -132,14 +131,12 @@ where
 struct ParFoldStates<FBase: Field, P: PackedExtension<FBase>> {
 	/// Evaluations of a multilinear subcube, embedded into P (see MultilinearPoly::subcube_evals). Scratch space.
 	evals: Vec<P>,
-	/// `evals` cast to base field and transposed to 2^skip_rounds * 2^log_batch row-major form. Scratch space.
-	interleaved_evals: Vec<PackedSubfield<P, FBase>>,
-	/// `interleaved_evals` extrapolated beyond first 2^skip_rounds domain points, per multilinear.
+	/// `evals` extrapolated beyond first 2^skip_rounds domain points, per multilinear.
 	extrapolated_evals: Vec<Vec<PackedSubfield<P, FBase>>>,
 	/// Evals of a single composition over extrapolated multilinears. Scratch space.
 	composition_evals: Vec<PackedSubfield<P, FBase>>,
-	/// Round evals accumulators, per multilinear.
-	round_evals: Vec<Vec<P::Scalar>>,
+	/// Packed round evals accumulators, per multilinear.
+	packed_round_evals: Vec<Vec<P>>,
 }
 
 impl<FBase: Field, P: PackedExtension<FBase>> ParFoldStates<FBase, P> {
@@ -160,8 +157,6 @@ impl<FBase: Field, P: PackedExtension<FBase>> ParFoldStates<FBase, P> {
 
 		let evals =
 			zeroed_vec(1 << subcube_vars.saturating_sub(P::LOG_WIDTH + log_embedding_degree));
-		let interleaved_evals =
-			zeroed_vec(1 << subcube_vars.saturating_sub(<PackedSubfield<P, FBase>>::LOG_WIDTH));
 
 		let extrapolated_evals = (0..n_multilinears)
 			.map(|_| zeroed_vec(extrapolated_packed_pbase_len))
@@ -169,18 +164,17 @@ impl<FBase: Field, P: PackedExtension<FBase>> ParFoldStates<FBase, P> {
 
 		let composition_evals = zeroed_vec(extrapolated_packed_pbase_len);
 
-		let round_evals = composition_degrees
+		let packed_round_evals = composition_degrees
 			.map(|composition_degree| {
-				zeroed_vec(extrapolated_scalars_count(composition_degree, skip_rounds))
+				zeroed_vec(extrapolated_evals_packed_len::<P>(composition_degree, skip_rounds, 0))
 			})
 			.collect();
 
 		Self {
 			evals,
-			interleaved_evals,
 			extrapolated_evals,
 			composition_evals,
-			round_evals,
+			packed_round_evals,
 		}
 	}
 }
@@ -214,7 +208,7 @@ where
 impl<F, P, Backend> ZerocheckUnivariateEvalsOutput<F, P, Backend>
 where
 	F: Field,
-	P: PackedFieldIndexable<Scalar = F>,
+	P: PackedField<Scalar = F>,
 	Backend: ComputationBackend,
 {
 	// Univariate round can be folded once the challenge has been sampled.
@@ -334,9 +328,7 @@ where
 	FDomain: TowerField,
 	FBase: ExtensionField<FDomain>,
 	F: TowerField,
-	P: PackedFieldIndexable<Scalar = F>
-		+ PackedExtension<FBase, PackedSubfield: PackedFieldIndexable>
-		+ PackedExtension<FDomain, PackedSubfield: PackedFieldIndexable>,
+	P: PackedField<Scalar = F> + PackedExtension<FBase> + PackedExtension<FDomain>,
 	Composition: CompositionPoly<PackedSubfield<P, FBase>>,
 	M: MultilinearPoly<P> + Send + Sync,
 	Backend: ComputationBackend,
@@ -388,7 +380,6 @@ where
 	// univariatized subcube.
 	// NB: expansion of the first `skip_rounds` variables is applied to the round evals sum
 	let partial_eq_ind_evals = backend.tensor_product_full_query(zerocheck_challenges)?;
-	let partial_eq_ind_evals_scalars = P::unpack_scalars(&partial_eq_ind_evals);
 
 	// Evaluate each composition on a minimal packed prefix corresponding to the degree
 	let pbase_prefix_lens = composition_degrees
@@ -404,6 +395,10 @@ where
 
 	let subcube_vars = log_batch + skip_rounds;
 	let log_subcube_count = n_vars - subcube_vars;
+
+	let p_coset_round_evals_len = 1 << skip_rounds.saturating_sub(P::LOG_WIDTH);
+	let pbase_coset_composition_evals_len =
+		1 << subcube_vars.saturating_sub(P::LOG_WIDTH + log_embedding_degree);
 
 	// NB: we avoid evaluation on the first 2^skip_rounds points because honest
 	// prover would always evaluate to zero there; we also factor out first
@@ -425,10 +420,9 @@ where
 			|mut par_fold_states, subcube_index| -> Result<_, Error> {
 				let ParFoldStates {
 					evals,
-					interleaved_evals,
 					extrapolated_evals,
 					composition_evals,
-					round_evals,
+					packed_round_evals,
 					..
 				} = &mut par_fold_states;
 
@@ -441,66 +435,30 @@ where
 						subcube_vars,
 						subcube_index,
 						log_embedding_degree,
-						evals.as_mut_slice(),
+						evals,
 					)?;
 
-					// Use the PackedExtension bound to cast evals to base field.
-					let evals_base =
-						<P as PackedExtension<FBase>>::cast_bases_mut(evals.as_mut_slice());
-
-					// The evals subcube can be seen as 2^log_batch subcubes of skip_rounds
-					// variables, laid out sequentially in memory; this can be seen as
-					// row major 2^log_batch * 2^skip_rounds scalar matrix. We need to transpose
-					// it to 2^skip_rounds * 2_log_batch shape in order for the strided NTT to work.
-					let interleaved_evals_ref = if log_batch == 0 {
-						// In case of no batching, pass the slice as is.
-						evals_base
-					} else {
-						let evals_base_scalars =
-							&<PackedSubfield<P, FBase>>::unpack_scalars(evals_base)
-								[..1 << subcube_vars];
-						let interleaved_evals_scalars =
-							&mut <PackedSubfield<P, FBase>>::unpack_scalars_mut(
-								interleaved_evals.as_mut_slice(),
-							)[..1 << subcube_vars];
-
-						transpose(
-							evals_base_scalars,
-							interleaved_evals_scalars,
-							1 << skip_rounds,
-							1 << log_batch,
-						);
-
-						interleaved_evals.as_mut_slice()
-					};
-
 					// Extrapolate evals using a conservative upper bound of the composition
-					// degree. When evals are correctly strided, we can use additive NTT to
-					// extrapolate them beyond the first 2^skip_rounds. We use the fact that an NTT
-					// over the extension is just a strided NTT over the base field.
-					let interleaved_evals_bases =
-						recast_packed_mut::<P, FBase, FDomain>(interleaved_evals_ref);
-					let extrapolated_evals_bases =
+					// degree. We use Additive NTT to extrapolate evals beyond the first 2^skip_rounds,
+					// exploiting the fact that extension field NTT is a strided base field NTT.
+					let evals_base = <P as PackedExtension<FBase>>::cast_bases_mut(evals);
+					let evals_domain = recast_packed_mut::<P, FBase, FDomain>(evals_base);
+					let extrapolated_evals_domain =
 						recast_packed_mut::<P, FBase, FDomain>(extrapolated_evals);
 
 					ntt_extrapolate(
 						&fdomain_ntt,
 						skip_rounds,
-						log_batch + log_extension_degree_base_domain,
-						composition_max_degree,
-						interleaved_evals_bases,
-						extrapolated_evals_bases,
+						log_extension_degree_base_domain,
+						log_batch,
+						evals_domain,
+						extrapolated_evals_domain,
 					)?
 				}
 
-				// Obtain 1 << log_batch partial equality indicator constant factors for each
-				// of the subcubes of size 1 << skip_rounds.
-				let partial_eq_ind_evals_scalars_subslice =
-					&partial_eq_ind_evals_scalars[subcube_index << log_batch..][..1 << log_batch];
-
 				// Evaluate the compositions and accumulate round results
-				for (composition, round_evals, &pbase_prefix_len) in
-					izip!(compositions, round_evals, &pbase_prefix_lens)
+				for (composition, packed_round_evals, &pbase_prefix_len) in
+					izip!(compositions, packed_round_evals, &pbase_prefix_lens)
 				{
 					let extrapolated_evals_iter = extrapolated_evals
 						.iter()
@@ -518,37 +476,50 @@ where
 
 					// Accumulate round evals and multiply by the constant part of the
 					// zerocheck equality indicator
-					let composition_evals_scalars = <PackedSubfield<P, FBase>>::unpack_scalars_mut(
-						composition_evals.as_mut_slice(),
-					);
-
-					for (round_evals_coset, composition_evals_scalars_coset) in izip!(
-						round_evals.chunks_exact_mut(1 << skip_rounds),
-						composition_evals_scalars.chunks_exact(
-							1 << subcube_vars.max(log_embedding_degree + P::LOG_WIDTH)
-						)
+					for (packed_round_evals_coset, composition_evals_coset) in izip!(
+						packed_round_evals.chunks_exact_mut(p_coset_round_evals_len,),
+						composition_evals.chunks_exact(pbase_coset_composition_evals_len)
 					) {
-						for (round_eval, composition_evals) in izip!(
-							round_evals_coset,
-							composition_evals_scalars_coset.chunks_exact(1 << log_batch),
-						) {
-							// Inner product is with the high n_vars - skip_rounds projection
-							// of the zerocheck equality indicator (one factor per subcube).
-							*round_eval += inner_product_unchecked(
-								partial_eq_ind_evals_scalars_subslice.iter().copied(),
-								composition_evals.iter().copied(),
-							);
-						}
+						// Inner product is with the high `n_vars - skip_rounds`` projection
+						// of the zerocheck equality indicator (one factor per skipped subcube).
+						spread_product::<_, FBase>(
+							packed_round_evals_coset,
+							composition_evals_coset,
+							&partial_eq_ind_evals,
+							subcube_index,
+							skip_rounds,
+							log_batch,
+						);
 					}
-
-					// REVIEW: only slow path is left, fast path is to be reintroduced in the followup PRs
-					//         targeted on dropping PackedFieldIndexable
 				}
 
 				Ok(par_fold_states)
 			},
 		)
-		.map(|states| -> Result<_, Error> { Ok(states?.round_evals) })
+		.map(|states| -> Result<_, Error> {
+			let scalar_round_evals = izip!(composition_degrees.clone(), states?.packed_round_evals)
+				.map(|(composition_degree, packed_round_evals)| {
+					let mut composition_round_evals = Vec::with_capacity(
+						extrapolated_scalars_count(composition_degree, skip_rounds),
+					);
+
+					for packed_round_evals_coset in
+						packed_round_evals.chunks_exact(p_coset_round_evals_len)
+					{
+						let coset_scalars = packed_round_evals_coset
+							.iter()
+							.flat_map(|packed| packed.iter())
+							.take(1 << skip_rounds);
+
+						composition_round_evals.extend(coset_scalars);
+					}
+
+					composition_round_evals
+				})
+				.collect::<Vec<_>>();
+
+			Ok(scalar_round_evals)
+		})
 		.try_reduce(
 			|| {
 				composition_degrees
@@ -561,6 +532,7 @@ where
 			|lhs, rhs| -> Result<_, Error> {
 				let round_evals_sum = izip!(lhs, rhs)
 					.map(|(mut lhs_vals, rhs_vals)| {
+						debug_assert_eq!(lhs_vals.len(), rhs_vals.len());
 						for (lhs_val, rhs_val) in izip!(&mut lhs_vals, rhs_vals) {
 							*lhs_val += rhs_val;
 						}
@@ -586,6 +558,66 @@ where
 	})
 }
 
+// A helper to perform spread multiplication of small field composition evals by appropriate
+// equality indicator scalars. See `zerocheck_univariate_evals` impl for intuition.
+fn spread_product<P, FBase>(
+	accum: &mut [P],
+	small: &[PackedSubfield<P, FBase>],
+	large: &[P],
+	subcube_index: usize,
+	log_n: usize,
+	log_batch: usize,
+) where
+	P: PackedExtension<FBase>,
+	FBase: Field,
+{
+	let log_embedding_degree = <P::Scalar as ExtensionField<FBase>>::LOG_DEGREE;
+	let pbase_log_width = P::LOG_WIDTH + log_embedding_degree;
+
+	debug_assert_eq!(accum.len(), 1 << log_n.saturating_sub(P::LOG_WIDTH));
+	debug_assert_eq!(small.len(), 1 << (log_n + log_batch).saturating_sub(pbase_log_width));
+
+	if log_n >= P::LOG_WIDTH {
+		// Use spread multiplication on fast path.
+		accum.fill(P::zero());
+
+		let mask = (1 << log_embedding_degree) - 1;
+		for batch_idx in 0..1 << log_batch {
+			let mult = get_packed_slice(large, subcube_index << log_batch | batch_idx);
+			let spread_large = P::cast_base(P::broadcast(mult));
+
+			for (block_idx, dest) in accum.iter_mut().enumerate() {
+				let block_offset = block_idx | batch_idx << (log_n - P::LOG_WIDTH);
+				let spread_small = small[block_offset >> log_embedding_degree]
+					.spread(P::LOG_WIDTH, block_offset & mask);
+				*dest += P::cast_ext(spread_large * spread_small);
+			}
+		}
+	} else {
+		// Multiple skipped subcube evaluations do fit into a single packed field
+		// This never occurs with large traces under frontloaded univariate skip batching,
+		// making this a non-critical slow path.
+		for (outer_idx, dest) in accum.iter_mut().enumerate() {
+			*dest = P::from_fn(|inner_idx| {
+				if inner_idx >= 1 << log_n {
+					return P::Scalar::ZERO;
+				}
+				(0..1 << log_batch)
+					.map(|batch_idx| {
+						let large = get_packed_slice(large, subcube_index << log_batch | batch_idx);
+						let small = get_packed_slice_checked(
+							small,
+							batch_idx << log_n | outer_idx << P::LOG_WIDTH | inner_idx,
+						)
+						.unwrap_or_default();
+						large * small
+					})
+					.sum()
+			})
+		}
+	}
+}
+
 // Extrapolate round evaluations to the full domain.
 // NB: this method relies on the fact that `round_evals` have specific lengths
 // (namely `d * 2^n`, where `n` is not less than the number of skipped rounds and thus d
@@ -598,7 +630,7 @@ fn extrapolate_round_evals<F: TowerField>(
 	max_domain_size: usize,
 ) -> Result<Vec<Vec<F>>, Error> {
 	// Instantiate a large enough NTT over F to be able to forward transform to full domain size.
-	// REVIEW: should be possible to use an existing FDomain NTT with striding.
+	// REVIEW: should be possible to use an existing FDomain NTT with striding, possibly with larger domain.
 	let ntt = SingleThreadedNTT::with_canonical_field(log2_ceil_usize(max_domain_size))?;
 
 	// Cache OddInterpolate instances, which, albeit small in practice, take cubic time to create.
@@ -649,41 +681,30 @@ fn ntt_extrapolate<NTT, P>(
 	ntt: &NTT,
 	skip_rounds: usize,
 	log_stride_batch: usize,
-	composition_max_degree: usize,
-	interleaved_evals: &mut [P],
+	log_batch: usize,
+	evals: &mut [P],
 	extrapolated_evals: &mut [P],
 ) -> Result<(), Error>
 where
-	P: PackedFieldIndexable<Scalar: BinaryField>,
+	P: PackedField<Scalar: BinaryField>,
 	NTT: AdditiveNTT<P::Scalar>,
 {
-	let subcube_vars = skip_rounds + log_stride_batch;
-	debug_assert_eq!(1 << subcube_vars.saturating_sub(P::LOG_WIDTH), interleaved_evals.len());
-	debug_assert_eq!(
-		extrapolated_evals_packed_len::<P>(composition_max_degree, skip_rounds, log_stride_batch),
-		extrapolated_evals.len()
-	);
-	debug_assert!(
-		NTT::log_domain_size(ntt)
-			>= log2_ceil_usize(domain_size(composition_max_degree, skip_rounds))
-	);
-
 	let shape = NTTShape {
 		log_x: log_stride_batch,
 		log_y: skip_rounds,
-		..Default::default()
+		log_z: log_batch,
 	};
 
 	// Inverse NTT: convert evals to novel basis representation
-	ntt.inverse_transform(interleaved_evals, shape, 0)?;
+	ntt.inverse_transform(evals, shape, 0)?;
 
 	// Forward NTT: evaluate novel basis representation at consecutive cosets
-	for (i, extrapolated_chunk) in extrapolated_evals
-		.chunks_exact_mut(interleaved_evals.len())
-		.enumerate()
+	for (coset, extrapolated_chunk) in
+		izip!(1u32.., extrapolated_evals.chunks_exact_mut(evals.len()))
 	{
-		extrapolated_chunk.copy_from_slice(interleaved_evals);
-		ntt.forward_transform(extrapolated_chunk, shape, (i + 1) as u32)?;
+		// REVIEW: can avoid that copy (and extrapolated_evals scratchpad) when composition_max_degree == 2
+		extrapolated_chunk.copy_from_slice(evals);
+		ntt.forward_transform(extrapolated_chunk, shape, coset)?;
 	}
 
 	Ok(())
@@ -763,8 +784,8 @@ mod tests {
 					super::ntt_extrapolate(
 						&ntt,
 						skip_rounds,
-						log_batch + log_extension_degree_p_domain,
-						composition_degree,
+						log_extension_degree_p_domain,
+						log_batch,
 						interleaved_evals_domain,
 						extrapolated_evals_domain,
 					)
@@ -776,9 +797,8 @@ mod tests {
 						[..extrapolated_scalars_cnt << log_batch];
 
 					for batch_idx in 0..1 << log_batch {
-						let values = (0..1 << skip_rounds)
-							.map(|i| interleaved_scalars[(i << log_batch) + batch_idx])
-							.collect::<Vec<_>>();
+						let values =
+							&interleaved_scalars[batch_idx << skip_rounds..][..1 << skip_rounds];
 
 						for (i, &point) in max_domain.finite_points()[1 << skip_rounds..]
 							[..extrapolated_scalars_cnt]
@@ -786,8 +806,8 @@ mod tests {
 							.take(1 << skip_rounds)
 							.enumerate()
 						{
-							let extrapolated = domain.extrapolate(&values, point.into()).unwrap();
-							let expected = extrapolated_scalars[(i << log_batch) + batch_idx];
+							let extrapolated = domain.extrapolate(values, point.into()).unwrap();
+							let expected = extrapolated_scalars[batch_idx << skip_rounds | i];
 							assert_eq!(extrapolated, expected);
 						}
 					}

--- a/crates/core/src/protocols/sumcheck/prove/zerocheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/zerocheck.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use binius_field::{
 	packed::copy_packed_from_scalars_slice, util::powers, ExtensionField, Field, PackedExtension,
-	PackedField, PackedFieldIndexable, PackedSubfield, TowerField,
+	PackedField, PackedSubfield, TowerField,
 };
 use binius_hal::ComputationBackend;
 use binius_math::{
@@ -143,7 +143,7 @@ where
 	F: TowerField,
 	FDomain: Field,
 	FBase: ExtensionField<FDomain>,
-	P: PackedFieldIndexable<Scalar = F>
+	P: PackedField<Scalar = F>
 		+ PackedExtension<F, PackedSubfield = P>
 		+ PackedExtension<FBase>
 		+ PackedExtension<FDomain>,
@@ -275,10 +275,10 @@ where
 	F: TowerField,
 	FDomain: TowerField,
 	FBase: ExtensionField<FDomain>,
-	P: PackedFieldIndexable<Scalar = F>
+	P: PackedField<Scalar = F>
 		+ PackedExtension<F, PackedSubfield = P>
-		+ PackedExtension<FBase, PackedSubfield: PackedFieldIndexable>
-		+ PackedExtension<FDomain, PackedSubfield: PackedFieldIndexable>,
+		+ PackedExtension<FBase>
+		+ PackedExtension<FDomain>,
 	CompositionBase: CompositionPoly<PackedSubfield<P, FBase>> + 'static,
 	Composition: CompositionPoly<P> + 'static,
 	M: MultilinearPoly<P> + Send + Sync + 'a,

--- a/crates/core/src/protocols/sumcheck/univariate.rs
+++ b/crates/core/src/protocols/sumcheck/univariate.rs
@@ -5,7 +5,7 @@ use std::{
 	ops::{Mul, MulAssign},
 };
 
-use binius_field::{ExtensionField, Field, PackedFieldIndexable, TowerField};
+use binius_field::{packed::set_packed_slice, ExtensionField, Field, PackedField, TowerField};
 use binius_hal::{make_portable_backend, ComputationBackendExt};
 use binius_math::{BinarySubspace, EvaluationDomain, MultilinearExtension};
 use binius_utils::{bail, checked_arithmetics::log2_strict_usize, sorting::is_sorted_ascending};
@@ -203,14 +203,16 @@ pub(super) fn lagrange_evals_multilinear_extension<FDomain, F, P>(
 where
 	FDomain: Field,
 	F: Field + ExtensionField<FDomain>,
-	P: PackedFieldIndexable<Scalar = F>,
+	P: PackedField<Scalar = F>,
 {
 	let lagrange_evals = evaluation_domain.lagrange_evals(univariate_challenge);
 
 	let n_vars = log2_strict_usize(lagrange_evals.len());
 	let mut packed = zeroed_vec(lagrange_evals.len().div_ceil(P::WIDTH));
-	let scalars = P::unpack_scalars_mut(packed.as_mut_slice());
-	scalars[..lagrange_evals.len()].copy_from_slice(lagrange_evals.as_slice());
+
+	for (i, &lagrange_eval) in lagrange_evals.iter().enumerate() {
+		set_packed_slice(&mut packed, i, lagrange_eval);
+	}
 
 	Ok(MultilinearExtension::new(n_vars, packed)?)
 }

--- a/crates/core/src/protocols/sumcheck/zerocheck.rs
+++ b/crates/core/src/protocols/sumcheck/zerocheck.rs
@@ -97,7 +97,7 @@ mod tests {
 
 	use binius_field::{
 		BinaryField128b, BinaryField32b, BinaryField8b, PackedBinaryField1x128b, PackedExtension,
-		PackedFieldIndexable, PackedSubfield, RepackedExtension,
+		PackedField, PackedSubfield, RepackedExtension,
 	};
 	use binius_hal::{make_portable_backend, ComputationBackend, ComputationBackendExt};
 	use binius_hash::groestl::Groestl256;
@@ -143,7 +143,7 @@ mod tests {
 	where
 		F: Field,
 		FDomain: Field,
-		P: PackedFieldIndexable<Scalar = F> + PackedExtension<FDomain> + RepackedExtension<P>,
+		P: PackedField<Scalar = F> + PackedExtension<FDomain> + RepackedExtension<P>,
 		Composition: CompositionPoly<P>,
 		M: MultilinearPoly<P> + Send + Sync + 'static,
 		Backend: ComputationBackend,


### PR DESCRIPTION
> Depends on #200 

Leverages newly introduced NTT non-strided batching and a packed spread multiplication by equality indicator to remove `PackedFieldIndexable` bound from all zerocheck routines, making byte sliced usage feasible.
