### PR TITLE
Fix shape of terminal FRI oracle

### DIFF
--- a/crates/core/src/fiat_shamir/hasher_challenger.rs
+++ b/crates/core/src/fiat_shamir/hasher_challenger.rs
@@ -11,7 +11,7 @@ use digest::{
 use super::Challenger;
 
 /// Challenger type which implements `[Buf]` that has similar functionality as `[CanSample]`
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct HasherSampler<H: Digest> {
 	index: usize,
 	buffer: Output<H>,
@@ -19,7 +19,7 @@ pub struct HasherSampler<H: Digest> {
 }
 
 /// Challenger type which implements `[BufMut]` that has similar functionality as `[CanObserve]`
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct HasherObserver<H: Digest + BlockSizeUser> {
 	index: usize,
 	buffer: Block<H>,
@@ -29,7 +29,7 @@ pub struct HasherObserver<H: Digest + BlockSizeUser> {
 /// Challenger interface over hashes that implement `[Digest]` trait,
 ///
 /// This challenger works over bytes instead of Field elements
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum HasherChallenger<H: Digest + BlockSizeUser> {
 	Observer(HasherObserver<H>),
 	Sampler(HasherSampler<H>),

--- a/crates/core/src/protocols/fri/prove.rs
+++ b/crates/core/src/protocols/fri/prove.rs
@@ -381,12 +381,6 @@ where
 			.get(self.round_committed.len() + 1)
 			.map(|log| 1 << log)
 			.unwrap_or_else(|| {
-				println!(
-					"fold {}",
-					log2_strict_usize(folded_codeword.len())
-						.saturating_sub(self.params.rs_code().log_inv_rate())
-				);
-
 				1 << log2_strict_usize(folded_codeword.len())
 					.saturating_sub(self.params.rs_code().log_inv_rate())
 			});

--- a/crates/core/src/protocols/fri/prove.rs
+++ b/crates/core/src/protocols/fri/prove.rs
@@ -6,7 +6,7 @@ use binius_field::{
 };
 use binius_hal::{make_portable_backend, ComputationBackend};
 use binius_maybe_rayon::prelude::*;
-use binius_utils::{bail, checked_arithmetics::log2_strict_usize, SerializeBytes};
+use binius_utils::{bail, SerializeBytes};
 use bytemuck::zeroed_vec;
 use bytes::BufMut;
 use itertools::izip;
@@ -232,9 +232,7 @@ where
 	rs_code.encode_ext_batch_inplace(&mut encoded, log_batch_size)?;
 
 	// Take the first arity as coset_log_len, or use the value such that the number of leaves equals 1 << log_inv_rate if arities is empty
-	let coset_log_len = params.fold_arities().first().copied().unwrap_or_else(|| {
-		log2_strict_usize(encoded.len() * P::WIDTH).saturating_sub(rs_code.log_inv_rate())
-	});
+	let coset_log_len = params.fold_arities().first().copied().unwrap_or(log_elems);
 
 	let log_len = params.log_len() - coset_log_len;
 
@@ -380,10 +378,7 @@ where
 			.fold_arities()
 			.get(self.round_committed.len() + 1)
 			.map(|log| 1 << log)
-			.unwrap_or_else(|| {
-				1 << log2_strict_usize(folded_codeword.len())
-					.saturating_sub(self.params.rs_code().log_inv_rate())
-			});
+			.unwrap_or_else(|| 1 << self.params.n_final_challenges());
 
 		let (commitment, committed) = self
 			.merkle_prover

--- a/crates/core/src/protocols/fri/tests.rs
+++ b/crates/core/src/protocols/fri/tests.rs
@@ -14,12 +14,13 @@ use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_math::MultilinearExtension;
 use binius_maybe_rayon::prelude::ParallelIterator;
 use binius_ntt::NTTOptions;
+use binius_utils::checked_arithmetics::log2_strict_usize;
 use rand::prelude::*;
 
 use super::to_par_scalar_big_chunks;
 use crate::{
 	fiat_shamir::{CanSample, HasherChallenger},
-	merkle_tree::BinaryMerkleTreeProver,
+	merkle_tree::{BinaryMerkleTreeProver, MerkleTreeProver},
 	protocols::fri::{
 		self, to_par_scalar_small_chunks, CommitOutput, FRIFolder, FRIParams, FRIVerifier,
 		FoldRoundOutput,
@@ -128,7 +129,29 @@ fn test_commit_prove_verify_success<U, F, FA>(
 	)
 	.unwrap();
 
-	let final_fri_value = verifier.verify(&mut verifier_challenger).unwrap();
+	let mut cloned_verifier_challenger = verifier_challenger.clone();
+
+	let terminate_codeword_len =
+		1 << (params.n_final_challenges() + params.rs_code().log_inv_rate());
+
+	let mut advice = verifier_challenger.decommitment();
+	let terminate_codeword: Vec<F> = advice.read_scalar_slice(terminate_codeword_len).unwrap();
+
+	let log_batch_size =
+		log2_strict_usize(terminate_codeword.len()).saturating_sub(params.rs_code().log_inv_rate());
+
+	let (commitment, tree) = merkle_prover
+		.commit(&terminate_codeword, 1 << log_batch_size)
+		.unwrap();
+
+	// Ensure that the terminate_codeword commitment is correct
+	let last_round_commitment = round_commitments.last().unwrap_or(&codeword_commitment);
+	assert_eq!(*last_round_commitment, commitment.root);
+
+	// Verify that the Merkle tree has exactly inv_rate leaves.
+	assert_eq!(tree.log_len, params.rs_code().log_inv_rate());
+
+	let final_fri_value = verifier.verify(&mut cloned_verifier_challenger).unwrap();
 	assert_eq!(computed_eval, final_fri_value);
 }
 

--- a/crates/core/src/transcript/mod.rs
+++ b/crates/core/src/transcript/mod.rs
@@ -38,13 +38,13 @@ pub struct ProverTranscript<Challenger> {
 ///
 /// You must manually call the destructor with `finalize()` to check anything that's written is
 /// fully read out
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct VerifierTranscript<Challenger> {
 	combined: FiatShamirBuf<Bytes, Challenger>,
 	debug_assertions: bool,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 struct FiatShamirBuf<Inner, Challenger> {
 	buffer: Inner,
 	challenger: Challenger,


### PR DESCRIPTION
Update the batch_size of the `terminate_codeword` Merkle tree so that it has exactly `inv_rate` leaves