### PR TITLE
Change MultilinearExtension::from_vales to MultilinearExtension::new

### DIFF
--- a/crates/core/src/protocols/evalcheck/subclaims.rs
+++ b/crates/core/src/protocols/evalcheck/subclaims.rs
@@ -369,7 +369,8 @@ where
 	let eq_indicators = dedup_eval_points
 		.into_iter()
 		.map(|eval_point| {
-			let mle = MLEDirectAdapter::from(MultilinearExtension::from_values(
+			let mle = MLEDirectAdapter::from(MultilinearExtension::new(
+				eval_point.len(),
 				memoized_queries
 					.full_query_readonly(eval_point)
 					.expect("computed above")

--- a/crates/core/src/ring_switch/eq_ind.rs
+++ b/crates/core/src/ring_switch/eq_ind.rs
@@ -101,7 +101,7 @@ where
 					.map(|v| inner_product_subfield(v, &self.row_batch_coeffs)),
 			);
 		});
-		Ok(MultilinearExtension::from_values(evals)?)
+		Ok(MultilinearExtension::new(self.z_vals.len(), evals)?)
 	}
 }
 

--- a/crates/core/src/transparent/eq_ind.rs
+++ b/crates/core/src/transparent/eq_ind.rs
@@ -45,7 +45,7 @@ impl<F: Field> EqIndPartialEval<F> {
 		backend: &Backend,
 	) -> Result<MultilinearExtension<P, Backend::Vec<P>>, Error> {
 		let multilin_query = backend.tensor_product_full_query(&self.r)?;
-		Ok(MultilinearExtension::from_values_generic(multilin_query)?)
+		Ok(MultilinearExtension::new(self.n_vars(), multilin_query)?)
 	}
 }
 

--- a/crates/core/src/transparent/shift_ind.rs
+++ b/crates/core/src/transparent/shift_ind.rs
@@ -121,7 +121,7 @@ impl<F: Field> ShiftIndPartialEval<F> {
 			.zip(pps)
 			.map(|(p, pp)| *p + pp)
 			.collect::<Vec<_>>();
-		Ok(MultilinearExtension::from_values(values)?)
+		Ok(MultilinearExtension::new(self.block_size, values)?)
 	}
 
 	fn multilinear_extension_logical_left<P>(&self) -> Result<MultilinearExtension<P>, Error>
@@ -130,7 +130,7 @@ impl<F: Field> ShiftIndPartialEval<F> {
 	{
 		let (ps, _) =
 			partial_evaluate_hypercube_impl::<P>(self.block_size, self.shift_offset, &self.r)?;
-		Ok(MultilinearExtension::from_values(ps)?)
+		Ok(MultilinearExtension::new(self.block_size, ps)?)
 	}
 
 	fn multilinear_extension_logical_right<P>(&self) -> Result<MultilinearExtension<P>, Error>
@@ -140,7 +140,7 @@ impl<F: Field> ShiftIndPartialEval<F> {
 		let right_shift_offset = get_left_shift_offset(self.block_size, self.shift_offset);
 		let (_, pps) =
 			partial_evaluate_hypercube_impl::<P>(self.block_size, right_shift_offset, &self.r)?;
-		Ok(MultilinearExtension::from_values(pps)?)
+		Ok(MultilinearExtension::new(self.block_size, pps)?)
 	}
 
 	/// Evaluates this partially evaluated circular shift indicator MLE $f(X, r)$
@@ -272,8 +272,8 @@ fn partial_evaluate_hypercube_impl<P: PackedField>(
 	r: &[P::Scalar],
 ) -> Result<(Vec<P>, Vec<P>), Error> {
 	assert_valid_shift_ind_args(block_size, shift_offset, r)?;
-	let mut s_ind_p = vec![P::one(); 1 << (block_size - P::LOG_WIDTH)];
-	let mut s_ind_pp = vec![P::zero(); 1 << (block_size - P::LOG_WIDTH)];
+	let mut s_ind_p = vec![P::one(); 1 << block_size.saturating_sub(P::LOG_WIDTH)];
+	let mut s_ind_pp = vec![P::zero(); 1 << block_size.saturating_sub(P::LOG_WIDTH)];
 
 	partial_evaluate_hypercube_with_buffers_within_packed(
 		block_size.min(P::LOG_WIDTH),

--- a/crates/core/src/witness.rs
+++ b/crates/core/src/witness.rs
@@ -18,9 +18,7 @@ pub struct IndexEntry<'a, P: PackedField> {
 /// Data structure that indexes multilinear extensions by oracle ID.
 ///
 /// A [`crate::oracle::MultilinearOracleSet`] indexes multilinear polynomial oracles by assigning
-/// unique, sequential oracle IDs. The caller can get the [`MultilinearExtension`] defined natively
-/// over a subfield. This is possible because the [`MultilinearExtensionIndex::get`] method is
-/// generic over the subfield type and the struct itself only stores the underlying data.
+/// unique, sequential oracle IDs.
 #[derive(Default, Debug)]
 pub struct MultilinearExtensionIndex<'a, P>
 where

--- a/crates/core/src/witness.rs
+++ b/crates/core/src/witness.rs
@@ -2,9 +2,8 @@
 
 use std::{fmt::Debug, sync::Arc};
 
-use binius_field::{ExtensionField, PackedExtension, PackedField, TowerField};
-use binius_math::{MultilinearExtension, MultilinearExtensionBorrowed, MultilinearPoly};
-use binius_utils::bail;
+use binius_field::PackedField;
+use binius_math::MultilinearPoly;
 
 use crate::{oracle::OracleId, polynomial::Error as PolynomialError};
 
@@ -104,38 +103,5 @@ where
 			});
 		}
 		Ok(())
-	}
-
-	/// TODO: Remove once PCS no longer needs this
-	pub fn get<PS>(&self, id: OracleId) -> Result<MultilinearExtensionBorrowed<PS>, Error>
-	where
-		PS: PackedField,
-		P: PackedExtension<PS::Scalar, PackedSubfield = PS>,
-		PS::Scalar: TowerField,
-		P::Scalar: ExtensionField<PS::Scalar>,
-	{
-		let entry = self
-			.entries
-			.get(id)
-			.ok_or(Error::MissingWitness { id })?
-			.as_ref()
-			.ok_or(Error::MissingWitness { id })?;
-
-		let log_extension_degree = entry.multilin_poly.log_extension_degree();
-		if log_extension_degree != PS::Scalar::LOG_DEGREE {
-			bail!(Error::OracleExtensionDegreeMismatch {
-				oracle_id: id,
-				field_log_extension_degree: PS::Scalar::LOG_DEGREE,
-				entry_log_extension_degree: log_extension_degree
-			})
-		}
-
-		let evals = entry
-			.multilin_poly
-			.packed_evals()
-			.map(P::cast_bases)
-			.ok_or(Error::NoExplicitBackingMultilinearExtension { id })?;
-
-		Ok(MultilinearExtension::from_values_slice(evals)?)
 	}
 }


### PR DESCRIPTION
Byte-sliced PackedFields have a large width, so using from_values may lead to incorrect n_vars and unexpected behavior. It’s better to replace `MultilinearExtension::from_vales` to `MultilinearExtension::new`.