### PR TITLE
[Evalcheck] Deduplication using advices

### DIFF
--- a/crates/core/src/protocols/evalcheck/error.rs
+++ b/crates/core/src/protocols/evalcheck/error.rs
@@ -41,6 +41,10 @@ pub enum VerificationError {
 	IncorrectCompositePolyEvaluation(String),
 	#[error("subproof type or shape does not match the claim")]
 	SubproofMismatch,
+	#[error("The referenced duplicate claim is different from expected")]
+	DuplicateClaimMismatch,
+	#[error("Out of advices")]
+	OutOfAdvices,
 }
 
 impl VerificationError {

--- a/crates/core/src/protocols/evalcheck/error.rs
+++ b/crates/core/src/protocols/evalcheck/error.rs
@@ -41,10 +41,10 @@ pub enum VerificationError {
 	IncorrectCompositePolyEvaluation(String),
 	#[error("subproof type or shape does not match the claim")]
 	SubproofMismatch,
+	#[error("LinearCombination must contain an eval")]
+	MissingLinearCombinationEval,
 	#[error("The referenced duplicate claim is different from expected")]
 	DuplicateClaimMismatch,
-	#[error("Out of advices")]
-	OutOfAdvices,
 }
 
 impl VerificationError {

--- a/crates/core/src/protocols/evalcheck/evalcheck.rs
+++ b/crates/core/src/protocols/evalcheck/evalcheck.rs
@@ -149,6 +149,10 @@ impl EvalcheckProofAdviceNumerics {
 	}
 }
 
+/// Additional information provided by the prover to the verifier.
+/// If the claim has already been proven/verified, the prover provides the position in the
+/// `round_claims` list. This allows the verifier to confirm the validity of a duplicate claim
+/// without performing an additional search through the list.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EvalcheckProofAdvice {
 	HandleClaim,

--- a/crates/core/src/protocols/evalcheck/evalcheck.rs
+++ b/crates/core/src/protocols/evalcheck/evalcheck.rs
@@ -1,6 +1,7 @@
 // Copyright 2023-2025 Irreducible Inc.
 
 use std::{
+	hash::Hash,
 	ops::{Deref, Range},
 	slice,
 	sync::Arc,
@@ -15,7 +16,7 @@ use crate::{
 	transcript::{TranscriptReader, TranscriptWriter},
 };
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EvalcheckMultilinearClaim<F: Field> {
 	/// Virtual Polynomial Oracle for which the evaluation is claimed
 	pub id: OracleId,
@@ -308,7 +309,7 @@ impl<T: Clone, F: Field> Default for EvalPointOracleIdMap<T, F> {
 	}
 }
 
-#[derive(Debug, Clone, Hash, Eq)]
+#[derive(Debug, Clone, Eq)]
 pub struct EvalPoint<F: Field> {
 	data: Arc<[F]>,
 	range: Range<usize>,
@@ -317,6 +318,12 @@ pub struct EvalPoint<F: Field> {
 impl<F: Field> PartialEq for EvalPoint<F> {
 	fn eq(&self, other: &Self) -> bool {
 		self.data[self.range.clone()] == other.data[other.range.clone()]
+	}
+}
+
+impl<F: Field> Hash for EvalPoint<F> {
+	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+		self.data[self.range.clone()].hash(state)
 	}
 }
 

--- a/crates/core/src/protocols/evalcheck/evalcheck.rs
+++ b/crates/core/src/protocols/evalcheck/evalcheck.rs
@@ -308,8 +308,8 @@ impl<T: Clone, F: Field> Default for EvalPointOracleIdMap<T, F> {
 	}
 }
 
-#[derive(Debug, Clone)]
-pub struct EvalPoint<F> {
+#[derive(Debug, Clone, Hash, Eq)]
+pub struct EvalPoint<F: Field> {
 	data: Arc<[F]>,
 	range: Range<usize>,
 }
@@ -320,7 +320,7 @@ impl<F: Field> PartialEq for EvalPoint<F> {
 	}
 }
 
-impl<F: Clone> EvalPoint<F> {
+impl<F: Field> EvalPoint<F> {
 	pub fn slice(&self, range: Range<usize>) -> Self {
 		assert!(self.range.len() >= range.len());
 
@@ -337,7 +337,7 @@ impl<F: Clone> EvalPoint<F> {
 	}
 }
 
-impl<F> From<Vec<F>> for EvalPoint<F> {
+impl<F: Field> From<Vec<F>> for EvalPoint<F> {
 	fn from(data: Vec<F>) -> Self {
 		let range = 0..data.len();
 		Self {
@@ -347,7 +347,7 @@ impl<F> From<Vec<F>> for EvalPoint<F> {
 	}
 }
 
-impl<F: Clone> From<&[F]> for EvalPoint<F> {
+impl<F: Field> From<&[F]> for EvalPoint<F> {
 	fn from(data: &[F]) -> Self {
 		let range = 0..data.len();
 		Self {
@@ -357,7 +357,7 @@ impl<F: Clone> From<&[F]> for EvalPoint<F> {
 	}
 }
 
-impl<F> Deref for EvalPoint<F> {
+impl<F: Field> Deref for EvalPoint<F> {
 	type Target = [F];
 
 	fn deref(&self) -> &Self::Target {

--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -129,6 +129,7 @@ where
 		self.round_claim_index = 0;
 		self.visited_claims.clear();
 		self.claim_to_index.clear();
+		self.new_evals_memoization.clear();
 
 		for claim in &evalcheck_claims {
 			if self

--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -4,6 +4,7 @@ use binius_field::{PackedField, TowerField};
 use binius_hal::ComputationBackend;
 use binius_math::MultilinearExtension;
 use binius_maybe_rayon::prelude::*;
+use bytes::BufMut;
 use getset::{Getters, MutGetters};
 use itertools::izip;
 use tracing::instrument;
@@ -11,13 +12,15 @@ use tracing::instrument;
 use super::{
 	error::Error,
 	evalcheck::{EvalcheckMultilinearClaim, EvalcheckProof},
+	serialize_advice,
 	subclaims::{
 		add_composite_sumcheck_to_constraints, calculate_projected_mles, composite_sumcheck_meta,
 		fill_eq_witness_for_composites, MemoizedData, ProjectedBivariateMeta,
 	},
-	EvalPoint, EvalPointOracleIdMap,
+	EvalPoint, EvalPointOracleIdMap, EvalcheckProofAdvice,
 };
 use crate::{
+	fiat_shamir::Challenger,
 	oracle::{
 		ConstraintSet, ConstraintSetBuilder, Error as OracleError, MultilinearOracleSet,
 		MultilinearPolyOracle, MultilinearPolyVariant, OracleId,
@@ -26,6 +29,7 @@ use crate::{
 		packed_sumcheck_meta, process_packed_sumcheck, process_shifted_sumcheck,
 		shifted_sumcheck_meta,
 	},
+	transcript::{ProverTranscript, TranscriptWriter},
 	witness::MultilinearExtensionIndex,
 };
 
@@ -47,10 +51,7 @@ where
 	#[getset(get = "pub", get_mut = "pub")]
 	committed_eval_claims: Vec<EvalcheckMultilinearClaim<F>>,
 
-	finalized_proofs: EvalPointOracleIdMap<(F, EvalcheckProof<F>), F>,
-
 	claims_queue: Vec<EvalcheckMultilinearClaim<F>>,
-	incomplete_proof_claims: EvalPointOracleIdMap<EvalcheckMultilinearClaim<F>, F>,
 	claims_without_evals: Vec<(MultilinearPolyOracle<F>, EvalPoint<F>)>,
 	claims_without_evals_dedup: EvalPointOracleIdMap<(), F>,
 	projected_bivariate_claims: Vec<EvalcheckMultilinearClaim<F>>,
@@ -58,6 +59,11 @@ where
 	new_sumchecks_constraints: Vec<ConstraintSetBuilder<F>>,
 	pub memoized_data: MemoizedData<'b, P, Backend>,
 	backend: &'a Backend,
+
+	visited_claims: EvalPointOracleIdMap<(), F>,
+	new_evals_memoization: EvalPointOracleIdMap<F, F>,
+	round_claims: Vec<EvalcheckMultilinearClaim<F>>,
+	advices: Vec<EvalcheckProofAdvice>,
 }
 
 impl<'a, 'b, F, P, Backend> EvalcheckProver<'a, 'b, F, P, Backend>
@@ -79,14 +85,17 @@ where
 			witness_index,
 			committed_eval_claims: Vec::new(),
 			new_sumchecks_constraints: Vec::new(),
-			finalized_proofs: EvalPointOracleIdMap::new(),
 			claims_queue: Vec::new(),
 			claims_without_evals: Vec::new(),
 			claims_without_evals_dedup: EvalPointOracleIdMap::new(),
 			projected_bivariate_claims: Vec::new(),
 			memoized_data: MemoizedData::new(),
 			backend,
-			incomplete_proof_claims: EvalPointOracleIdMap::new(),
+
+			visited_claims: EvalPointOracleIdMap::new(),
+			new_evals_memoization: EvalPointOracleIdMap::new(),
+			round_claims: Vec::new(),
+			advices: Vec::new(),
 		}
 	}
 
@@ -118,7 +127,10 @@ where
 	pub fn prove(
 		&mut self,
 		evalcheck_claims: Vec<EvalcheckMultilinearClaim<F>>,
-	) -> Result<Vec<EvalcheckProof<F>>, Error> {
+	) -> Result<(Vec<Option<EvalcheckProof<F>>>, Vec<EvalcheckProofAdvice>), Error> {
+		self.round_claims.clear();
+		self.visited_claims.clear();
+
 		for claim in &evalcheck_claims {
 			self.claims_without_evals_dedup
 				.insert(claim.id, claim.eval_point.clone(), ());
@@ -127,31 +139,18 @@ where
 		// Step 1: Collect proofs
 		self.claims_queue.extend(evalcheck_claims.clone());
 
-		// Use modified BFS approach with memoization to collect proofs.
-		// The `prove_multilinear` function saves a proof if it can be generated immediately; otherwise, the claim is added to `incomplete_proof_claims` and resolved after BFS.
-		// Claims requiring additional evaluation are stored in `claims_without_evals` and processed in parallel.
+		// pre-calculation of subclaims
 		while !self.claims_without_evals.is_empty() || !self.claims_queue.is_empty() {
 			// Prove all available claims
 			while !self.claims_queue.is_empty() {
 				std::mem::take(&mut self.claims_queue)
 					.into_iter()
-					.for_each(|claim| self.prove_multilinear(claim));
+					.for_each(|claim| self.collect_subclaims_for_precompute(claim));
 			}
 
 			let mut deduplicated_claims_without_evals = Vec::new();
 
 			for (poly, eval_point) in std::mem::take(&mut self.claims_without_evals) {
-				if self.finalized_proofs.get(poly.id(), &eval_point).is_some() {
-					continue;
-				}
-				if self
-					.claims_without_evals_dedup
-					.get(poly.id(), &eval_point)
-					.is_some()
-				{
-					continue;
-				}
-
 				self.claims_without_evals_dedup
 					.insert(poly.id(), eval_point.clone(), ());
 
@@ -179,21 +178,17 @@ where
 				})
 				.collect::<Result<Vec<_>, Error>>()?;
 
+			for subclaim in &subclaims {
+				self.new_evals_memoization.insert(
+					subclaim.id,
+					subclaim.eval_point.clone(),
+					subclaim.eval,
+				);
+			}
+
 			subclaims
 				.into_iter()
-				.for_each(|claim| self.prove_multilinear(claim));
-		}
-
-		let mut incomplete_proof_claims =
-			std::mem::take(&mut self.incomplete_proof_claims).flatten();
-
-		while !incomplete_proof_claims.is_empty() {
-			for claim in std::mem::take(&mut incomplete_proof_claims) {
-				if self.complete_proof(&claim) {
-					continue;
-				}
-				incomplete_proof_claims.push(claim);
-			}
+				.for_each(|claim| self.collect_subclaims_for_precompute(claim));
 		}
 
 		// Step 2: Collect batch_committed_eval_claims and projected_bivariate_claims in right order
@@ -201,13 +196,13 @@ where
 		// Since we use BFS for collecting proofs and DFS for verifying them,
 		// it imposes restrictions on the correct order of collecting `batch_committed_eval_claims` and `projected_bivariate_claims`.
 		// Therefore, we run a DFS to handle this.
-		evalcheck_claims
+		let proofs = evalcheck_claims
 			.iter()
 			.cloned()
-			.for_each(|claim| self.collect_projected_committed(claim));
+			.map(|claim| self.prove_multilinear(claim))
+			.collect::<Result<Vec<_>, Error>>();
 
 		// Step 3: Process projected_bivariate_claims
-
 		let projected_bivariate_metas = self
 			.projected_bivariate_claims
 			.iter()
@@ -245,17 +240,7 @@ where
 			self.witness_index,
 		);
 
-		// Step 4: Find and return the proofs of the original claims.
-
-		Ok(evalcheck_claims
-			.iter()
-			.map(|claim| {
-				self.finalized_proofs
-					.get(claim.id, &claim.eval_point)
-					.map(|(_, proof)| proof.clone())
-					.expect("finalized_proofs contains all the proofs")
-			})
-			.collect::<Vec<_>>())
+		proofs.map(|proofs| (proofs, std::mem::take(&mut self.advices)))
 	}
 
 	#[instrument(
@@ -263,48 +248,27 @@ where
 		name = "EvalcheckProverState::prove_multilinear",
 		level = "debug"
 	)]
-	fn prove_multilinear(&mut self, evalcheck_claim: EvalcheckMultilinearClaim<F>) {
+	fn collect_subclaims_for_precompute(&mut self, evalcheck_claim: EvalcheckMultilinearClaim<F>) {
 		let multilinear_id = evalcheck_claim.id;
 
-		let eval_point = evalcheck_claim.eval_point.clone();
+		let eval_point = evalcheck_claim.eval_point;
 
 		let eval = evalcheck_claim.eval;
 
 		if self
-			.finalized_proofs
+			.visited_claims
 			.get(multilinear_id, &eval_point)
 			.is_some()
 		{
 			return;
 		}
 
-		if self
-			.incomplete_proof_claims
-			.get(multilinear_id, &eval_point)
-			.is_some()
-		{
-			return;
-		}
+		self.visited_claims
+			.insert(multilinear_id, eval_point.clone(), ());
 
 		let multilinear = self.oracles.oracle(multilinear_id);
 
 		match multilinear.variant {
-			MultilinearPolyVariant::Transparent { .. } => {
-				self.finalized_proofs.insert(
-					multilinear_id,
-					eval_point,
-					(eval, EvalcheckProof::Transparent),
-				);
-			}
-
-			MultilinearPolyVariant::Committed => {
-				self.finalized_proofs.insert(
-					multilinear_id,
-					eval_point,
-					(eval, EvalcheckProof::Committed),
-				);
-			}
-
 			MultilinearPolyVariant::Repeating { id, .. } => {
 				let n_vars = self.oracles.n_vars(id);
 				let inner_eval_point = eval_point.slice(0..n_vars);
@@ -313,33 +277,7 @@ where
 					eval_point: inner_eval_point,
 					eval,
 				};
-				self.incomplete_proof_claims
-					.insert(multilinear_id, eval_point, evalcheck_claim);
 				self.claims_queue.push(subclaim);
-			}
-
-			MultilinearPolyVariant::Shifted { .. } => {
-				self.finalized_proofs.insert(
-					multilinear_id,
-					eval_point,
-					(eval, EvalcheckProof::Shifted),
-				);
-			}
-
-			MultilinearPolyVariant::Packed { .. } => {
-				self.finalized_proofs.insert(
-					multilinear_id,
-					eval_point,
-					(eval, EvalcheckProof::Packed),
-				);
-			}
-
-			MultilinearPolyVariant::Composite(_) => {
-				self.finalized_proofs.insert(
-					multilinear_id,
-					eval_point,
-					(eval, EvalcheckProof::CompositeMLE),
-				);
 			}
 
 			MultilinearPolyVariant::Projected(projected) => {
@@ -357,8 +295,6 @@ where
 					eval_point: new_eval_point.into(),
 					eval,
 				};
-				self.incomplete_proof_claims
-					.insert(multilinear_id, eval_point, evalcheck_claim);
 				self.claims_queue.push(subclaim);
 			}
 
@@ -375,7 +311,7 @@ where
 							* coeff.invert().expect("not zero");
 						let subclaim = EvalcheckMultilinearClaim {
 							id: suboracle_id,
-							eval_point: eval_point.clone(),
+							eval_point,
 							eval,
 						};
 						self.claims_queue.push(subclaim);
@@ -387,9 +323,6 @@ where
 						}
 					}
 				};
-
-				self.incomplete_proof_claims
-					.insert(multilinear_id, eval_point, evalcheck_claim);
 			}
 
 			MultilinearPolyVariant::ZeroPadded(id) => {
@@ -397,97 +330,40 @@ where
 				let inner_n_vars = inner.n_vars();
 				let inner_eval_point = eval_point.slice(0..inner_n_vars);
 				self.claims_without_evals.push((inner, inner_eval_point));
-				self.incomplete_proof_claims
-					.insert(multilinear_id, eval_point, evalcheck_claim);
 			}
+			_ => return,
 		};
 	}
 
-	fn complete_proof(&mut self, evalcheck_claim: &EvalcheckMultilinearClaim<F>) -> bool {
-		let id = &evalcheck_claim.id;
-		let eval_point = evalcheck_claim.eval_point.clone();
-		let eval = evalcheck_claim.eval;
-
-		let res = match self.oracles.oracle(*id).variant {
-			MultilinearPolyVariant::Repeating { id, .. } => {
-				let n_vars = self.oracles.n_vars(id);
-				let inner_eval_point = &evalcheck_claim.eval_point[..n_vars];
-				self.finalized_proofs
-					.get(id, inner_eval_point)
-					.map(|(_, subproof)| subproof.clone())
-					.map(move |subproof| {
-						let proof = EvalcheckProof::Repeating(Box::new(subproof));
-						self.finalized_proofs
-							.insert(evalcheck_claim.id, eval_point, (eval, proof));
-					})
-			}
-			MultilinearPolyVariant::Projected(projected) => {
-				let (id, values) = (projected.id(), projected.values());
-				let new_eval_point = {
-					let idx = projected.start_index();
-					let mut new_eval_point = eval_point[0..idx].to_vec();
-					new_eval_point.extend(values.clone());
-					new_eval_point.extend(eval_point[idx..].to_vec());
-					new_eval_point
-				};
-
-				self.finalized_proofs
-					.get(id, &new_eval_point)
-					.map(|(_, subproof)| subproof.clone())
-					.map(|subproof| {
-						self.finalized_proofs.insert(
-							evalcheck_claim.id,
-							eval_point,
-							(eval, subproof),
-						);
-					})
-			}
-
-			MultilinearPolyVariant::LinearCombination(linear_combination) => linear_combination
-				.polys()
-				.map(|suboracle_id| {
-					self.finalized_proofs
-						.get(suboracle_id, &evalcheck_claim.eval_point)
-						.map(|(eval, subproof)| (*eval, subproof.clone()))
-				})
-				.collect::<Option<Vec<_>>>()
-				.map(|subproofs| {
-					self.finalized_proofs.insert(
-						evalcheck_claim.id,
-						eval_point,
-						(eval, EvalcheckProof::LinearCombination { subproofs }),
-					);
-				}),
-
-			MultilinearPolyVariant::ZeroPadded(inner_id) => {
-				let inner_n_vars = self.oracles.n_vars(inner_id);
-				let inner_eval_point = &evalcheck_claim.eval_point[..inner_n_vars];
-				self.finalized_proofs
-					.get(inner_id, inner_eval_point)
-					.map(|(eval, subproof)| (*eval, subproof.clone()))
-					.map(|(internal_eval, subproof)| {
-						self.finalized_proofs.insert(
-							evalcheck_claim.id,
-							eval_point,
-							(eval, EvalcheckProof::ZeroPadded(internal_eval, Box::new(subproof))),
-						);
-					})
-			}
-
-			_ => unreachable!(),
-		};
-		res.is_some()
-	}
-
-	fn collect_projected_committed(&mut self, evalcheck_claim: EvalcheckMultilinearClaim<F>) {
+	fn prove_multilinear(
+		&mut self,
+		evalcheck_claim: EvalcheckMultilinearClaim<F>,
+	) -> Result<Option<EvalcheckProof<F>>, Error> {
 		let EvalcheckMultilinearClaim {
 			id,
 			eval_point,
 			eval,
 		} = evalcheck_claim.clone();
 
+		let claim_id = self
+			.round_claims
+			.iter()
+			.position(|claim| *claim == evalcheck_claim);
+
+		if let Some(claim_id) = claim_id {
+			self.advices
+				.push(EvalcheckProofAdvice::DuplicateClaim(claim_id));
+			return Ok(None);
+		}
+
+		self.advices.push(EvalcheckProofAdvice::HandleClaim);
+
+		self.round_claims.push(evalcheck_claim.clone());
+
 		let multilinear = self.oracles.oracle(id);
-		match multilinear.variant {
+		let proof = match multilinear.variant {
+			MultilinearPolyVariant::Transparent { .. } => Some(EvalcheckProof::Transparent),
+
 			MultilinearPolyVariant::Committed => {
 				let subclaim = EvalcheckMultilinearClaim {
 					id: multilinear.id,
@@ -496,6 +372,7 @@ where
 				};
 
 				self.committed_eval_claims.push(subclaim);
+				Some(EvalcheckProof::Committed)
 			}
 			MultilinearPolyVariant::Repeating { id, .. } => {
 				let n_vars = self.oracles.n_vars(id);
@@ -506,7 +383,8 @@ where
 					eval,
 				};
 
-				self.collect_projected_committed(subclaim);
+				let subproof = self.prove_multilinear(subclaim)?;
+				Some(EvalcheckProof::Repeating(Box::new(subproof)))
 			}
 			MultilinearPolyVariant::Projected(projected) => {
 				let (id, values) = (projected.id(), projected.values());
@@ -523,45 +401,80 @@ where
 					eval_point: new_eval_point.into(),
 					eval,
 				};
-				self.collect_projected_committed(subclaim);
+				self.prove_multilinear(subclaim)?
 			}
-			MultilinearPolyVariant::Shifted { .. }
-			| MultilinearPolyVariant::Packed { .. }
-			| MultilinearPolyVariant::Composite { .. } => {
-				self.projected_bivariate_claims.push(evalcheck_claim)
+			MultilinearPolyVariant::Shifted { .. } => {
+				self.projected_bivariate_claims.push(evalcheck_claim);
+				Some(EvalcheckProof::Shifted)
+			}
+			MultilinearPolyVariant::Packed { .. } => {
+				self.projected_bivariate_claims.push(evalcheck_claim);
+				Some(EvalcheckProof::Packed)
+			}
+			MultilinearPolyVariant::Composite { .. } => {
+				self.projected_bivariate_claims.push(evalcheck_claim);
+				Some(EvalcheckProof::CompositeMLE)
 			}
 			MultilinearPolyVariant::LinearCombination(linear_combination) => {
-				for id in linear_combination.polys() {
-					let (eval, _) = self
-						.finalized_proofs
-						.get(id, &eval_point)
-						.expect("finalized_proofs contains all the proofs");
-					let subclaim = EvalcheckMultilinearClaim {
-						id,
-						eval_point: eval_point.clone(),
-						eval: *eval,
-					};
-					self.collect_projected_committed(subclaim);
-				}
+				let n_polys = linear_combination.n_polys();
+
+				let subproofs = match linear_combination
+					.polys()
+					.zip(linear_combination.coefficients())
+					.next()
+				{
+					Some((suboracle_id, coeff)) if n_polys == 1 && !coeff.is_zero() => {
+						let eval = (eval - linear_combination.offset())
+							* coeff.invert().expect("not zero");
+						let subclaim = EvalcheckMultilinearClaim {
+							id: suboracle_id,
+							eval_point,
+							eval,
+						};
+						vec![(eval, self.prove_multilinear(subclaim)?)]
+					}
+					_ => linear_combination
+						.polys()
+						.map(|suboracle_id| {
+							let eval = *self
+								.new_evals_memoization
+								.get(suboracle_id, &eval_point)
+								.unwrap();
+
+							let subclaim = EvalcheckMultilinearClaim {
+								id: suboracle_id,
+								eval_point: eval_point.clone(),
+								eval,
+							};
+							(eval, self.prove_multilinear(subclaim).unwrap())
+						})
+						.collect::<Vec<_>>(),
+				};
+
+				Some(EvalcheckProof::LinearCombination { subproofs })
 			}
 			MultilinearPolyVariant::ZeroPadded(id) => {
 				let inner_n_vars = self.oracles.n_vars(id);
-				let inner_eval_point = eval_point.slice(0..inner_n_vars);
 
-				let (eval, _) = self
-					.finalized_proofs
-					.get(id, &inner_eval_point)
-					.expect("finalized_proofs contains all the proofs");
+				let inner_eval_point = &eval_point[..inner_n_vars];
+
+				let eval = *self
+					.new_evals_memoization
+					.get(id, inner_eval_point)
+					.unwrap();
 
 				let subclaim = EvalcheckMultilinearClaim {
 					id,
-					eval_point,
-					eval: *eval,
+					eval_point: eval_point.clone(),
+					eval,
 				};
-				self.collect_projected_committed(subclaim);
+
+				let subproof = self.prove_multilinear(subclaim)?;
+
+				Some(EvalcheckProof::ZeroPadded(eval, Box::new(subproof)))
 			}
-			_ => {}
-		}
+		};
+		Ok(proof)
 	}
 
 	fn projected_bivariate_meta(

--- a/crates/core/src/protocols/evalcheck/subclaims.rs
+++ b/crates/core/src/protocols/evalcheck/subclaims.rs
@@ -19,6 +19,7 @@ use binius_math::{
 };
 use binius_maybe_rayon::prelude::*;
 use binius_utils::bail;
+use tracing::instrument;
 
 use super::{error::Error, evalcheck::EvalcheckMultilinearClaim, EvalPointOracleIdMap};
 use crate::{
@@ -445,6 +446,7 @@ impl<'a, P: PackedField, Backend: ComputationBackend> MemoizedData<'a, P, Backen
 			})
 	}
 
+	#[instrument(skip_all, name = "memoize_query_par", level = "debug")]
 	pub fn memoize_query_par(
 		&mut self,
 		eval_points: &[&[P::Scalar]],

--- a/crates/core/src/protocols/evalcheck/tests.rs
+++ b/crates/core/src/protocols/evalcheck/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 Irreducible Inc.
+// // Copyright 2024-2025 Irreducible Inc.
 
 use std::{array, iter::repeat_with, slice};
 
@@ -553,19 +553,19 @@ where
 
 	let mut values = vec![P::zero(); 1 << (n_vars - P::LOG_WIDTH)];
 
-	let values_len = values.len();
+// 	let values_len = values.len();
 
 	let (_, x_values) = values.split_at_mut(values_len - (1 << (x.n_vars() - P::LOG_WIDTH)));
 
-	x.subcube_evals(x.n_vars(), 0, 0, x_values).unwrap();
+// 	x.subcube_evals(x.n_vars(), 0, 0, x_values).unwrap();
 
-	let zero_padded_poly = MultilinearExtension::from_values(values).unwrap();
+// 	let zero_padded_poly = MultilinearExtension::from_values(values).unwrap();
 
-	let select_row_oracle_id = oracles.add_transparent(select_row.clone()).unwrap();
+// 	let select_row_oracle_id = oracles.add_transparent(select_row.clone()).unwrap();
 
-	let zero_padded_id = oracles
-		.add_zero_padded(select_row_oracle_id, n_vars)
-		.unwrap();
+// 	let zero_padded_id = oracles
+// 		.add_zero_padded(select_row_oracle_id, n_vars)
+// 		.unwrap();
 
 	let mut witness_index = MultilinearExtensionIndex::<PExtension>::new();
 	witness_index
@@ -575,16 +575,16 @@ where
 		])
 		.unwrap();
 
-	let mut rng = StdRng::seed_from_u64(0);
+// 	let mut rng = StdRng::seed_from_u64(0);
 
-	let eval_point = repeat_with(|| <FExtension as Field>::random(&mut rng))
-		.take(n_vars)
-		.collect::<Vec<_>>();
+// 	let eval_point = repeat_with(|| <FExtension as Field>::random(&mut rng))
+// 		.take(n_vars)
+// 		.collect::<Vec<_>>();
 
-	let inner_eval_point = &eval_point[..inner_n_vars];
-	let eval = select_row.evaluate(inner_eval_point).unwrap();
+// 	let inner_eval_point = &eval_point[..inner_n_vars];
+// 	let eval = select_row.evaluate(inner_eval_point).unwrap();
 
-	let mut inner_eval = eval;
+// 	let mut inner_eval = eval;
 
 	for i in 0..n_vars - inner_n_vars {
 		inner_eval = extrapolate_line::<FExtension, FExtension>(
@@ -594,21 +594,21 @@ where
 		);
 	}
 
-	let claim = EvalcheckMultilinearClaim {
-		id: zero_padded_id,
-		eval_point: eval_point.into(),
-		eval: inner_eval,
-	};
+// 	let claim = EvalcheckMultilinearClaim {
+// 		id: zero_padded_id,
+// 		eval_point: eval_point.into(),
+// 		eval: inner_eval,
+// 	};
 
-	let backend = make_portable_backend();
-	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
-	let proof = prover_state.prove(vec![claim.clone()]).unwrap();
+// 	let backend = make_portable_backend();
+// 	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
+// 	let proof = prover_state.prove(vec![claim.clone()]).unwrap();
 
-	assert_matches!(proof[0], EvalcheckProof::ZeroPadded { .. });
+// 	assert_matches!(proof[0], EvalcheckProof::ZeroPadded { .. });
 
-	let mut verifier_state = EvalcheckVerifier::<FExtension>::new(&mut oracles);
-	verifier_state.verify(vec![claim], proof).unwrap();
-}
+// 	let mut verifier_state = EvalcheckVerifier::<FExtension>::new(&mut oracles);
+// 	verifier_state.verify(vec![claim], proof).unwrap();
+// }
 
 #[test]
 /// Constructs a small ZeroPadded oracle, proves and verifies it.
@@ -620,54 +620,54 @@ fn test_evalcheck_zero_padded() {
 }
 
 // Test evalcheck serialization
-#[test]
-fn test_evalcheck_serialization() {
-	fn rand_committed<F: TowerField, const N: usize>() -> [EvalcheckProof<F>; N] {
-		array::from_fn(|_| EvalcheckProof::Committed)
-	}
+// #[test]
+// fn test_evalcheck_serialization() {
+// 	fn rand_committed<F: TowerField, const N: usize>() -> [EvalcheckProof<F>; N] {
+// 		array::from_fn(|_| EvalcheckProof::Committed)
+// 	}
 
-	fn rand_transparent<F: TowerField, const N: usize>() -> [EvalcheckProof<F>; N] {
-		array::from_fn(|_| EvalcheckProof::Transparent)
-	}
+// 	fn rand_transparent<F: TowerField, const N: usize>() -> [EvalcheckProof<F>; N] {
+// 		array::from_fn(|_| EvalcheckProof::Transparent)
+// 	}
 
-	fn rand_composite<'a, F: TowerField>(
-		elems: impl Iterator<Item = &'a EvalcheckProof<F>>,
-	) -> EvalcheckProof<F> {
-		let mut rng = thread_rng();
-		EvalcheckProof::LinearCombination {
-			subproofs: elems
-				.map(|x| (F::random(&mut rng), x.clone()))
-				.collect::<Vec<_>>(),
-		}
-	}
+// 	fn rand_composite<'a, F: TowerField>(
+// 		elems: impl Iterator<Item = &'a EvalcheckProof<F>>,
+// 	) -> EvalcheckProof<F> {
+// 		let mut rng = thread_rng();
+// 		EvalcheckProof::LinearCombination {
+// 			subproofs: elems
+// 				.map(|x| Some((F::random(&mut rng), x.clone())))
+// 				.collect::<Vec<_>>(),
+// 		}
+// 	}
 
-	fn rand_repeating<F: TowerField>(inner: &EvalcheckProof<F>) -> EvalcheckProof<F> {
-		EvalcheckProof::Repeating(Box::new(inner.clone()))
-	}
+// 	fn rand_repeating<F: TowerField>(inner: &EvalcheckProof<F>) -> EvalcheckProof<F> {
+// 		EvalcheckProof::Repeating(Box::new(inner.clone()))
+// 	}
 
-	let committed = rand_committed::<BinaryField128b, 10>();
-	let transparent = rand_transparent::<_, 20>();
-	let repeating = transparent.clone().map(|x| rand_repeating(&x));
-	let first_linear_combination =
-		rand_composite(committed[..10].iter().chain(repeating[..2].iter()));
-	let second_linear_combination = rand_composite(
-		slice::from_ref(&first_linear_combination)
-			.iter()
-			.chain(transparent[..20].iter()),
-	);
+// 	let committed = rand_committed::<BinaryField128b, 10>();
+// 	let transparent = rand_transparent::<_, 20>();
+// 	let repeating = transparent.clone().map(|x| rand_repeating(&x));
+// 	let first_linear_combination =
+// 		rand_composite(committed[..10].iter().chain(repeating[..2].iter()));
+// 	let second_linear_combination = rand_composite(
+// 		slice::from_ref(&first_linear_combination)
+// 			.iter()
+// 			.chain(transparent[..20].iter()),
+// 	);
 
-	let mut transcript = crate::transcript::ProverTranscript::<
-		crate::fiat_shamir::HasherChallenger<Groestl256>,
-	>::new();
+// 	let mut transcript = crate::transcript::ProverTranscript::<
+// 		crate::fiat_shamir::HasherChallenger<Groestl256>,
+// 	>::new();
 
-	let mut writer = transcript.message();
-	serialize_evalcheck_proof(&mut writer, &second_linear_combination);
-	let mut transcript = transcript.into_verifier();
-	let mut reader = transcript.message();
+// 	let mut writer = transcript.message();
+// 	serialize_evalcheck_proof(&mut writer, &second_linear_combination);
+// 	let mut transcript = transcript.into_verifier();
+// 	let mut reader = transcript.message();
 
-	let out_deserialized = deserialize_evalcheck_proof::<_, BinaryField128b>(&mut reader).unwrap();
+// 	let out_deserialized = deserialize_evalcheck_proof::<_, BinaryField128b>(&mut reader).unwrap();
 
-	assert_eq!(out_deserialized, second_linear_combination);
+// 	assert_eq!(out_deserialized, second_linear_combination);
 
-	transcript.finalize().unwrap()
-}
+// 	transcript.finalize().unwrap()
+// }

--- a/crates/core/src/protocols/evalcheck/tests.rs
+++ b/crates/core/src/protocols/evalcheck/tests.rs
@@ -1,6 +1,6 @@
-// // Copyright 2024-2025 Irreducible Inc.
+// // // Copyright 2024-2025 Irreducible Inc.
 
-use std::{array, iter::repeat_with, slice};
+// use std::{array, iter::repeat_with, slice};
 
 use assert_matches::assert_matches;
 use binius_field::{

--- a/crates/core/src/protocols/evalcheck/tests.rs
+++ b/crates/core/src/protocols/evalcheck/tests.rs
@@ -1,6 +1,6 @@
-// // // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2024-2025 Irreducible Inc.
 
-// use std::{array, iter::repeat_with, slice};
+use std::{array, iter::repeat_with, slice};
 
 use assert_matches::assert_matches;
 use binius_field::{
@@ -553,19 +553,19 @@ where
 
 	let mut values = vec![P::zero(); 1 << (n_vars - P::LOG_WIDTH)];
 
-// 	let values_len = values.len();
+	let values_len = values.len();
 
 	let (_, x_values) = values.split_at_mut(values_len - (1 << (x.n_vars() - P::LOG_WIDTH)));
 
-// 	x.subcube_evals(x.n_vars(), 0, 0, x_values).unwrap();
+	x.subcube_evals(x.n_vars(), 0, 0, x_values).unwrap();
 
-// 	let zero_padded_poly = MultilinearExtension::from_values(values).unwrap();
+	let zero_padded_poly = MultilinearExtension::from_values(values).unwrap();
 
-// 	let select_row_oracle_id = oracles.add_transparent(select_row.clone()).unwrap();
+	let select_row_oracle_id = oracles.add_transparent(select_row.clone()).unwrap();
 
-// 	let zero_padded_id = oracles
-// 		.add_zero_padded(select_row_oracle_id, n_vars)
-// 		.unwrap();
+	let zero_padded_id = oracles
+		.add_zero_padded(select_row_oracle_id, n_vars)
+		.unwrap();
 
 	let mut witness_index = MultilinearExtensionIndex::<PExtension>::new();
 	witness_index
@@ -575,16 +575,16 @@ where
 		])
 		.unwrap();
 
-// 	let mut rng = StdRng::seed_from_u64(0);
+	let mut rng = StdRng::seed_from_u64(0);
 
-// 	let eval_point = repeat_with(|| <FExtension as Field>::random(&mut rng))
-// 		.take(n_vars)
-// 		.collect::<Vec<_>>();
+	let eval_point = repeat_with(|| <FExtension as Field>::random(&mut rng))
+		.take(n_vars)
+		.collect::<Vec<_>>();
 
-// 	let inner_eval_point = &eval_point[..inner_n_vars];
-// 	let eval = select_row.evaluate(inner_eval_point).unwrap();
+	let inner_eval_point = &eval_point[..inner_n_vars];
+	let eval = select_row.evaluate(inner_eval_point).unwrap();
 
-// 	let mut inner_eval = eval;
+	let mut inner_eval = eval;
 
 	for i in 0..n_vars - inner_n_vars {
 		inner_eval = extrapolate_line::<FExtension, FExtension>(
@@ -594,21 +594,21 @@ where
 		);
 	}
 
-// 	let claim = EvalcheckMultilinearClaim {
-// 		id: zero_padded_id,
-// 		eval_point: eval_point.into(),
-// 		eval: inner_eval,
-// 	};
+	let claim = EvalcheckMultilinearClaim {
+		id: zero_padded_id,
+		eval_point: eval_point.into(),
+		eval: inner_eval,
+	};
 
-// 	let backend = make_portable_backend();
-// 	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
-// 	let proof = prover_state.prove(vec![claim.clone()]).unwrap();
+	let backend = make_portable_backend();
+	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
+	let proof = prover_state.prove(vec![claim.clone()]).unwrap();
 
-// 	assert_matches!(proof[0], EvalcheckProof::ZeroPadded { .. });
+	assert_matches!(proof[0], EvalcheckProof::ZeroPadded { .. });
 
-// 	let mut verifier_state = EvalcheckVerifier::<FExtension>::new(&mut oracles);
-// 	verifier_state.verify(vec![claim], proof).unwrap();
-// }
+	let mut verifier_state = EvalcheckVerifier::<FExtension>::new(&mut oracles);
+	verifier_state.verify(vec![claim], proof).unwrap();
+}
 
 #[test]
 /// Constructs a small ZeroPadded oracle, proves and verifies it.
@@ -620,54 +620,54 @@ fn test_evalcheck_zero_padded() {
 }
 
 // Test evalcheck serialization
-// #[test]
-// fn test_evalcheck_serialization() {
-// 	fn rand_committed<F: TowerField, const N: usize>() -> [EvalcheckProof<F>; N] {
-// 		array::from_fn(|_| EvalcheckProof::Committed)
-// 	}
+#[test]
+fn test_evalcheck_serialization() {
+	fn rand_committed<F: TowerField, const N: usize>() -> [EvalcheckProof<F>; N] {
+		array::from_fn(|_| EvalcheckProof::Committed)
+	}
 
-// 	fn rand_transparent<F: TowerField, const N: usize>() -> [EvalcheckProof<F>; N] {
-// 		array::from_fn(|_| EvalcheckProof::Transparent)
-// 	}
+	fn rand_transparent<F: TowerField, const N: usize>() -> [EvalcheckProof<F>; N] {
+		array::from_fn(|_| EvalcheckProof::Transparent)
+	}
 
-// 	fn rand_composite<'a, F: TowerField>(
-// 		elems: impl Iterator<Item = &'a EvalcheckProof<F>>,
-// 	) -> EvalcheckProof<F> {
-// 		let mut rng = thread_rng();
-// 		EvalcheckProof::LinearCombination {
-// 			subproofs: elems
-// 				.map(|x| Some((F::random(&mut rng), x.clone())))
-// 				.collect::<Vec<_>>(),
-// 		}
-// 	}
+	fn rand_composite<'a, F: TowerField>(
+		elems: impl Iterator<Item = &'a EvalcheckProof<F>>,
+	) -> EvalcheckProof<F> {
+		let mut rng = thread_rng();
+		EvalcheckProof::LinearCombination {
+			subproofs: elems
+				.map(|x| (F::random(&mut rng), x.clone()))
+				.collect::<Vec<_>>(),
+		}
+	}
 
-// 	fn rand_repeating<F: TowerField>(inner: &EvalcheckProof<F>) -> EvalcheckProof<F> {
-// 		EvalcheckProof::Repeating(Box::new(inner.clone()))
-// 	}
+	fn rand_repeating<F: TowerField>(inner: &EvalcheckProof<F>) -> EvalcheckProof<F> {
+		EvalcheckProof::Repeating(Box::new(inner.clone()))
+	}
 
-// 	let committed = rand_committed::<BinaryField128b, 10>();
-// 	let transparent = rand_transparent::<_, 20>();
-// 	let repeating = transparent.clone().map(|x| rand_repeating(&x));
-// 	let first_linear_combination =
-// 		rand_composite(committed[..10].iter().chain(repeating[..2].iter()));
-// 	let second_linear_combination = rand_composite(
-// 		slice::from_ref(&first_linear_combination)
-// 			.iter()
-// 			.chain(transparent[..20].iter()),
-// 	);
+	let committed = rand_committed::<BinaryField128b, 10>();
+	let transparent = rand_transparent::<_, 20>();
+	let repeating = transparent.clone().map(|x| rand_repeating(&x));
+	let first_linear_combination =
+		rand_composite(committed[..10].iter().chain(repeating[..2].iter()));
+	let second_linear_combination = rand_composite(
+		slice::from_ref(&first_linear_combination)
+			.iter()
+			.chain(transparent[..20].iter()),
+	);
 
-// 	let mut transcript = crate::transcript::ProverTranscript::<
-// 		crate::fiat_shamir::HasherChallenger<Groestl256>,
-// 	>::new();
+	let mut transcript = crate::transcript::ProverTranscript::<
+		crate::fiat_shamir::HasherChallenger<Groestl256>,
+	>::new();
 
-// 	let mut writer = transcript.message();
-// 	serialize_evalcheck_proof(&mut writer, &second_linear_combination);
-// 	let mut transcript = transcript.into_verifier();
-// 	let mut reader = transcript.message();
+	let mut writer = transcript.message();
+	serialize_evalcheck_proof(&mut writer, &second_linear_combination);
+	let mut transcript = transcript.into_verifier();
+	let mut reader = transcript.message();
 
-// 	let out_deserialized = deserialize_evalcheck_proof::<_, BinaryField128b>(&mut reader).unwrap();
+	let out_deserialized = deserialize_evalcheck_proof::<_, BinaryField128b>(&mut reader).unwrap();
 
-// 	assert_eq!(out_deserialized, second_linear_combination);
+	assert_eq!(out_deserialized, second_linear_combination);
 
-// 	transcript.finalize().unwrap()
-// }
+	transcript.finalize().unwrap()
+}

--- a/crates/core/src/protocols/evalcheck/tests.rs
+++ b/crates/core/src/protocols/evalcheck/tests.rs
@@ -636,7 +636,7 @@ fn test_evalcheck_serialization() {
 		let mut rng = thread_rng();
 		EvalcheckProof::LinearCombination {
 			subproofs: elems
-				.map(|x| (F::random(&mut rng), x.clone()))
+				.map(|x| (Some(F::random(&mut rng)), x.clone()))
 				.collect::<Vec<_>>(),
 		}
 	}

--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -107,13 +107,16 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 				proof
 			}
 			(super::EvalcheckProofAdvice::DuplicateClaim(claim_id), _) => {
-				if self.round_claims[claim_id] == evalcheck_claim {
-					return Ok(());
+				if let Some(expected_claim) = self.round_claims.get(claim_id) {
+					if *expected_claim == evalcheck_claim {
+						return Ok(());
+					}
+					return Err(VerificationError::DuplicateClaimMismatch.into());
 				}
-				panic!("137")
+				return Err(VerificationError::OutOfAdvices.into());
 			}
 			_ => {
-				unreachable!()
+				return Err(VerificationError::OutOfAdvices.into());
 			}
 		};
 

--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -242,7 +242,7 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 							if self.round_claims[*index].id != sub_oracle_id
 								|| self.round_claims[*index].eval_point != eval_point
 							{
-								panic!("137");
+								return Err(VerificationError::DuplicateClaimMismatch.into());
 							}
 
 							evals.push(self.round_claims[*index].eval);

--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -100,7 +100,7 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 
 		self.advice_index += 1;
 
-		let evalcheck_proof = match (claim_advice, evalcheck_proof.clone()) {
+		let evalcheck_proof = match (claim_advice, evalcheck_proof) {
 			(super::EvalcheckProofAdvice::HandleClaim, Some(proof)) => {
 				self.round_claims.push(evalcheck_claim.clone());
 

--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -103,7 +103,6 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 		let evalcheck_proof = match (claim_advice, evalcheck_proof) {
 			(super::EvalcheckProofAdvice::HandleClaim, Some(proof)) => {
 				self.round_claims.push(evalcheck_claim.clone());
-
 				proof
 			}
 			(super::EvalcheckProofAdvice::DuplicateClaim(claim_id), _) => {

--- a/crates/core/src/protocols/greedy_evalcheck/prove.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/prove.rs
@@ -14,7 +14,7 @@ use crate::{
 	protocols::evalcheck::{
 		serialize_advice, serialize_evalcheck_proof,
 		subclaims::{prove_bivariate_sumchecks_with_switchover, MemoizedData},
-		EvalcheckMultilinearClaim, EvalcheckProver,
+		EvalcheckMultilinearClaim, EvalcheckProver, ProofsWithAdvices,
 	},
 	transcript::{write_u64, ProverTranscript},
 	witness::MultilinearExtensionIndex,
@@ -51,7 +51,10 @@ where
 	let claims: Vec<_> = claims.into_iter().collect();
 
 	// Prove the initial evalcheck claims
-	let (evalcheck_proofs, advices) = evalcheck_prover.prove(claims)?;
+	let ProofsWithAdvices {
+		proofs: evalcheck_proofs,
+		advices,
+	} = evalcheck_prover.prove(claims)?;
 	write_u64(&mut transcript.decommitment(), evalcheck_proofs.len() as u64);
 	write_u64(&mut transcript.decommitment(), advices.len() as u64);
 	let mut writer = transcript.message();
@@ -79,7 +82,10 @@ where
 				backend,
 			)?;
 
-		let (new_evalcheck_proofs, new_advices) = evalcheck_prover.prove(new_evalcheck_claims)?;
+		let ProofsWithAdvices {
+			proofs: new_evalcheck_proofs,
+			advices: new_advices,
+		} = evalcheck_prover.prove(new_evalcheck_claims)?;
 
 		write_u64(&mut transcript.decommitment(), new_evalcheck_proofs.len() as u64);
 		write_u64(&mut transcript.decommitment(), new_advices.len() as u64);

--- a/crates/core/src/protocols/greedy_evalcheck/prove.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/prove.rs
@@ -12,7 +12,7 @@ use crate::{
 	fiat_shamir::Challenger,
 	oracle::MultilinearOracleSet,
 	protocols::evalcheck::{
-		serialize_evalcheck_proof,
+		serialize_advice, serialize_evalcheck_proof,
 		subclaims::{prove_bivariate_sumchecks_with_switchover, MemoizedData},
 		EvalcheckMultilinearClaim, EvalcheckProver,
 	},
@@ -51,11 +51,15 @@ where
 	let claims: Vec<_> = claims.into_iter().collect();
 
 	// Prove the initial evalcheck claims
-	let evalcheck_proofs = evalcheck_prover.prove(claims)?;
+	let (evalcheck_proofs, advices) = evalcheck_prover.prove(claims)?;
 	write_u64(&mut transcript.decommitment(), evalcheck_proofs.len() as u64);
+	write_u64(&mut transcript.decommitment(), advices.len() as u64);
 	let mut writer = transcript.message();
 	for evalcheck_proof in &evalcheck_proofs {
 		serialize_evalcheck_proof(&mut writer, evalcheck_proof)
+	}
+	for advice in &advices {
+		serialize_advice(&mut writer, advice);
 	}
 
 	loop {
@@ -75,11 +79,16 @@ where
 				backend,
 			)?;
 
-		let new_evalcheck_proofs = evalcheck_prover.prove(new_evalcheck_claims)?;
+		let (new_evalcheck_proofs, new_advices) = evalcheck_prover.prove(new_evalcheck_claims)?;
 
+		write_u64(&mut transcript.decommitment(), new_evalcheck_proofs.len() as u64);
+		write_u64(&mut transcript.decommitment(), new_advices.len() as u64);
 		let mut writer = transcript.message();
 		for evalcheck_proof in &new_evalcheck_proofs {
 			serialize_evalcheck_proof(&mut writer, evalcheck_proof);
+		}
+		for advice in &new_advices {
+			serialize_advice(&mut writer, advice);
 		}
 	}
 

--- a/crates/core/src/protocols/greedy_evalcheck/verify.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/verify.rs
@@ -9,13 +9,10 @@ use crate::{
 	fiat_shamir::Challenger,
 	oracle::MultilinearOracleSet,
 	protocols::{
-		evalcheck::{
-			deserialize_advice, deserialize_evalcheck_proof, EvalcheckMultilinearClaim,
-			EvalcheckVerifier,
-		},
+		evalcheck::{deserialize_evalcheck_proof, EvalcheckMultilinearClaim, EvalcheckVerifier},
 		sumcheck::{self, batch_verify, constraint_set_sumcheck_claims, SumcheckClaimsWithMeta},
 	},
-	transcript::{read_u64, VerifierTranscript},
+	transcript::VerifierTranscript,
 };
 
 pub fn verify<F, Challenger_>(
@@ -32,21 +29,13 @@ where
 	// Verify the initial evalcheck claims
 	let claims = claims.into_iter().collect::<Vec<_>>();
 
-	let len_initial_evalcheck_proofs = read_u64(&mut transcript.decommitment())? as usize;
-	let len_initial_advices = read_u64(&mut transcript.decommitment())? as usize;
-	let mut initial_evalcheck_proofs = Vec::with_capacity(len_initial_evalcheck_proofs);
-	let mut initial_advices = Vec::with_capacity(len_initial_advices);
+	let mut initial_evalcheck_proofs = Vec::with_capacity(claims.len());
 	let mut reader = transcript.message();
-	for _ in 0..len_initial_evalcheck_proofs {
+	for _ in 0..claims.len() {
 		let eval_check_proof = deserialize_evalcheck_proof(&mut reader)?;
 		initial_evalcheck_proofs.push(eval_check_proof);
 	}
-	for _ in 0..len_initial_advices {
-		let advice = deserialize_advice(&mut reader)?;
-		initial_advices.push(advice);
-	}
-
-	evalcheck_verifier.verify(claims, initial_evalcheck_proofs, initial_advices)?;
+	evalcheck_verifier.verify(claims, initial_evalcheck_proofs)?;
 
 	loop {
 		let SumcheckClaimsWithMeta { claims, metas } = constraint_set_sumcheck_claims(
@@ -63,21 +52,14 @@ where
 		let new_evalcheck_claims =
 			sumcheck::make_eval_claims(EvaluationOrder::HighToLow, metas, sumcheck_output)?;
 
-		let len_new_evalcheck_proofs = read_u64(&mut transcript.decommitment())? as usize;
-		let len_new_advices = read_u64(&mut transcript.decommitment())? as usize;
-		let mut evalcheck_proofs = Vec::with_capacity(len_new_evalcheck_proofs);
-		let mut advices = Vec::with_capacity(len_new_advices);
+		let mut evalcheck_proofs = Vec::with_capacity(new_evalcheck_claims.len());
 		let mut reader = transcript.message();
-		for _ in 0..len_new_evalcheck_proofs {
+		for _ in 0..new_evalcheck_claims.len() {
 			let evalcheck_proof = deserialize_evalcheck_proof(&mut reader)?;
 			evalcheck_proofs.push(evalcheck_proof)
 		}
-		for _ in 0..len_new_advices {
-			let advice = deserialize_advice(&mut reader)?;
-			advices.push(advice);
-		}
 
-		evalcheck_verifier.verify(new_evalcheck_claims, evalcheck_proofs, advices)?;
+		evalcheck_verifier.verify(new_evalcheck_claims, evalcheck_proofs)?;
 	}
 
 	let new_sumchecks = evalcheck_verifier.take_new_sumcheck_constraints().unwrap();

--- a/crates/core/src/protocols/greedy_evalcheck/verify.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/verify.rs
@@ -9,7 +9,10 @@ use crate::{
 	fiat_shamir::Challenger,
 	oracle::MultilinearOracleSet,
 	protocols::{
-		evalcheck::{deserialize_evalcheck_proof, EvalcheckMultilinearClaim, EvalcheckVerifier},
+		evalcheck::{
+			deserialize_advice, deserialize_evalcheck_proof, EvalcheckMultilinearClaim,
+			EvalcheckVerifier,
+		},
 		sumcheck::{self, batch_verify, constraint_set_sumcheck_claims, SumcheckClaimsWithMeta},
 	},
 	transcript::{read_u64, VerifierTranscript},
@@ -30,14 +33,20 @@ where
 	let claims = claims.into_iter().collect::<Vec<_>>();
 
 	let len_initial_evalcheck_proofs = read_u64(&mut transcript.decommitment())? as usize;
+	let len_initial_advices = read_u64(&mut transcript.decommitment())? as usize;
 	let mut initial_evalcheck_proofs = Vec::with_capacity(len_initial_evalcheck_proofs);
+	let mut initial_advices = Vec::with_capacity(len_initial_advices);
 	let mut reader = transcript.message();
 	for _ in 0..len_initial_evalcheck_proofs {
 		let eval_check_proof = deserialize_evalcheck_proof(&mut reader)?;
 		initial_evalcheck_proofs.push(eval_check_proof);
 	}
+	for _ in 0..len_initial_advices {
+		let advice = deserialize_advice(&mut reader)?;
+		initial_advices.push(advice);
+	}
 
-	evalcheck_verifier.verify(claims, initial_evalcheck_proofs)?;
+	evalcheck_verifier.verify(claims, initial_evalcheck_proofs, initial_advices)?;
 
 	loop {
 		let SumcheckClaimsWithMeta { claims, metas } = constraint_set_sumcheck_claims(
@@ -54,14 +63,21 @@ where
 		let new_evalcheck_claims =
 			sumcheck::make_eval_claims(EvaluationOrder::HighToLow, metas, sumcheck_output)?;
 
-		let mut evalcheck_proofs = Vec::with_capacity(new_evalcheck_claims.len());
+		let len_new_evalcheck_proofs = read_u64(&mut transcript.decommitment())? as usize;
+		let len_new_advices = read_u64(&mut transcript.decommitment())? as usize;
+		let mut evalcheck_proofs = Vec::with_capacity(len_new_evalcheck_proofs);
+		let mut advices = Vec::with_capacity(len_new_advices);
 		let mut reader = transcript.message();
-		for _ in 0..new_evalcheck_claims.len() {
+		for _ in 0..len_new_evalcheck_proofs {
 			let evalcheck_proof = deserialize_evalcheck_proof(&mut reader)?;
 			evalcheck_proofs.push(evalcheck_proof)
 		}
+		for _ in 0..len_new_advices {
+			let advice = deserialize_advice(&mut reader)?;
+			advices.push(advice);
+		}
 
-		evalcheck_verifier.verify(new_evalcheck_claims, evalcheck_proofs)?;
+		evalcheck_verifier.verify(new_evalcheck_claims, evalcheck_proofs, advices)?;
 	}
 
 	let new_sumchecks = evalcheck_verifier.take_new_sumcheck_constraints().unwrap();

--- a/crates/core/src/transcript/mod.rs
+++ b/crates/core/src/transcript/mod.rs
@@ -119,9 +119,7 @@ impl<Challenger_: Default + Challenger> Default for ProverTranscript<Challenger_
 
 impl<Challenger_: Challenger> ProverTranscript<Challenger_> {
 	pub fn finalize(self) -> Vec<u8> {
-		println!("start finalize");
 		let res = self.combined.buffer.to_vec();
-		println!("finish finalize");
 		res
 	}
 

--- a/crates/core/src/transcript/mod.rs
+++ b/crates/core/src/transcript/mod.rs
@@ -119,8 +119,7 @@ impl<Challenger_: Default + Challenger> Default for ProverTranscript<Challenger_
 
 impl<Challenger_: Challenger> ProverTranscript<Challenger_> {
 	pub fn finalize(self) -> Vec<u8> {
-		let res = self.combined.buffer.to_vec();
-		res
+		self.combined.buffer.to_vec()
 	}
 
 	/// Sets the debug flag.

--- a/crates/core/src/transcript/mod.rs
+++ b/crates/core/src/transcript/mod.rs
@@ -119,7 +119,10 @@ impl<Challenger_: Default + Challenger> Default for ProverTranscript<Challenger_
 
 impl<Challenger_: Challenger> ProverTranscript<Challenger_> {
 	pub fn finalize(self) -> Vec<u8> {
-		self.combined.buffer.to_vec()
+		println!("start finalize");
+		let res = self.combined.buffer.to_vec();
+		println!("finish finalize");
+		res
 	}
 
 	/// Sets the debug flag.


### PR DESCRIPTION
This PR introduces deduplication for EvalCheck claim prove/verify steps, which positively impacts both proof size and verification time.

The core idea is to leverage Advice — supplementary information the prover provides to the verifier. If a claim has already been proven/verified, the prover includes its position within the `round_claims` list. This allows the verifier to efficiently confirm the validity of a duplicate claim without the need for an additional search through the list.

The proving process has been updated and now consists of three key steps:
1. **Evaluation Memoization with modified BFS** 
   Since the order of processing stamps is not important, we take full advantage of multithreading  
   for improved performance.
2. **Prove multilinears**  
   Constructs both the proofs and the associated advice  
   in the same order that the verifier will process them.  
   This ensures consistency and correct indexing between prover and verifier.
3. **Processing `projected_bivariate_claims`** 