### PR TITLE
[circuits] Optimised Blake3 compression

### DIFF
--- a/crates/circuits/src/blake3.rs
+++ b/crates/circuits/src/blake3.rs
@@ -47,13 +47,13 @@ const IV: [u32; 8] = [
 const MSG_PERMUTATION: [usize; 16] = [2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9, 14, 15, 8];
 
 #[derive(Debug, Default, Copy, Clone)]
-struct Blake3CompressState {
-	cv: [u32; 8],
-	block: [u32; 16],
-	counter_low: u32,
-	counter_high: u32,
-	block_len: u32,
-	flags: u32,
+pub struct Blake3CompressState {
+	pub cv: [u32; 8],
+	pub block: [u32; 16],
+	pub counter_low: u32,
+	pub counter_high: u32,
+	pub block_len: u32,
+	pub flags: u32,
 }
 
 pub struct Blake3CompressOracles {
@@ -64,7 +64,7 @@ pub struct Blake3CompressOracles {
 type F32 = BinaryField32b;
 type F1 = BinaryField1b;
 
-fn blake3_compress(
+pub fn blake3_compress(
 	builder: &mut ConstraintSystemBuilder,
 	input_witness: &Option<impl AsRef<[Blake3CompressState]>>,
 	states_amount: usize,

--- a/crates/circuits/src/blake3.rs
+++ b/crates/circuits/src/blake3.rs
@@ -471,7 +471,7 @@ pub fn blake3_compress(
 	/* Constraints */
 
 	// TODO: remove this technical constraint (figure out how to properly constrain the 'state_i_8')
-	builder.assert_zero("state_i_8", [state_i_8], arith_expr!([x] = x - x).convert_field());
+	//builder.assert_zero("state_i_8", [state_i_8], arith_expr!([x] = x - x).convert_field());
 
 	let xins = [a_in, a_0_tmp, c_in, a_0, a_1_tmp, c_0];
 	let yins = [b_in, mx_in, d_0, b_0, my_in, d_1];

--- a/examples/blake3_circuit.rs
+++ b/examples/blake3_circuit.rs
@@ -46,7 +46,6 @@ fn main() -> Result<()> {
 
 	let mut rng = OsRng;
 	let input_witness = (0..args.n_compressions as usize)
-		.into_iter()
 		.map(|_| {
 			let cv: [u32; 8] = array::from_fn(|_| rng.gen::<u32>());
 			let block: [u32; 16] = array::from_fn(|_| rng.gen::<u32>());


### PR DESCRIPTION
This PR re-implements Blake3 compression circuit more optimally for verifier using "horizontal" witness population (inspired by keccakf), which allows proving multiple compressions at once. 

There are couple of questions to reviewers:

1) How should I constrain the `state_i_8` [column](https://github.com/storojs72/binius/blob/as/blake3-horizontal/crates/circuits/src/blake3.rs#L475) properly? Initially, I had a following issue (when running the entire prove / verify example):
```
PIOPCompilerError(Math(PiecewiseMultilinearIncompatibleEvals { actual: 88, expected: 91 }))

or

Error: PIOP compilation error: binius_math error: there are a total of 50 polynomials, according to n_pieces_by_vars, while you have provided evaluations for 53

Caused by:
    0: binius_math error: there are a total of 50 polynomials, according to n_pieces_by_vars, while you have provided evaluations for 53
    1: there are a total of 50 polynomials, according to n_pieces_by_vars, while you have provided evaluations for 53
```


which at high-level says: "You have some column(s) completely or partially unconstrained". I have identified the problem column - its  `state_i_8`, which is a part of [this](https://github.com/storojs72/binius/blob/as/blake3-horizontal/crates/circuits/src/blake3.rs#L106) and [this](https://github.com/storojs72/binius/blob/as/blake3-horizontal/crates/circuits/src/blake3.rs#L106) linear combinations, but I'm not sure what is the problem - so I just left "technical" [constrain](https://github.com/storojs72/binius/blob/as/blake3-horizontal/crates/circuits/src/blake3.rs#L475): `x - x`. Not sure if this is correct.

2) In keccakf circuit, there is a specific selector-based [constrain](https://github.com/storojs72/binius/blob/as/blake3-horizontal/crates/circuits/src/keccakf.rs#L430), which I don't understand actually, and I don't know if I need something similar in Blake3. Let me know please.

3) I experimented with [SeveralU32Add](https://github.com/storojs72/binius/blob/as/blake3-horizontal/crates/circuits/src/lasso/u32add.rs#L49) gadget from lasso lookup package for constraining additions, and it turned out that it is slower than using [regular](https://github.com/storojs72/binius/blob/as/blake3-horizontal/crates/circuits/src/arithmetic/u32.rs#L88) one. Could You please elaborate, what is the benefit of SeveralU32Add and under what conditions it might be better?