### PR TITLE
[m3] Fix the small-table flushing bug for lookups

### DIFF
--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -180,11 +180,20 @@ impl<F: TowerField> ConstraintSystem<F> {
 			if count == 0 {
 				continue;
 			}
-			if table.power_of_two_sized && !count.is_power_of_two() {
-				return Err(Error::TableSizePowerOfTwoRequired {
-					table_id: table.id,
-					size: count,
-				});
+			if table.power_of_two_sized {
+				if !count.is_power_of_two() {
+					return Err(Error::TableSizePowerOfTwoRequired {
+						table_id: table.id,
+						size: count,
+					});
+				}
+				if count != 1 << table.log_capacity(count) {
+					panic!(
+						"Tables with required power-of-two size currently cannot have capacity \
+						exceeding their count. This is because the flushes do not have automatic \
+						selectors applied, and so the table would flush invalid events"
+					);
+				}
 			}
 
 			let mut oracle_lookup = Vec::new();

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -443,25 +443,6 @@ impl<F: TowerField> Table<F> {
 		self.id
 	}
 
-	/// Returns the binary logarithm of the minimum capacity.
-	///
-	/// This value is chosen so that every committed column fills at least one large field element
-	/// in packed representation. This is because the polynomial commitment scheme requires full
-	/// packed field elements.
-	pub fn min_log_capacity(&self) -> usize {
-		let min_cell_size = self
-			.columns
-			.iter()
-			.filter_map(|col| match col.col {
-				ColumnDef::Committed { .. } => Some(col.shape.log_cell_size()),
-				_ => None,
-			})
-			.min()
-			// return 0 if table has no columns
-			.unwrap_or(F::TOWER_LEVEL);
-		F::TOWER_LEVEL.saturating_sub(min_cell_size)
-	}
-
 	/// Returns the binary logarithm of the table capacity required to accommodate the given number
 	/// of rows.
 	///
@@ -470,7 +451,7 @@ impl<F: TowerField> Table<F> {
 	/// This will normally be the next power of two greater than the table size, but could require
 	/// more padding to get a minimum capacity.
 	pub fn log_capacity(&self, table_size: usize) -> usize {
-		log2_ceil_usize(table_size).max(self.min_log_capacity())
+		log2_ceil_usize(table_size)
 	}
 
 	fn new_column<FSub, const V: usize>(

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -1246,7 +1246,7 @@ mod tests {
 		let _col2 = table.add_committed::<B8, 1>("col2");
 		let _col3 = table.add_committed::<B32, 1>("col3");
 
-		let allocator = bumpalo::Bump::new();
+		let allocator = Bump::new();
 		let table_size = 7;
 		let mut index = TableWitnessIndex::<PackedType<OptimalUnderlier256b, B128>>::new(
 			&allocator,
@@ -1255,18 +1255,18 @@ mod tests {
 		)
 		.unwrap();
 
-		assert_eq!(index.log_capacity(), 4);
-		assert_eq!(index.min_log_segment_size(), 4);
+		assert_eq!(index.log_capacity(), 3);
+		assert_eq!(index.min_log_segment_size(), 3);
 
 		let mut iter = index.segments(5);
 		// Check that the segment size is clamped to the capacity.
-		assert_eq!(iter.next().unwrap().log_size(), 4);
+		assert_eq!(iter.next().unwrap().log_size(), 3);
 		assert!(iter.next().is_none());
 		drop(iter);
 
 		let mut iter = index.segments(2);
 		// Check that the segment size is clamped to the minimum segment size.
-		assert_eq!(iter.next().unwrap().log_size(), 4);
+		assert_eq!(iter.next().unwrap().log_size(), 3);
 		assert!(iter.next().is_none());
 		drop(iter);
 	}

--- a/crates/m3/src/gadgets/lookup.rs
+++ b/crates/m3/src/gadgets/lookup.rs
@@ -87,8 +87,10 @@ mod tests {
 	use super::*;
 	use crate::builder::{test_utils::ClosureFiller, ConstraintSystem, Statement, WitnessIndex};
 
-	#[test]
-	fn test_basic_lookup_producer() {
+	fn with_lookup_test_instance(
+		no_zero_counts: bool,
+		f: impl FnOnce(&ConstraintSystem<B128>, WitnessIndex<PackedType<OptimalUnderlier128b, B128>>),
+	) {
 		let mut cs = ConstraintSystem::new();
 		let chan = cs.add_channel("values");
 
@@ -117,22 +119,26 @@ mod tests {
 		let mut counts = vec![0u32; lookup_table_size];
 
 		let looker_1_size = 56;
-		let inputs_1 = repeat_with(|| {
-			let index = rng.gen_range(0..lookup_table_size);
-			counts[index] += 1;
-			values[index]
-		})
-		.take(looker_1_size)
-		.collect::<Vec<_>>();
-
 		let looker_2_size = 67;
-		let inputs_2 = repeat_with(|| {
-			let index = rng.gen_range(0..lookup_table_size);
-			counts[index] += 1;
-			values[index]
-		})
-		.take(looker_2_size)
-		.collect::<Vec<_>>();
+
+		// Choose looked-up indices randomly, but ensuring they are at least one if no_zero_counts
+		// is true. This tests an edge case.
+		let mut look_indices = Vec::with_capacity(looker_1_size + looker_2_size);
+		if no_zero_counts {
+			look_indices.extend(0..lookup_table_size);
+		}
+		let remaining = look_indices.capacity() - look_indices.len();
+		look_indices.extend(repeat_with(|| rng.gen_range(0..lookup_table_size)).take(remaining));
+
+		let look_values = look_indices
+			.into_iter()
+			.map(|index| {
+				counts[index] += 1;
+				values[index]
+			})
+			.collect::<Vec<_>>();
+
+		let (inputs_1, inputs_2) = look_values.split_at(looker_1_size);
 
 		let values_and_counts = iter::zip(values, counts)
 			.sorted_unstable_by_key(|&(_val, count)| Reverse(count))
@@ -170,7 +176,7 @@ mod tests {
 					}
 					Ok(())
 				}),
-				&inputs_1,
+				inputs_1,
 			)
 			.unwrap();
 
@@ -183,17 +189,40 @@ mod tests {
 					}
 					Ok(())
 				}),
-				&inputs_2,
+				inputs_2,
 			)
 			.unwrap();
 
-		let statement = Statement {
-			boundaries: vec![],
-			table_sizes: witness.table_sizes(),
-		};
-		let ccs = cs.compile(&statement).unwrap();
-		let witness = witness.into_multilinear_extension_index();
+		f(&cs, witness)
+	}
 
-		binius_core::constraint_system::validate::validate_witness(&ccs, &[], &witness).unwrap();
+	#[test]
+	fn test_basic_lookup_producer() {
+		with_lookup_test_instance(false, |cs, witness| {
+			let statement = Statement {
+				boundaries: vec![],
+				table_sizes: witness.table_sizes(),
+			};
+			let ccs = cs.compile(&statement).unwrap();
+			let witness = witness.into_multilinear_extension_index();
+
+			binius_core::constraint_system::validate::validate_witness(&ccs, &[], &witness)
+				.unwrap();
+		});
+	}
+
+	#[test]
+	fn test_basic_lookup_producer_nonzero_counts() {
+		with_lookup_test_instance(true, |cs, witness| {
+			let statement = Statement {
+				boundaries: vec![],
+				table_sizes: witness.table_sizes(),
+			};
+			let ccs = cs.compile(&statement).unwrap();
+			let witness = witness.into_multilinear_extension_index();
+
+			binius_core::constraint_system::validate::validate_witness(&ccs, &[], &witness)
+				.unwrap();
+		});
 	}
 }


### PR DESCRIPTION
This was identified by @sai-deng in https://github.com/IrreducibleOSS/binius/pull/185.

This issue is caused by the solution of https://github.com/IrreducibleOSS/binius/pull/170, which makes it possible for tables to be automatically allocated capacity exceeding their event count. That works fine for regular tables, but not lookup tables that are `power_of_two_sized`. However, that solution is now obsolete because of an alternative fix in https://github.com/IrreducibleOSS/binius/pull/227, so this adds a test and assertion and rolls the change back.