### PR TITLE
[piop] Fix failing PIOP case when there are no evaluation claims

### DIFF
--- a/crates/core/src/piop/prove.rs
+++ b/crates/core/src/piop/prove.rs
@@ -237,9 +237,11 @@ where
 	let non_empty_sumcheck_descs = sumcheck_claim_descs
 		.iter()
 		.enumerate()
-		.filter(|(_n_vars, desc)| !desc.composite_sums.is_empty());
+		// Keep sumcheck claims with >0 committed multilinears, even with 0 composite claims. This
+		// indicates unconstrained columns, but we still need the final evaluations from the
+		// sumcheck prover in order to derive the final FRI value.
+		.filter(|(_n_vars, desc)| !desc.committed_indices.is_empty());
 	let sumcheck_provers = non_empty_sumcheck_descs
-		.clone()
 		.map(|(_n_vars, desc)| {
 			let multilins = chain!(
 				packed_committed_multilins[desc.committed_indices.clone()]

--- a/crates/core/src/piop/tests.rs
+++ b/crates/core/src/piop/tests.rs
@@ -223,6 +223,21 @@ fn test_with_one_poly() {
 }
 
 #[test]
+fn test_without_opening_claims() {
+	let commit_meta = CommitMeta::with_vars([4, 4, 6, 7]);
+	let merkle_prover = BinaryMerkleTreeProver::<_, Groestl256, _>::new(Groestl256ByteCompression);
+	let n_transparents = 0;
+	let log_inv_rate = 1;
+
+	commit_prove_verify::<_, BinaryField8b, BinaryField16b, PackedBinaryField2x128b, _>(
+		&commit_meta,
+		n_transparents,
+		&merkle_prover,
+		log_inv_rate,
+	);
+}
+
+#[test]
 fn test_with_one_n_vars() {
 	let commit_meta = CommitMeta::with_vars([4, 4]);
 	let merkle_prover = BinaryMerkleTreeProver::<_, Groestl256, _>::new(Groestl256ByteCompression);

--- a/crates/core/src/piop/verify.rs
+++ b/crates/core/src/piop/verify.rs
@@ -302,7 +302,10 @@ where
 	let non_empty_sumcheck_descs = sumcheck_claim_descs
 		.iter()
 		.enumerate()
-		.filter(|(_n_vars, desc)| !desc.composite_sums.is_empty());
+		// Keep sumcheck claims with >0 committed multilinears, even with 0 composite claims. This
+		// indicates unconstrained columns, but we still need the final evaluations from the
+		// sumcheck prover in order to derive the final FRI value.
+		.filter(|(_n_vars, desc)| !desc.committed_indices.is_empty());
 	let sumcheck_claims = non_empty_sumcheck_descs
 		.clone()
 		.map(|(n_vars, desc)| {


### PR DESCRIPTION
Previously, when a committed column had no evaluation claims, the PIOP compiler would throw a `Math(PiecewiseMultilinearIncompatibleEvals` error. While an unconstrained committed is bad, this should get warned about at a higher level, not throw a confusing error deep in the stack.