### PR TITLE
SYS-110: compute API supports host buffer management, allocation

### DIFF
--- a/crates/compute/src/alloc.rs
+++ b/crates/compute/src/alloc.rs
@@ -2,87 +2,87 @@
 
 use std::cell::Cell;
 
-use super::memory::{ComputeMemory, DevSlice};
-
-pub trait ComputeBufferAllocator<'a, 'b, F, Mem>
+use crate::memory::{ComputeMemoryOperations, ComputeMemoryTypes, OpaqueSlice};
+/// A trait for allocating slices from a compute memory buffer.
+///
+/// This trait provides an interface for allocating fixed-size slices from an underlying
+/// memory buffer, such as device memory or host memory. The allocator maintains ownership
+/// of the buffer and hands out slices with lifetimes tied to the allocator.
+///
+/// # Type Parameters
+///
+/// - `'a`: The lifetime of the allocator and allocated slices
+/// - `F`: The element type stored in the buffer
+/// - `Mem`: The memory types trait defining slice representations
+/// - `MemOperations`: The memory operations trait for manipulating slices
+///
+/// # Safety
+///
+/// Implementations must ensure:
+/// - Allocated slices do not overlap
+/// - Slice lengths are valid multiples of `Mem::MIN_SLICE_LEN`
+/// - Slices remain valid for their full lifetime
+/// - The total allocation size does not exceed the underlying buffer
+pub trait ComputeBufferAllocator<'a, F, Mem, MemOperations>
 where
-	Mem: ComputeMemory<F>,
+	Mem: ComputeMemoryTypes<F>,
+	MemOperations: ComputeMemoryOperations<F, Mem>,
 {
-	/// Allocates a slice of elements in device memory for use in compute kernels.
+	/// Allocates a slice of elements.
 	///
 	/// This method operates on an immutable self reference so that multiple allocator references
 	/// can co-exist.
 	///
 	/// ## Pre-conditions
 	///
-	/// - `n` must be a multiple of `Mem::MIN_DEVICE_SLICE_LEN`
-	fn alloc_device(&self, n: usize) -> Result<Mem::FSliceMut<'a>, Error>;
-
-	/// Allocates a slice of elements in host memory that can be transferred to and from device memory.
-	///
-	/// Aligns the allocated host memory to support transfers to and from device memory.
-	///
-	/// ## Pre-conditions
-	///
-	/// - `n` must be a multiple of `Mem::MIN_HOST_SLICE_LEN`
-	fn alloc_host(&self, n: usize) -> Result<Mem::HostSliceMut<'b>, Error>;
+	/// - `n` must be a multiple of `Mem::MIN_SLICE_LEN`
+	fn alloc(&self, n: usize) -> Result<Mem::FSliceMut<'a>, Error>;
 }
 
 /// Basic bump allocator that allocates slices from an underlying memory buffer provided at
 /// construction.
-pub struct BumpAllocator<'a, 'b, F, Mem: ComputeMemory<F>> {
-	device_buffer: Cell<Option<Mem::FSliceMut<'a>>>,
-	host_buffer: Cell<Option<Mem::HostSliceMut<'b>>>,
+pub struct BumpAllocator<
+	'a,
+	F,
+	Mem: ComputeMemoryTypes<F>,
+	MemOperations: ComputeMemoryOperations<F, Mem>,
+> {
+	buffer: Cell<Option<Mem::FSliceMut<'a>>>,
+	_phantom: std::marker::PhantomData<fn() -> MemOperations>,
 }
 
-impl<'a, 'b, F, Mem> BumpAllocator<'a, 'b, F, Mem>
+impl<'a, F, Mem, MemOperations> BumpAllocator<'a, F, Mem, MemOperations>
 where
-	F: 'static,
-	Mem: ComputeMemory<F>,
+	Mem: ComputeMemoryTypes<F>,
+	MemOperations: ComputeMemoryOperations<F, Mem>,
 {
-	pub fn new(device_buffer: Mem::FSliceMut<'a>, host_buffer: Mem::HostSliceMut<'b>) -> Self {
+	pub fn new(buffer: Mem::FSliceMut<'a>) -> Self {
 		Self {
-			device_buffer: Cell::new(Some(device_buffer)),
-			host_buffer: Cell::new(Some(host_buffer)),
+			buffer: Cell::new(Some(buffer)),
+			_phantom: std::marker::PhantomData,
 		}
 	}
 }
 
-impl<'a, 'b, F, Mem> ComputeBufferAllocator<'a, 'b, F, Mem> for BumpAllocator<'a, 'b, F, Mem>
+impl<'a, F, Mem, MemOperations> ComputeBufferAllocator<'a, F, Mem, MemOperations>
+	for BumpAllocator<'a, F, Mem, MemOperations>
 where
-	F: 'static,
-	Mem: ComputeMemory<F>,
+	Mem: ComputeMemoryTypes<F>,
+	MemOperations: ComputeMemoryOperations<F, Mem>,
 {
-	fn alloc_device(&self, n: usize) -> Result<Mem::FSliceMut<'a>, Error> {
+	fn alloc(&self, n: usize) -> Result<Mem::FSliceMut<'a>, Error> {
 		let buffer = self
-			.device_buffer
+			.buffer
 			.take()
-			.expect("device_buffer is always Some by invariant");
+			.expect("buffer is always Some by invariant");
 		// buffer temporarily contains None
 		if buffer.len() < n {
-			self.device_buffer.set(Some(buffer));
+			self.buffer.set(Some(buffer));
 			// buffer contains Some, invariant restored
 			Err(Error::OutOfMemory)
 		} else {
-			let (lhs, rhs) = Mem::device_split_at_mut(buffer, n.max(Mem::MIN_DEVICE_SLICE_LEN));
-			self.device_buffer.set(Some(rhs));
-			// buffer contains Some, invariant restored
-			Ok(lhs)
-		}
-	}
-
-	fn alloc_host(&self, n: usize) -> Result<Mem::HostSliceMut<'b>, Error> {
-		let mut buffer = self
-			.host_buffer
-			.take()
-			.expect("host_buffer is always Some by invariant");
-		if buffer.as_mut().len() < n {
-			self.host_buffer.set(Some(buffer));
-			// buffer contains Some, invariant restored
-			Err(Error::OutOfMemory)
-		} else {
-			let (lhs, rhs) = Mem::host_split_at_mut(buffer, n.max(Mem::MIN_HOST_SLICE_LEN));
-			self.host_buffer.set(Some(rhs));
+			let (lhs, rhs) = MemOperations::split_at_mut(buffer, n.max(Mem::MIN_SLICE_LEN));
+			self.buffer.set(Some(rhs));
 			// buffer contains Some, invariant restored
 			Ok(lhs)
 		}
@@ -100,36 +100,23 @@ mod tests {
 	use assert_matches::assert_matches;
 
 	use super::*;
-	use crate::cpu::memory::CpuMemory;
+	use crate::cpu::memory::{CpuMemory, CpuMemoryTypes};
 
 	#[test]
 	fn test_alloc() {
-		let mut device_data = (0..256u128).collect::<Vec<_>>();
-		let mut host_data = (0..256u128).collect::<Vec<_>>();
+		let mut data = (0..256u128).collect::<Vec<_>>();
+
 		{
-			let bump = BumpAllocator::<u128, CpuMemory>::new(&mut device_data, &mut host_data);
-			let first_device_alloc = bump.alloc_device(100).unwrap();
-			let first_host_alloc = bump.alloc_host(200).unwrap();
-			assert_eq!(first_device_alloc.len(), 100);
-			assert_eq!(first_host_alloc.len(), 200);
-
-			// Assert that the device and host allocations are obtained from separate buffers
-			assert_eq!(first_device_alloc[0], first_host_alloc[0]);
-			first_host_alloc[0] += 1;
-			assert_ne!(first_device_alloc[0], first_host_alloc[0]);
-
-			assert_eq!(bump.alloc_device(100).unwrap().len(), 100);
-			assert_matches!(bump.alloc_device(100), Err(Error::OutOfMemory));
+			let bump = BumpAllocator::<u128, CpuMemoryTypes, CpuMemory>::new(&mut data);
+			assert_eq!(bump.alloc(100).unwrap().len(), 100);
+			assert_eq!(bump.alloc(100).unwrap().len(), 100);
+			assert_matches!(bump.alloc(100), Err(Error::OutOfMemory));
 			// Release memory all at once.
 		}
 
 		// Reuse memory
-		let bump = BumpAllocator::<u128, CpuMemory>::new(&mut device_data, &mut host_data);
-		let device_data = bump.alloc_device(100).unwrap();
-		let host_data = bump.alloc_host(200).unwrap();
-		assert_eq!(device_data.len(), 100);
-		assert_eq!(host_data.len(), 200);
-		assert_eq!(0, device_data[0]);
-		assert_eq!(1, host_data[0]);
+		let bump = BumpAllocator::<u128, CpuMemoryTypes, CpuMemory>::new(&mut data);
+		let data = bump.alloc(100).unwrap();
+		assert_eq!(data.len(), 100);
 	}
 }

--- a/crates/compute/src/cpu/memory.rs
+++ b/crates/compute/src/cpu/memory.rs
@@ -2,25 +2,37 @@
 
 use std::{collections::Bound, ops::RangeBounds};
 
-use crate::memory::ComputeMemory;
+use crate::{
+	alloc::BumpAllocator,
+	memory::{
+		ComputeMemoryOperations, ComputeMemorySuite, ComputeMemoryTypes, ComputeMemoryTypesHost,
+	},
+};
 
 #[derive(Debug)]
-pub struct CpuMemory;
+pub struct CpuMemoryTypes {}
 
-impl<F: 'static> ComputeMemory<F> for CpuMemory {
-	const MIN_DEVICE_SLICE_LEN: usize = 1;
-	const MIN_HOST_SLICE_LEN: usize = 1;
-
+impl<F: 'static> ComputeMemoryTypes<F> for CpuMemoryTypes {
+	const MIN_SLICE_LEN: usize = 1;
 	type FSlice<'a> = &'a [F];
 	type FSliceMut<'a> = &'a mut [F];
-	type HostSlice<'a> = &'a [F];
-	type HostSliceMut<'a> = &'a mut [F];
+}
 
-	fn as_const<'a>(data: &'a &mut [F]) -> &'a [F] {
-		data
+impl<F: 'static> ComputeMemoryTypesHost<F> for CpuMemoryTypes {}
+
+pub struct CpuMemory {}
+
+impl<F: 'static> ComputeMemoryOperations<F, CpuMemoryTypes> for CpuMemory {
+	fn as_const<'a>(
+		data: &'a <CpuMemoryTypes as ComputeMemoryTypes<F>>::FSliceMut<'_>,
+	) -> <CpuMemoryTypes as ComputeMemoryTypes<F>>::FSlice<'a> {
+		*data
 	}
 
-	fn device_slice(data: Self::FSlice<'_>, range: impl RangeBounds<usize>) -> Self::FSlice<'_> {
+	fn slice(
+		data: <CpuMemoryTypes as ComputeMemoryTypes<F>>::FSlice<'_>,
+		range: impl RangeBounds<usize>,
+	) -> <CpuMemoryTypes as ComputeMemoryTypes<F>>::FSlice<'_> {
 		let start = match range.start_bound() {
 			Bound::Included(&start) => start,
 			Bound::Excluded(&start) => start + 1,
@@ -34,7 +46,7 @@ impl<F: 'static> ComputeMemory<F> for CpuMemory {
 		&data[start..end]
 	}
 
-	fn device_slice_mut<'a>(data: &'a mut &mut [F], range: impl RangeBounds<usize>) -> &'a mut [F] {
+	fn slice_mut<'a>(data: &'a mut &mut [F], range: impl RangeBounds<usize>) -> &'a mut [F] {
 		let start = match range.start_bound() {
 			Bound::Included(&start) => start,
 			Bound::Excluded(&start) => start + 1,
@@ -48,43 +60,56 @@ impl<F: 'static> ComputeMemory<F> for CpuMemory {
 		&mut data[start..end]
 	}
 
-	fn device_split_at_mut(
-		data: Self::FSliceMut<'_>,
+	fn split_at_mut(
+		data: <CpuMemoryTypes as ComputeMemoryTypes<F>>::FSliceMut<'_>,
 		mid: usize,
-	) -> (Self::FSliceMut<'_>, Self::FSliceMut<'_>) {
+	) -> (
+		<CpuMemoryTypes as ComputeMemoryTypes<F>>::FSliceMut<'_>,
+		<CpuMemoryTypes as ComputeMemoryTypes<F>>::FSliceMut<'_>,
+	) {
 		data.split_at_mut(mid)
 	}
+}
 
-	fn host_slice(
-		data: Self::HostSlice<'_>,
-		range: impl RangeBounds<usize>,
-	) -> Self::HostSlice<'_> {
-		Self::device_slice(data, range)
+struct CpuComputeMemorySuite {}
+
+impl<'a, 'b, F: 'static + Copy> ComputeMemorySuite<'a, 'b, F> for CpuComputeMemorySuite {
+	type HostComputeMemoryOperations = CpuMemory;
+	type HostAllocator = BumpAllocator<'a, F, CpuMemoryTypes, CpuMemory>;
+	type DeviceComputeMemoryOperations = CpuMemory;
+	type DeviceAllocator = BumpAllocator<'b, F, CpuMemoryTypes, CpuMemory>;
+	type MemTypesHost = CpuMemoryTypes;
+	type MemTypesDevice = CpuMemoryTypes;
+
+	fn copy_host_to_device(
+		host_slice: <CpuMemoryTypes as ComputeMemoryTypes<F>>::FSlice<'_>,
+		device_slice: &mut <CpuMemoryTypes as ComputeMemoryTypes<F>>::FSliceMut<'_>,
+	) {
+		// TODO consider implementing a copy-on-write mechanism for CpuComputeMemorySuite to skip copying data until the original
+		// version is modified.
+		device_slice.as_mut().copy_from_slice(host_slice.as_ref());
 	}
 
-	fn host_slice_mut<'a>(data: &'a mut &mut [F], range: impl RangeBounds<usize>) -> &'a mut [F] {
-		Self::device_slice_mut(data, range)
-	}
-
-	fn host_split_at_mut(
-		data: Self::HostSliceMut<'_>,
-		mid: usize,
-	) -> (Self::HostSliceMut<'_>, Self::HostSliceMut<'_>) {
-		Self::device_split_at_mut(data, mid)
+	fn copy_device_to_host(
+		device_slice: <CpuMemoryTypes as ComputeMemoryTypes<F>>::FSlice<'_>,
+		host_slice: &mut <CpuMemoryTypes as ComputeMemoryTypes<F>>::FSliceMut<'_>,
+	) {
+		host_slice.as_mut().copy_from_slice(device_slice.as_ref());
 	}
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::alloc::ComputeBufferAllocator;
 
 	#[test]
 	fn test_try_slice_on_mem_slice() {
 		let data = [4, 5, 6];
-		assert_eq!(CpuMemory::device_slice(&data, 0..2), &data[0..2]);
-		assert_eq!(CpuMemory::device_slice(&data, ..2), &data[..2]);
-		assert_eq!(CpuMemory::device_slice(&data, 1..), &data[1..]);
-		assert_eq!(CpuMemory::device_slice(&data, ..), &data[..]);
+		assert_eq!(CpuMemory::slice(&data, 0..2), &data[0..2]);
+		assert_eq!(CpuMemory::slice(&data, ..2), &data[..2]);
+		assert_eq!(CpuMemory::slice(&data, 1..), &data[1..]);
+		assert_eq!(CpuMemory::slice(&data, ..), &data[..]);
 	}
 
 	#[test]
@@ -100,10 +125,45 @@ mod tests {
 	fn test_try_slice_on_mut_mem_slice() {
 		let mut data = [4, 5, 6];
 		let mut data_clone = data;
-		let mut data = &mut data[..];
-		assert_eq!(CpuMemory::device_slice_mut(&mut data, 0..2), &mut data_clone[0..2]);
-		assert_eq!(CpuMemory::device_slice_mut(&mut data, ..2), &mut data_clone[..2]);
-		assert_eq!(CpuMemory::device_slice_mut(&mut data, 1..), &mut data_clone[1..]);
-		assert_eq!(CpuMemory::device_slice_mut(&mut data, ..), &mut data_clone[..]);
+		let data = &mut data[..];
+		assert_eq!(CpuMemory::slice(data, 0..2), &mut data_clone[0..2]);
+		assert_eq!(CpuMemory::slice(data, ..2), &mut data_clone[..2]);
+		assert_eq!(CpuMemory::slice(data, 1..), &mut data_clone[1..]);
+		assert_eq!(CpuMemory::slice(data, ..), &mut data_clone[..]);
+	}
+
+	fn run_alloc_and_copy_roundtrip<'a, 'b, Suite: ComputeMemorySuite<'a, 'b, u128>>(
+		host_allocator: &Suite::HostAllocator,
+		device_allocator: &Suite::DeviceAllocator,
+	) {
+		const BUFFER_SIZE: usize = 4;
+		let mut host_source_data = host_allocator.alloc(BUFFER_SIZE).unwrap();
+		let mut host_dest_data = host_allocator.alloc(BUFFER_SIZE).unwrap();
+		let mut device_data = device_allocator.alloc(BUFFER_SIZE).unwrap();
+		for idx in 0..BUFFER_SIZE {
+			host_source_data.as_mut()[idx] = idx as u128 + 1024;
+			assert_ne!(host_dest_data.as_mut()[idx], host_source_data.as_mut()[idx]);
+		}
+		Suite::copy_host_to_device(
+			Suite::HostComputeMemoryOperations::as_const(&host_source_data),
+			&mut device_data,
+		);
+		Suite::copy_device_to_host(
+			Suite::DeviceComputeMemoryOperations::as_const(&device_data),
+			&mut host_dest_data,
+		);
+		for idx in 0..BUFFER_SIZE {
+			assert_eq!(host_source_data.as_mut()[idx], host_dest_data.as_mut()[idx]);
+		}
+	}
+
+	#[test]
+	fn test_alloc_and_copy_roundtrip() {
+		let mut host_data = (0..256u128).collect::<Vec<_>>();
+		let mut device_data = (0..256u128).collect::<Vec<_>>();
+		let host_allocator = BumpAllocator::<u128, CpuMemoryTypes, CpuMemory>::new(&mut host_data);
+		let device_allocator =
+			BumpAllocator::<u128, CpuMemoryTypes, CpuMemory>::new(&mut device_data);
+		run_alloc_and_copy_roundtrip::<CpuComputeMemorySuite>(&host_allocator, &device_allocator);
 	}
 }

--- a/crates/compute/src/memory.rs
+++ b/crates/compute/src/memory.rs
@@ -24,13 +24,20 @@ impl<T> DevSlice<T> for &mut [T] {
 
 /// Interface for manipulating handles to memory in a compute device.
 pub trait ComputeMemory<F> {
-	const MIN_SLICE_LEN: usize;
+	const MIN_DEVICE_SLICE_LEN: usize;
+	const MIN_HOST_SLICE_LEN: usize;
 
 	/// An opaque handle to an immutable slice of elements stored in a compute memory.
 	type FSlice<'a>: Copy + DevSlice<F>;
 
 	/// An opaque handle to a mutable slice of elements stored in a compute memory.
 	type FSliceMut<'a>: DevSlice<F>;
+
+	/// A transparent handle to immutable host memory
+	type HostSlice<'a>: AsRef<[F]>;
+
+	/// A transparent handle to mutable host memory
+	type HostSliceMut<'a>: AsMut<[F]>;
 
 	/// Borrows a mutable memory slice as immutable.
 	///
@@ -41,34 +48,70 @@ pub trait ComputeMemory<F> {
 	///
 	/// ## Preconditions
 	///
-	/// - the range bounds must be multiples of [`Self::MIN_SLICE_LEN`]
-	fn slice(data: Self::FSlice<'_>, range: impl RangeBounds<usize>) -> Self::FSlice<'_>;
+	/// - the range bounds must be multiples of [`Self::MIN_DEVICE_SLICE_LEN`]
+	fn device_slice(data: Self::FSlice<'_>, range: impl RangeBounds<usize>) -> Self::FSlice<'_>;
+
+	/// Borrows a subslice of an immutable memory slice.
+	///
+	/// ## Preconditions
+	///
+	/// - the range bounds must be multiples of [`Self::MIN_HOST_SLICE_LEN`]
+	fn host_slice(data: Self::HostSlice<'_>, range: impl RangeBounds<usize>)
+		-> Self::HostSlice<'_>;
 
 	/// Borrows a subslice of a mutable memory slice.
 	///
 	/// ## Preconditions
 	///
-	/// - the range bounds must be multiples of [`Self::MIN_SLICE_LEN`]
-	fn slice_mut<'a>(
+	/// - the range bounds must be multiples of [`Self::MIN_DEVICE_SLICE_LEN`]
+	fn device_slice_mut<'a>(
 		data: &'a mut Self::FSliceMut<'_>,
 		range: impl RangeBounds<usize>,
 	) -> Self::FSliceMut<'a>;
+
+	/// Borrows a subslice of a mutable memory slice.
+	///
+	/// ## Preconditions
+	///
+	/// - the range bounds must be multiples of [`Self::MIN_HOST_SLICE_LEN`]
+	fn host_slice_mut<'a>(
+		data: &'a mut Self::HostSliceMut<'_>,
+		range: impl RangeBounds<usize>,
+	) -> Self::HostSliceMut<'a>;
 
 	/// Splits a mutable slice into two disjoint subslices.
 	///
 	/// ## Preconditions
 	///
-	/// - `mid` must be a multiple of [`Self::MIN_SLICE_LEN`]
-	fn split_at_mut(
+	/// - `mid` must be a multiple of [`Self::MIN_DEVICE_SLICE_LEN`]
+	fn device_split_at_mut(
 		data: Self::FSliceMut<'_>,
 		mid: usize,
 	) -> (Self::FSliceMut<'_>, Self::FSliceMut<'_>);
 
-	fn split_at_mut_borrowed<'a>(
+	fn device_split_at_mut_borrowed<'a>(
 		data: &'a mut Self::FSliceMut<'_>,
 		mid: usize,
 	) -> (Self::FSliceMut<'a>, Self::FSliceMut<'a>) {
-		let borrowed = Self::slice_mut(data, ..);
-		Self::split_at_mut(borrowed, mid)
+		let borrowed = Self::device_slice_mut(data, ..);
+		Self::device_split_at_mut(borrowed, mid)
+	}
+
+	/// Splits a mutable slice into two disjoint subslices.
+	///
+	/// ## Preconditions
+	///
+	/// - `mid` must be a multiple of [`Self::MIN_HOST_SLICE_LEN`]
+	fn host_split_at_mut(
+		data: Self::HostSliceMut<'_>,
+		mid: usize,
+	) -> (Self::HostSliceMut<'_>, Self::HostSliceMut<'_>);
+
+	fn host_split_at_mut_borrowed<'a>(
+		data: &'a mut Self::HostSliceMut<'_>,
+		mid: usize,
+	) -> (Self::HostSliceMut<'a>, Self::HostSliceMut<'a>) {
+		let borrowed = Self::host_slice_mut(data, ..);
+		Self::host_split_at_mut(borrowed, mid)
 	}
 }

--- a/crates/compute/src/memory.rs
+++ b/crates/compute/src/memory.rs
@@ -2,7 +2,18 @@
 
 use std::ops::RangeBounds;
 
-pub trait DevSlice<T> {
+use crate::alloc::ComputeBufferAllocator;
+
+/// A trait for types that behave like slices but may have different underlying representations.
+///
+/// This trait provides basic slice-like operations that work across different memory types
+/// and compute devices. It abstracts over the specific slice implementation while maintaining
+/// core slice functionality like length checks.
+///
+/// The trait is used as a bound on memory types to ensure they provide basic slice operations
+/// regardless of their internal representation and accessibility from instructions executing
+/// on the host.
+pub trait OpaqueSlice<T> {
 	fn is_empty(&self) -> bool {
 		self.len() == 0
 	}
@@ -10,108 +21,165 @@ pub trait DevSlice<T> {
 	fn len(&self) -> usize;
 }
 
-impl<T> DevSlice<T> for &[T] {
+impl<T> OpaqueSlice<T> for &[T] {
 	fn len(&self) -> usize {
 		(**self).len()
 	}
 }
 
-impl<T> DevSlice<T> for &mut [T] {
+impl<T> OpaqueSlice<T> for &mut [T] {
 	fn len(&self) -> usize {
 		(**self).len()
 	}
 }
 
-/// Interface for manipulating handles to memory in a compute device.
-pub trait ComputeMemory<F> {
-	const MIN_DEVICE_SLICE_LEN: usize;
-	const MIN_HOST_SLICE_LEN: usize;
+/// A trait defining the memory types and slice representations for a compute device.
+///
+/// This trait specifies the slice types and minimum slice length requirements for memory
+/// that can be used with a particular compute device (e.g. CPU, GPU).
+///
+/// The generic parameter `F` represents the element type stored in the memory.
+///
+/// # Type Parameters
+///
+/// - `FSlice<'a>`: The immutable slice type for this memory, must implement `OpaqueSlice<F>`
+/// - `FSliceMut<'a>`: The mutable slice type for this memory, must implement `OpaqueSlice<F>`
+///
+/// # Associated Constants
+///
+/// - `MIN_SLICE_LEN`: The minimum allowed length for slices of this memory type. Memory
+///   operations must use slice lengths that are multiples of this value.
+pub trait ComputeMemoryTypes<F> {
+	type FSlice<'a>: OpaqueSlice<F>;
+	type FSliceMut<'a>: OpaqueSlice<F>;
+	const MIN_SLICE_LEN: usize;
+}
 
-	/// An opaque handle to an immutable slice of elements stored in a compute memory.
-	type FSlice<'a>: Copy + DevSlice<F>;
-
-	/// An opaque handle to a mutable slice of elements stored in a compute memory.
-	type FSliceMut<'a>: DevSlice<F>;
-
-	/// A transparent handle to immutable host memory
-	type HostSlice<'a>: AsRef<[F]>;
-
-	/// A transparent handle to mutable host memory
-	type HostSliceMut<'a>: AsMut<[F]>;
-
+/// A trait defining memory operations that can be performed on compute device memory.
+///
+/// This trait provides a common interface for performing slice operations on memory,
+/// regardless of whether it is host-accessible or device-accessible. The operations
+/// include converting between mutable and immutable views, taking subslices, and
+/// splitting slices.
+///
+/// # Type Parameters
+///
+/// - `F`: The element type stored in memory
+/// - `MemTypes`: The memory types trait defining the slice representations
+///
+/// # Safety
+///
+/// Implementations must ensure:
+/// - All slice operations maintain proper alignment and size requirements
+/// - Mutable slices have exclusive access to their memory regions
+/// - Range bounds in slice operations are valid for the underlying memory
+/// - Split operations produce non-overlapping slices
+pub trait ComputeMemoryOperations<F, MemTypes: ComputeMemoryTypes<F>> {
 	/// Borrows a mutable memory slice as immutable.
 	///
 	/// This allows the immutable reference to be copied.
-	fn as_const<'a>(data: &'a Self::FSliceMut<'_>) -> Self::FSlice<'a>;
+	fn as_const<'a>(data: &'a MemTypes::FSliceMut<'_>) -> MemTypes::FSlice<'a>;
 
 	/// Borrows a subslice of an immutable memory slice.
 	///
 	/// ## Preconditions
 	///
-	/// - the range bounds must be multiples of [`Self::MIN_DEVICE_SLICE_LEN`]
-	fn device_slice(data: Self::FSlice<'_>, range: impl RangeBounds<usize>) -> Self::FSlice<'_>;
-
-	/// Borrows a subslice of an immutable memory slice.
-	///
-	/// ## Preconditions
-	///
-	/// - the range bounds must be multiples of [`Self::MIN_HOST_SLICE_LEN`]
-	fn host_slice(data: Self::HostSlice<'_>, range: impl RangeBounds<usize>)
-		-> Self::HostSlice<'_>;
+	/// - the range bounds must be multiples of `MemTypes::MIN_SLICE_LEN`
+	fn slice(data: MemTypes::FSlice<'_>, range: impl RangeBounds<usize>) -> MemTypes::FSlice<'_>;
 
 	/// Borrows a subslice of a mutable memory slice.
 	///
 	/// ## Preconditions
 	///
-	/// - the range bounds must be multiples of [`Self::MIN_DEVICE_SLICE_LEN`]
-	fn device_slice_mut<'a>(
-		data: &'a mut Self::FSliceMut<'_>,
+	/// - the range bounds must be multiples of `MemTypes::MIN_SLICE_LEN`
+	fn slice_mut<'a>(
+		data: &'a mut MemTypes::FSliceMut<'_>,
 		range: impl RangeBounds<usize>,
-	) -> Self::FSliceMut<'a>;
-
-	/// Borrows a subslice of a mutable memory slice.
-	///
-	/// ## Preconditions
-	///
-	/// - the range bounds must be multiples of [`Self::MIN_HOST_SLICE_LEN`]
-	fn host_slice_mut<'a>(
-		data: &'a mut Self::HostSliceMut<'_>,
-		range: impl RangeBounds<usize>,
-	) -> Self::HostSliceMut<'a>;
+	) -> MemTypes::FSliceMut<'a>;
 
 	/// Splits a mutable slice into two disjoint subslices.
 	///
 	/// ## Preconditions
 	///
-	/// - `mid` must be a multiple of [`Self::MIN_DEVICE_SLICE_LEN`]
-	fn device_split_at_mut(
-		data: Self::FSliceMut<'_>,
+	/// - `mid` must be a multiple of `MemTypes::MIN_SLICE_LEN`
+	fn split_at_mut(
+		data: MemTypes::FSliceMut<'_>,
 		mid: usize,
-	) -> (Self::FSliceMut<'_>, Self::FSliceMut<'_>);
+	) -> (MemTypes::FSliceMut<'_>, MemTypes::FSliceMut<'_>);
 
-	fn device_split_at_mut_borrowed<'a>(
-		data: &'a mut Self::FSliceMut<'_>,
+	fn split_at_mut_borrowed<'a>(
+		data: &'a mut MemTypes::FSliceMut<'_>,
 		mid: usize,
-	) -> (Self::FSliceMut<'a>, Self::FSliceMut<'a>) {
-		let borrowed = Self::device_slice_mut(data, ..);
-		Self::device_split_at_mut(borrowed, mid)
+	) -> (MemTypes::FSliceMut<'a>, MemTypes::FSliceMut<'a>) {
+		let borrowed = Self::slice_mut(data, ..);
+		Self::split_at_mut(borrowed, mid)
 	}
+}
 
-	/// Splits a mutable slice into two disjoint subslices.
-	///
-	/// ## Preconditions
-	///
-	/// - `mid` must be a multiple of [`Self::MIN_HOST_SLICE_LEN`]
-	fn host_split_at_mut(
-		data: Self::HostSliceMut<'_>,
-		mid: usize,
-	) -> (Self::HostSliceMut<'_>, Self::HostSliceMut<'_>);
+/// A trait for host-side memory types that can be accessed as Rust slices.
+///
+/// This trait extends [`ComputeMemoryTypes`] to require that the slice types can be converted
+/// to standard Rust slices via [`AsRef`] and [`AsMut`]. This enables direct access to the
+/// underlying memory on the host side.
+///
+/// Host memory types are used for data that needs to be accessed directly by the CPU, as opposed
+/// to device memory which may live in a separate address space (e.g. GPU memory).
+pub trait ComputeMemoryTypesHost<F>: ComputeMemoryTypes<F>
+where
+	for<'a> Self::FSlice<'a>: AsRef<[F]>,
+	for<'a> Self::FSliceMut<'a>: AsMut<[F]>,
+{
+}
 
-	fn host_split_at_mut_borrowed<'a>(
-		data: &'a mut Self::HostSliceMut<'_>,
-		mid: usize,
-	) -> (Self::HostSliceMut<'a>, Self::HostSliceMut<'a>) {
-		let borrowed = Self::host_slice_mut(data, ..);
-		Self::host_split_at_mut(borrowed, mid)
-	}
+/// A trait that defines a complete memory management suite for a compute device.
+///
+/// This trait combines host and device memory types, memory operations, and allocators into a
+/// single abstraction that can be used to manage memory across the host-device boundary.
+///
+/// The type parameters are:
+/// - `'a`: lifetime of host memory allocations
+/// - `'b`: lifetime of device memory allocations  
+/// - `F`: the field element type being stored
+///
+/// The associated types define:
+/// - `MemTypesHost`: Memory types for host-accessible memory
+/// - `MemTypesDevice`: Memory types for device-accessible memory
+/// - `HostComputeMemoryOperations`: Operations on host memory
+/// - `HostAllocator`: Allocator for host memory
+/// - `DeviceComputeMemoryOperations`: Operations on device memory  
+/// - `DeviceAllocator`: Allocator for device memory
+///
+/// The trait provides methods to copy data between host and device memory.
+pub trait ComputeMemorySuite<'a, 'b, F: Copy>
+where
+	for<'c> <<Self as ComputeMemorySuite<'a, 'b, F>>::MemTypesHost as ComputeMemoryTypes<F>>::FSlice<'c>:
+		AsRef<[F]>,
+	for<'c> <<Self as ComputeMemorySuite<'a, 'b, F>>::MemTypesHost as ComputeMemoryTypes<F>>::FSliceMut<'c>:
+		AsMut<[F]>,
+{
+	type MemTypesHost: ComputeMemoryTypesHost<F>;
+	type MemTypesDevice: ComputeMemoryTypes<F>;
+	type HostComputeMemoryOperations: ComputeMemoryOperations<F, Self::MemTypesHost>;
+	type HostAllocator: ComputeBufferAllocator<
+		'a,
+		F,
+		Self::MemTypesHost,
+		Self::HostComputeMemoryOperations,
+	>;
+	type DeviceComputeMemoryOperations: ComputeMemoryOperations<F, Self::MemTypesDevice>;
+	type DeviceAllocator: ComputeBufferAllocator<
+		'b,
+		F,
+		Self::MemTypesDevice,
+		Self::DeviceComputeMemoryOperations,
+	>;
+
+	fn copy_host_to_device(
+		host_slice: <Self::MemTypesHost as ComputeMemoryTypes<F>>::FSlice<'_>,
+		device_slice: &mut <Self::MemTypesDevice as ComputeMemoryTypes<F>>::FSliceMut<'_>,
+	);
+	fn copy_device_to_host(
+		device_slice: <Self::MemTypesDevice as ComputeMemoryTypes<F>>::FSlice<'_>,
+		host_slice: &mut <Self::MemTypesHost as ComputeMemoryTypes<F>>::FSliceMut<'_>,
+	);
 }


### PR DESCRIPTION
Accelerated compute backends typically require setting up IOMMU or performing custom allocation and alignment for buffers that are copyable to and from device memory. Extend the `ComputeMemory` trait with a type that is transparent to Binius as a dense slice of elements with a minimum slice width.

Define a `ComputeBufferAllocator` trait supporting allocating host and device memory. Implementations will provide specializations of `ComputeMemory` and `ComputeBufferAllocator` that perform the device-specific setup for both classes of allocations in addition to specifying the implementation-specific constraints on minimum span widths.