### PR TITLE
chore: remove redundant backticks

### DIFF
--- a/crates/core/src/protocols/sumcheck/tests.rs
+++ b/crates/core/src/protocols/sumcheck/tests.rs
@@ -239,7 +239,7 @@ fn test_sumcheck_prove_verify_interaction_basic() {
 	}
 }
 
-/// For small numbers of variables, the [`test_prove_verify_interaction_basic'] test may have so
+/// For small numbers of variables, the [`test_prove_verify_interaction_basic`] test may have so
 /// few vertices to process that each vertex is processed on a separate thread. This ensures that
 /// each Rayon task processes more than one vertex and that accumulation is handled correctly in
 /// that case.

--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -98,7 +98,7 @@ impl TowerField for AESTowerField8b {
 	}
 }
 
-/// Returns true if `F`` is AES tower field.
+/// Returns true if `F` is AES tower field.
 #[inline(always)]
 pub fn is_aes_tower<F: TowerField>() -> bool {
 	TypeId::of::<F>() == TypeId::of::<F>()

--- a/crates/utils/src/checked_arithmetics.rs
+++ b/crates/utils/src/checked_arithmetics.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright (c) 2024 The Plonky3 Authors
 
-/// Division implementation that fails in case when `a`` isn't divisible by `b`
+/// Division implementation that fails in case when `a` isn't divisible by `b`
 pub const fn checked_int_div(a: usize, b: usize) -> usize {
 	let result = a / b;
 	assert!(b * result == a);


### PR DESCRIPTION
remove redundant backticks