### PR TITLE
Add tracing for unbalanced flushes

### DIFF
--- a/crates/core/src/constraint_system/channel.rs
+++ b/crates/core/src/constraint_system/channel.rs
@@ -212,6 +212,14 @@ where
 
 	for (id, channel) in channels.iter().enumerate() {
 		if !channel.is_balanced() {
+			let unbalanced_flushes: Vec<_> = channel
+				.multiplicities
+				.iter()
+				.filter(|(_, &c)| c != 0i64)
+				.collect();
+
+			tracing::debug!("Channel {:?} unbalanced: {:?}", id, unbalanced_flushes);
+
 			return Err((VerificationError::ChannelUnbalanced { id }).into());
 		}
 	}


### PR DESCRIPTION
We noticed it was a bit tedious to debug unbalanced channels as the returned error isn't so descriptive (only the channel ID is mentioned).

I added some tracing to get the unbalanced flushes displayed at the `DEBUG` level. 