### PR TITLE
[m3] Refactor away duplication of table size specification

### DIFF
--- a/crates/m3/Cargo.toml
+++ b/crates/m3/Cargo.toml
@@ -15,6 +15,7 @@ binius_utils = { path = "../utils" }
 bumpalo.workspace = true
 bytemuck.workspace = true
 derive_more.workspace = true
+either.workspace = true
 getset.workspace = true
 itertools.workspace = true
 thiserror.workspace = true

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -155,24 +155,8 @@ impl<F: TowerField> ConstraintSystem<F> {
 	pub fn build_witness<'cs, 'alloc, P: PackedField<Scalar = F>>(
 		&'cs self,
 		allocator: &'alloc Bump,
-		_statement: &Statement,
 	) -> Result<WitnessIndex<'cs, 'alloc, P>, Error> {
 		Ok(WitnessIndex::new(allocator, &self.tables))
-		// Ok(WitnessIndex {
-		// 	tables: self
-		// 		.tables
-		// 		.iter()
-		// 		.zip(&statement.table_sizes)
-		// 		.map(|(table, &table_size)| {
-		// 			let witness = if table_size > 0 {
-		// 				Some(TableWitnessIndex::new(allocator, table, table_size))
-		// 			} else {
-		// 				None
-		// 			};
-		// 			witness.transpose()
-		// 		})
-		// 		.collect::<Result<_, _>>()?,
-		// })
 	}
 
 	/// Compiles a [`CompiledConstraintSystem`] for a particular statement.

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -24,7 +24,7 @@ use super::{
 	statement::Statement,
 	table::TablePartition,
 	types::B128,
-	witness::{TableWitnessIndex, WitnessIndex},
+	witness::WitnessIndex,
 	Table, TableBuilder,
 };
 use crate::builder::expr::ArithExprNamedVars;
@@ -155,23 +155,24 @@ impl<F: TowerField> ConstraintSystem<F> {
 	pub fn build_witness<'cs, 'alloc, P: PackedField<Scalar = F>>(
 		&'cs self,
 		allocator: &'alloc Bump,
-		statement: &Statement,
+		_statement: &Statement,
 	) -> Result<WitnessIndex<'cs, 'alloc, P>, Error> {
-		Ok(WitnessIndex {
-			tables: self
-				.tables
-				.iter()
-				.zip(&statement.table_sizes)
-				.map(|(table, &table_size)| {
-					let witness = if table_size > 0 {
-						Some(TableWitnessIndex::new(allocator, table, table_size))
-					} else {
-						None
-					};
-					witness.transpose()
-				})
-				.collect::<Result<_, _>>()?,
-		})
+		Ok(WitnessIndex::new(allocator, &self.tables))
+		// Ok(WitnessIndex {
+		// 	tables: self
+		// 		.tables
+		// 		.iter()
+		// 		.zip(&statement.table_sizes)
+		// 		.map(|(table, &table_size)| {
+		// 			let witness = if table_size > 0 {
+		// 				Some(TableWitnessIndex::new(allocator, table, table_size))
+		// 			} else {
+		// 				None
+		// 			};
+		// 			witness.transpose()
+		// 		})
+		// 		.collect::<Result<_, _>>()?,
+		// })
 	}
 
 	/// Compiles a [`CompiledConstraintSystem`] for a particular statement.

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -147,16 +147,14 @@ impl<F: TowerField> ConstraintSystem<F> {
 		id
 	}
 
-	/// Creates and allocates the witness index for a statement.
+	/// Creates and allocates the witness index.
 	///
-	/// The statement includes information about the tables sizes, which this requires in order to
-	/// allocate the column data correctly. The created witness index needs to be populated before
-	/// proving.
+	/// **Deprecated**: This is a thin wrapper over [`WitnessIndex::new`] now, which is preferred.
 	pub fn build_witness<'cs, 'alloc, P: PackedField<Scalar = F>>(
 		&'cs self,
 		allocator: &'alloc Bump,
-	) -> Result<WitnessIndex<'cs, 'alloc, P>, Error> {
-		Ok(WitnessIndex::new(allocator, &self.tables))
+	) -> WitnessIndex<'cs, 'alloc, P> {
+		WitnessIndex::new(self, allocator)
 	}
 
 	/// Compiles a [`CompiledConstraintSystem`] for a particular statement.

--- a/crates/m3/src/builder/error.rs
+++ b/crates/m3/src/builder/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
 	},
 	#[error("cannot construct witness index for empty table {table_id}")]
 	EmptyTable { table_id: TableId },
+	#[error("table {table_id} index has already been initialized")]
+	TableIndexAlreadyInitialized { table_id: TableId },
 	#[error("column is not in table; column table ID: {column_table_id}, witness table ID: {witness_table_id}")]
 	TableMismatch {
 		column_table_id: TableId,

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -28,7 +28,7 @@ use super::{
 	error::Error,
 	table::{Table, TableId},
 	types::{B1, B128, B16, B32, B64, B8},
-	ColumnDef, ColumnId, ColumnIndex, Expr,
+	ColumnDef, ColumnId, ColumnIndex, ConstraintSystem, Expr,
 };
 use crate::builder::multi_iter::MultiIterator;
 
@@ -51,10 +51,11 @@ where
 }
 
 impl<'cs, 'alloc, F: TowerField, P: PackedField<Scalar = F>> WitnessIndex<'cs, 'alloc, P> {
-	pub fn new(allocator: &'alloc Bump, tables: &'cs [Table<F>]) -> Self {
+	/// Creates and allocates the witness index for a constraint system.
+	pub fn new(cs: &'cs ConstraintSystem<F>, allocator: &'alloc Bump) -> Self {
 		Self {
 			allocator,
-			tables: tables.iter().map(Either::Left).collect(),
+			tables: cs.tables.iter().map(Either::Left).collect(),
 		}
 	}
 
@@ -1321,7 +1322,7 @@ mod tests {
 		let allocator = Bump::new();
 
 		let table_size = 11;
-		let mut index = cs.build_witness(&allocator).unwrap();
+		let mut index = WitnessIndex::new(&cs, &allocator);
 		let table_index = index.init_table(test_table.id(), table_size).unwrap();
 
 		let mut rng = StdRng::seed_from_u64(0);
@@ -1365,7 +1366,7 @@ mod tests {
 		let allocator = Bump::new();
 
 		let table_size = 11;
-		let mut index = cs.build_witness(&allocator).unwrap();
+		let mut index = WitnessIndex::new(&cs, &allocator);
 		let table_index = index.init_table(test_table.id(), table_size).unwrap();
 
 		let mut rng = StdRng::seed_from_u64(0);
@@ -1409,7 +1410,7 @@ mod tests {
 		let allocator = Bump::new();
 
 		let table_size = 11;
-		let mut index = cs.build_witness(&allocator).unwrap();
+		let mut index = WitnessIndex::new(&cs, &allocator);
 
 		index.init_table(test_table.id(), table_size).unwrap();
 

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -1099,7 +1099,7 @@ mod tests {
 	use super::*;
 	use crate::builder::{
 		types::{B1, B32, B8},
-		ConstraintSystem, Statement, TableBuilder,
+		ConstraintSystem, TableBuilder,
 	};
 
 	#[test]
@@ -1314,11 +1314,7 @@ mod tests {
 		let allocator = Bump::new();
 
 		let table_size = 11;
-		let statement = Statement {
-			boundaries: vec![],
-			table_sizes: vec![table_size],
-		};
-		let mut index = cs.build_witness(&allocator, &statement).unwrap();
+		let mut index = cs.build_witness(&allocator).unwrap();
 		let table_index = index.init_table(test_table.id(), table_size).unwrap();
 
 		let mut rng = StdRng::seed_from_u64(0);
@@ -1359,14 +1355,10 @@ mod tests {
 		let mut cs = ConstraintSystem::new();
 		let test_table = TestTable::new(&mut cs);
 
-		let allocator = bumpalo::Bump::new();
+		let allocator = Bump::new();
 
 		let table_size = 11;
-		let statement = Statement {
-			boundaries: vec![],
-			table_sizes: vec![table_size],
-		};
-		let mut index = cs.build_witness(&allocator, &statement).unwrap();
+		let mut index = cs.build_witness(&allocator).unwrap();
 		let table_index = index.init_table(test_table.id(), table_size).unwrap();
 
 		let mut rng = StdRng::seed_from_u64(0);
@@ -1407,14 +1399,10 @@ mod tests {
 		let mut cs = ConstraintSystem::new();
 		let test_table = TestTable::new(&mut cs);
 
-		let allocator = bumpalo::Bump::new();
+		let allocator = Bump::new();
 
 		let table_size = 11;
-		let statement = Statement {
-			boundaries: vec![],
-			table_sizes: vec![table_size],
-		};
-		let mut index = cs.build_witness(&allocator, &statement).unwrap();
+		let mut index = cs.build_witness(&allocator).unwrap();
 
 		index.init_table(test_table.id(), table_size).unwrap();
 

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -138,12 +138,17 @@ impl<'cs, 'alloc, F: TowerField, P: PackedField<Scalar = F>> WitnessIndex<'cs, '
 			}
 			None => Err(Error::MissingTable { table_id }),
 		}
-		// let table_id = table.id();
-		// match self.get_table(table_id) {
-		// 	Some(witness) => witness.fill_parallel(table, rows),
-		// 	None if rows.is_empty() => Ok(()),
-		// 	None => Err(Error::MissingTable { table_id }),
-		// }
+	}
+
+	/// Returns the sizes of all tables in the witness, indexed by table ID.
+	pub fn table_sizes(&self) -> Vec<usize> {
+		self.tables
+			.iter()
+			.map(|entry| match entry {
+				Either::Left(_) => 0,
+				Either::Right(index) => index.size(),
+			})
+			.collect()
 	}
 
 	pub fn into_multilinear_extension_index(self) -> MultilinearExtensionIndex<'alloc, P>

--- a/crates/m3/src/gadgets/hash/groestl.rs
+++ b/crates/m3/src/gadgets/hash/groestl.rs
@@ -408,7 +408,7 @@ mod tests {
 	use rand::{prelude::StdRng, SeedableRng};
 
 	use super::*;
-	use crate::builder::{ConstraintSystem, Statement};
+	use crate::builder::{ConstraintSystem, Statement, WitnessIndex};
 
 	#[test]
 	fn test_sbox() {
@@ -426,9 +426,8 @@ mod tests {
 			boundaries: vec![],
 			table_sizes: vec![1 << 8],
 		};
-		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
-			.unwrap();
+		let mut witness =
+			WitnessIndex::<PackedType<OptimalUnderlier128b, B128>>::new(&cs, &allocator);
 
 		let table_witness = witness.init_table(table_id, 1 << 8).unwrap();
 
@@ -462,9 +461,8 @@ mod tests {
 			boundaries: vec![],
 			table_sizes: vec![1 << 8],
 		};
-		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
-			.unwrap();
+		let mut witness =
+			WitnessIndex::<PackedType<OptimalUnderlier128b, B128>>::new(&cs, &allocator);
 
 		let table_witness = witness.init_table(table_id, 1 << 8).unwrap();
 
@@ -516,9 +514,8 @@ mod tests {
 			boundaries: vec![],
 			table_sizes: vec![1 << 8],
 		};
-		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
-			.unwrap();
+		let mut witness =
+			WitnessIndex::<PackedType<OptimalUnderlier128b, B128>>::new(&cs, &allocator);
 
 		let table_witness = witness.init_table(table_id, 1 << 8).unwrap();
 

--- a/crates/m3/src/gadgets/hash/groestl.rs
+++ b/crates/m3/src/gadgets/hash/groestl.rs
@@ -430,7 +430,7 @@ mod tests {
 			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator, &statement)
 			.unwrap();
 
-		let table_witness = witness.get_table(table_id).unwrap();
+		let table_witness = witness.init_table(table_id, 1 << 8).unwrap();
 
 		let mut rng = StdRng::seed_from_u64(0);
 		let mut segment = table_witness.full_segment();
@@ -466,7 +466,7 @@ mod tests {
 			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator, &statement)
 			.unwrap();
 
-		let table_witness = witness.get_table(table_id).unwrap();
+		let table_witness = witness.init_table(table_id, 1 << 8).unwrap();
 
 		let mut rng = StdRng::seed_from_u64(0);
 		let in_states = repeat_with(|| array::from_fn::<_, 64, _>(|_| B8::random(&mut rng)))
@@ -520,7 +520,7 @@ mod tests {
 			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator, &statement)
 			.unwrap();
 
-		let table_witness = witness.get_table(table_id).unwrap();
+		let table_witness = witness.init_table(table_id, 1 << 8).unwrap();
 
 		let mut rng = StdRng::seed_from_u64(0);
 		let in_states = repeat_with(|| array::from_fn::<_, 64, _>(|_| B8::random(&mut rng)))

--- a/crates/m3/src/gadgets/hash/groestl.rs
+++ b/crates/m3/src/gadgets/hash/groestl.rs
@@ -427,7 +427,7 @@ mod tests {
 			table_sizes: vec![1 << 8],
 		};
 		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator, &statement)
+			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
 			.unwrap();
 
 		let table_witness = witness.init_table(table_id, 1 << 8).unwrap();
@@ -463,7 +463,7 @@ mod tests {
 			table_sizes: vec![1 << 8],
 		};
 		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator, &statement)
+			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
 			.unwrap();
 
 		let table_witness = witness.init_table(table_id, 1 << 8).unwrap();
@@ -517,7 +517,7 @@ mod tests {
 			table_sizes: vec![1 << 8],
 		};
 		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator, &statement)
+			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
 			.unwrap();
 
 		let table_witness = witness.init_table(table_id, 1 << 8).unwrap();

--- a/crates/m3/src/gadgets/lookup.rs
+++ b/crates/m3/src/gadgets/lookup.rs
@@ -138,10 +138,6 @@ mod tests {
 			.sorted_unstable_by_key(|&(_val, count)| Reverse(count))
 			.collect::<Vec<_>>();
 
-		let statement = Statement {
-			boundaries: vec![],
-			table_sizes: vec![lookup_table_size, looker_1_size, looker_2_size],
-		};
 		let allocator = Bump::new();
 		let mut witness = cs
 			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
@@ -192,6 +188,10 @@ mod tests {
 			)
 			.unwrap();
 
+		let statement = Statement {
+			boundaries: vec![],
+			table_sizes: witness.table_sizes(),
+		};
 		let ccs = cs.compile(&statement).unwrap();
 		let witness = witness.into_multilinear_extension_index();
 

--- a/crates/m3/src/gadgets/lookup.rs
+++ b/crates/m3/src/gadgets/lookup.rs
@@ -144,7 +144,7 @@ mod tests {
 		};
 		let allocator = Bump::new();
 		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator, &statement)
+			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
 			.unwrap();
 
 		// Fill the lookup table

--- a/crates/m3/src/gadgets/lookup.rs
+++ b/crates/m3/src/gadgets/lookup.rs
@@ -85,7 +85,7 @@ mod tests {
 	use rand::{rngs::StdRng, Rng, SeedableRng};
 
 	use super::*;
-	use crate::builder::{test_utils::ClosureFiller, ConstraintSystem, Statement};
+	use crate::builder::{test_utils::ClosureFiller, ConstraintSystem, Statement, WitnessIndex};
 
 	#[test]
 	fn test_basic_lookup_producer() {
@@ -139,9 +139,8 @@ mod tests {
 			.collect::<Vec<_>>();
 
 		let allocator = Bump::new();
-		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
-			.unwrap();
+		let mut witness =
+			WitnessIndex::<PackedType<OptimalUnderlier128b, B128>>::new(&cs, &allocator);
 
 		// Fill the lookup table
 		witness

--- a/crates/m3/tests/collatz.rs
+++ b/crates/m3/tests/collatz.rs
@@ -322,7 +322,7 @@ mod arithmetization {
 			table_sizes: vec![trace.evens.len(), trace.odds.len()],
 		};
 		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(allocator, &statement)
+			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(allocator)
 			.unwrap();
 		witness
 			.fill_table_sequential(&evens_table, &trace.evens)

--- a/crates/m3/tests/collatz.rs
+++ b/crates/m3/tests/collatz.rs
@@ -303,6 +303,17 @@ mod arithmetization {
 		let odds_table = OddsTable::new(&mut cs, collatz_orbit);
 
 		let trace = CollatzTrace::generate(3999);
+
+		let mut witness = cs
+			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(allocator)
+			.unwrap();
+		witness
+			.fill_table_sequential(&evens_table, &trace.evens)
+			.unwrap();
+		witness
+			.fill_table_sequential(&odds_table, &trace.odds)
+			.unwrap();
+
 		// TODO: Refactor boundary creation
 		let statement = Statement {
 			boundaries: vec![
@@ -319,18 +330,8 @@ mod arithmetization {
 					multiplicity: 1,
 				},
 			],
-			table_sizes: vec![trace.evens.len(), trace.odds.len()],
+			table_sizes: witness.table_sizes(),
 		};
-		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(allocator)
-			.unwrap();
-		witness
-			.fill_table_sequential(&evens_table, &trace.evens)
-			.unwrap();
-		witness
-			.fill_table_sequential(&odds_table, &trace.odds)
-			.unwrap();
-
 		Instance {
 			constraint_system: cs.compile(&statement).unwrap(),
 			witness: witness.into_multilinear_extension_index(),

--- a/crates/m3/tests/collatz.rs
+++ b/crates/m3/tests/collatz.rs
@@ -112,8 +112,8 @@ mod arithmetization {
 	use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 	use binius_m3::{
 		builder::{
-			Col, ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment, B1, B128,
-			B32,
+			Col, ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment,
+			WitnessIndex, B1, B128, B32,
 		},
 		gadgets::u32::{U32Add, U32AddFlags},
 	};
@@ -304,9 +304,8 @@ mod arithmetization {
 
 		let trace = CollatzTrace::generate(3999);
 
-		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(allocator)
-			.unwrap();
+		let mut witness =
+			WitnessIndex::<PackedType<OptimalUnderlier128b, B128>>::new(&cs, allocator);
 		witness
 			.fill_table_sequential(&evens_table, &trace.evens)
 			.unwrap();

--- a/crates/m3/tests/computed.rs
+++ b/crates/m3/tests/computed.rs
@@ -85,7 +85,7 @@ fn test_m3_computed_col() {
 		table_sizes: vec![N_ROWS],
 	};
 	let mut witness = cs
-		.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator, &statement)
+		.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
 		.unwrap();
 	witness
 		.fill_table_sequential(

--- a/crates/m3/tests/computed.rs
+++ b/crates/m3/tests/computed.rs
@@ -80,10 +80,7 @@ fn test_m3_computed_col() {
 	let allocator = Bump::new();
 	let mut cs = ConstraintSystem::<B128>::new();
 	let table = MyTable::new(&mut cs);
-	let statement = Statement {
-		boundaries: vec![],
-		table_sizes: vec![N_ROWS],
-	};
+
 	let mut witness = cs
 		.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
 		.unwrap();
@@ -96,6 +93,10 @@ fn test_m3_computed_col() {
 		)
 		.unwrap();
 
+	let statement = Statement {
+		boundaries: vec![],
+		table_sizes: witness.table_sizes(),
+	};
 	let constraint_system = cs.compile(&statement).unwrap();
 	let witness = witness.into_multilinear_extension_index();
 

--- a/crates/m3/tests/computed.rs
+++ b/crates/m3/tests/computed.rs
@@ -7,7 +7,7 @@ use binius_field::{
 };
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_m3::builder::{
-	Col, ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment, B128,
+	Col, ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment, WitnessIndex, B128,
 };
 use bumpalo::Bump;
 
@@ -81,9 +81,7 @@ fn test_m3_computed_col() {
 	let mut cs = ConstraintSystem::<B128>::new();
 	let table = MyTable::new(&mut cs);
 
-	let mut witness = cs
-		.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
-		.unwrap();
+	let mut witness = WitnessIndex::<PackedType<OptimalUnderlier128b, B128>>::new(&cs, &allocator);
 	witness
 		.fill_table_sequential(
 			&table,

--- a/crates/m3/tests/fibonacci.rs
+++ b/crates/m3/tests/fibonacci.rs
@@ -295,6 +295,16 @@ mod arithmetization {
 		let fibonacci_table =
 			FibonacciTable::with_table_builder(&mut fib_table_builder, fibonacci_pairs);
 		let trace = FibonacciTrace::generate((0, 1), 31);
+
+		let allocator = Bump::new();
+		let mut witness = cs
+			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
+			.unwrap();
+
+		witness
+			.fill_table_sequential(&fibonacci_table, &trace.rows)
+			.unwrap();
+
 		let statement = Statement {
 			boundaries: vec![
 				Boundary {
@@ -310,17 +320,8 @@ mod arithmetization {
 					multiplicity: 1,
 				},
 			],
-			table_sizes: vec![trace.rows.len()],
+			table_sizes: witness.table_sizes(),
 		};
-		let allocator = Bump::new();
-		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
-			.unwrap();
-
-		witness
-			.fill_table_sequential(&fibonacci_table, &trace.rows)
-			.unwrap();
-
 		compile_validate_prove_verify(&cs, &statement, witness);
 	}
 }

--- a/crates/m3/tests/fibonacci.rs
+++ b/crates/m3/tests/fibonacci.rs
@@ -187,9 +187,8 @@ mod arithmetization {
 			table_sizes: vec![trace.rows.len()],
 		};
 		let allocator = Bump::new();
-		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
-			.unwrap();
+		let mut witness =
+			WitnessIndex::<PackedType<OptimalUnderlier128b, B128>>::new(&cs, &allocator);
 
 		witness
 			.fill_table_sequential(&fibonacci_table, &trace.rows)
@@ -275,9 +274,8 @@ mod arithmetization {
 			table_sizes: vec![trace.rows.len()],
 		};
 		let allocator = Bump::new();
-		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
-			.unwrap();
+		let mut witness =
+			WitnessIndex::<PackedType<OptimalUnderlier128b, B128>>::new(&cs, &allocator);
 
 		witness
 			.fill_table_sequential(&fibonacci_table, &trace.rows)
@@ -297,9 +295,8 @@ mod arithmetization {
 		let trace = FibonacciTrace::generate((0, 1), 31);
 
 		let allocator = Bump::new();
-		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
-			.unwrap();
+		let mut witness =
+			WitnessIndex::<PackedType<OptimalUnderlier128b, B128>>::new(&cs, &allocator);
 
 		witness
 			.fill_table_sequential(&fibonacci_table, &trace.rows)

--- a/crates/m3/tests/fibonacci.rs
+++ b/crates/m3/tests/fibonacci.rs
@@ -188,7 +188,7 @@ mod arithmetization {
 		};
 		let allocator = Bump::new();
 		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator, &statement)
+			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
 			.unwrap();
 
 		witness
@@ -276,7 +276,7 @@ mod arithmetization {
 		};
 		let allocator = Bump::new();
 		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator, &statement)
+			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
 			.unwrap();
 
 		witness
@@ -314,7 +314,7 @@ mod arithmetization {
 		};
 		let allocator = Bump::new();
 		let mut witness = cs
-			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator, &statement)
+			.build_witness::<PackedType<OptimalUnderlier128b, B128>>(&allocator)
 			.unwrap();
 
 		witness

--- a/examples/groestl.rs
+++ b/examples/groestl.rs
@@ -14,7 +14,8 @@ use binius_field::{
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_m3::{
 	builder::{
-		ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment, B1, B128, B8,
+		ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment, WitnessIndex, B1,
+		B128, B8,
 	},
 	gadgets::hash::groestl,
 };
@@ -105,9 +106,7 @@ fn main() -> Result<()> {
 		.collect::<Vec<_>>();
 
 	let trace_gen_scope = tracing::info_span!("generating trace").entered();
-	let mut witness = cs
-		.build_witness::<PackedType<OptimalUnderlier, B128>>(&allocator)
-		.unwrap();
+	let mut witness = WitnessIndex::<PackedType<OptimalUnderlier, B128>>::new(&cs, &allocator);
 	witness.fill_table_sequential(&table, &events)?;
 	drop(trace_gen_scope);
 

--- a/examples/groestl.rs
+++ b/examples/groestl.rs
@@ -106,7 +106,7 @@ fn main() -> Result<()> {
 
 	let trace_gen_scope = tracing::info_span!("generating trace").entered();
 	let mut witness = cs
-		.build_witness::<PackedType<OptimalUnderlier, B128>>(&allocator, &statement)
+		.build_witness::<PackedType<OptimalUnderlier, B128>>(&allocator)
 		.unwrap();
 	witness.fill_table_sequential(&table, &events)?;
 	drop(trace_gen_scope);


### PR DESCRIPTION
Previously all table sizes needed to be specified when the witness index was created. There's enough information in the `fill_table_sequential` and `fill_table_parallel` calls to initialize the table indexes properly, so this change allows the table initialization to use the data from those calls. When creating the `Statement` for constraint system compilation, it's recommended to get the table information from the witness, or in the verifier's case, received from the prover.