### PR TITLE
Common expression extraction in `ArithExpr`

### DIFF
--- a/crates/circuits/src/lib.rs
+++ b/crates/circuits/src/lib.rs
@@ -284,7 +284,7 @@ mod tests {
 			.map(|i| B128::from(i * i))
 			.collect::<Vec<_>>();
 
-		let arith_poly_1 = ArithCircuitPoly::new(comp_1);
+		let arith_poly_1 = ArithCircuitPoly::new(&comp_1);
 		let values_comp_1 = (0..(1 << n_vars))
 			.map(|i| arith_poly_1.evaluate(&[values_x[i], values_y[i]]).unwrap())
 			.collect::<Vec<_>>();
@@ -293,7 +293,7 @@ mod tests {
 		let first = values_shift.remove(0);
 		values_shift.push(first);
 
-		let arith_poly_2 = ArithCircuitPoly::new(comp_2);
+		let arith_poly_2 = ArithCircuitPoly::new(&comp_2);
 		let values_comp_2 = (0..(1 << n_vars))
 			.map(|i| {
 				arith_poly_2
@@ -313,7 +313,7 @@ mod tests {
 			})
 			.collect::<Vec<_>>();
 
-		let arith_poly_3 = ArithCircuitPoly::new(comp_3);
+		let arith_poly_3 = ArithCircuitPoly::new(&comp_3);
 		let values_comp_3 = (0..(1 << n_vars))
 			.map(|i| {
 				arith_poly_3
@@ -329,7 +329,7 @@ mod tests {
 			})
 			.collect::<Vec<_>>();
 
-		let arith_poly_4 = ArithCircuitPoly::new(comp_4);
+		let arith_poly_4 = ArithCircuitPoly::new(&comp_4);
 		let values_comp_4 = (0..(1 << n_vars))
 			.map(|i| {
 				arith_poly_4

--- a/crates/core/benches/composition_poly.rs
+++ b/crates/core/benches/composition_poly.rs
@@ -62,9 +62,9 @@ fn benchmark_evaluate(c: &mut Criterion) {
 	let mut results1x128b = vec![PackedBinaryField1x128b::zero(); BATCH_SIZE];
 
 	let arith_circuit_poly = ArithCircuitPoly::new(
-		Expr::Var(0) * Expr::Var(1)
+		&(Expr::Var(0) * Expr::Var(1)
 			+ (Expr::Const(BinaryField1b::ONE) - Expr::Var(0)) * Expr::Var(2)
-			- Expr::Var(3),
+			- Expr::Var(3)),
 	);
 	let arith_circuit_poly_cached =
 		arith_circuit_poly!([h4, h5, h6, ch] = (h4 * h5 + (1 - h4) * h6) - ch, BinaryField1b);

--- a/crates/core/src/composition/index.rs
+++ b/crates/core/src/composition/index.rs
@@ -182,14 +182,14 @@ mod tests {
 
 	#[test]
 	fn tests_expr() {
-		let expr = ArithExpr::Add(
+		let expr = ArithExpr::Mul(
 			Arc::new(ArithExpr::Var(0)),
-			Arc::new(ArithExpr::Mul(
+			Arc::new(ArithExpr::Add(
 				Arc::new(ArithExpr::Var(1)),
 				Arc::new(ArithExpr::Const(BinaryField1b::ONE)),
 			)),
 		);
-		let circuit = ArithCircuitPoly::new(expr);
+		let circuit = ArithCircuitPoly::new(&expr);
 
 		let composition = IndexComposition {
 			n_vars: 3,
@@ -199,9 +199,9 @@ mod tests {
 
 		assert_eq!(
 			(&composition as &dyn CompositionPoly<BinaryField1b>).expression(),
-			ArithExpr::Add(
+			ArithExpr::Mul(
 				Arc::new(ArithExpr::Var(1)),
-				Arc::new(ArithExpr::Mul(
+				Arc::new(ArithExpr::Add(
 					Arc::new(ArithExpr::Var(2)),
 					Arc::new(ArithExpr::Const(BinaryField1b::ONE)),
 				)),

--- a/crates/core/src/composition/index.rs
+++ b/crates/core/src/composition/index.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Debug;
 
-use binius_field::{Field, PackedField};
+use binius_field::PackedField;
 use binius_math::{ArithExpr, CompositionPoly, RowsBatchRef};
 use binius_utils::bail;
 
@@ -46,26 +46,10 @@ impl<P: PackedField, C: CompositionPoly<P>, const N: usize> CompositionPoly<P>
 	}
 
 	fn expression(&self) -> ArithExpr<<P as PackedField>::Scalar> {
-		fn map_variables<F: Field, const M: usize>(
-			index_map: &[usize; M],
-			expr: &ArithExpr<F>,
-		) -> ArithExpr<F> {
-			match expr {
-				ArithExpr::Var(i) => ArithExpr::Var(index_map[*i]),
-				ArithExpr::Const(c) => ArithExpr::Const(*c),
-				ArithExpr::Add(a, b) => ArithExpr::Add(
-					Box::new(map_variables(index_map, a)),
-					Box::new(map_variables(index_map, b)),
-				),
-				ArithExpr::Mul(a, b) => ArithExpr::Mul(
-					Box::new(map_variables(index_map, a)),
-					Box::new(map_variables(index_map, b)),
-				),
-				ArithExpr::Pow(a, n) => ArithExpr::Pow(Box::new(map_variables(index_map, a)), *n),
-			}
-		}
-
-		map_variables(&self.indices, &self.composition.expression())
+		self.composition
+			.expression()
+			.remap_vars(&self.indices)
+			.expect("remapping must be valid")
 	}
 
 	fn evaluate(&self, query: &[P]) -> Result<P, binius_math::Error> {
@@ -189,7 +173,9 @@ impl<P: PackedField, C: CompositionPoly<P> + Debug + Send + Sync> CompositionPol
 
 #[cfg(test)]
 mod tests {
-	use binius_field::BinaryField1b;
+	use std::sync::Arc;
+
+	use binius_field::{BinaryField1b, Field};
 
 	use super::*;
 	use crate::polynomial::ArithCircuitPoly;
@@ -197,10 +183,10 @@ mod tests {
 	#[test]
 	fn tests_expr() {
 		let expr = ArithExpr::Add(
-			Box::new(ArithExpr::Var(0)),
-			Box::new(ArithExpr::Mul(
-				Box::new(ArithExpr::Var(1)),
-				Box::new(ArithExpr::Const(BinaryField1b::ONE)),
+			Arc::new(ArithExpr::Var(0)),
+			Arc::new(ArithExpr::Mul(
+				Arc::new(ArithExpr::Var(1)),
+				Arc::new(ArithExpr::Const(BinaryField1b::ONE)),
 			)),
 		);
 		let circuit = ArithCircuitPoly::new(expr);
@@ -214,10 +200,10 @@ mod tests {
 		assert_eq!(
 			(&composition as &dyn CompositionPoly<BinaryField1b>).expression(),
 			ArithExpr::Add(
-				Box::new(ArithExpr::Var(1)),
-				Box::new(ArithExpr::Mul(
-					Box::new(ArithExpr::Var(2)),
-					Box::new(ArithExpr::Const(BinaryField1b::ONE)),
+				Arc::new(ArithExpr::Var(1)),
+				Arc::new(ArithExpr::Mul(
+					Arc::new(ArithExpr::Var(2)),
+					Arc::new(ArithExpr::Const(BinaryField1b::ONE)),
 				)),
 			)
 		);

--- a/crates/core/src/constraint_system/validate.rs
+++ b/crates/core/src/constraint_system/validate.rs
@@ -44,7 +44,7 @@ where
 			match constraint.predicate {
 				ConstraintPredicate::Zero => zero_claims.push((
 					constraint.name.clone(),
-					ArithCircuitPoly::with_n_vars(
+					ArithCircuitPoly::with_n_vars_circuit(
 						multilinears.len(),
 						constraint.composition.clone(),
 					)?,

--- a/crates/core/src/oracle/composite.rs
+++ b/crates/core/src/oracle/composite.rs
@@ -93,10 +93,10 @@ mod tests {
 
 		fn expression(&self) -> ArithExpr<BinaryField128b> {
 			ArithExpr::Add(
-				Box::new(ArithExpr::Mul(Box::new(ArithExpr::Var(0)), Box::new(ArithExpr::Var(1)))),
-				Box::new(ArithExpr::Mul(
-					Box::new(ArithExpr::Var(2)),
-					Box::new(ArithExpr::Const(BinaryField128b::new(125))),
+				Arc::new(ArithExpr::Mul(Arc::new(ArithExpr::Var(0)), Arc::new(ArithExpr::Var(1)))),
+				Arc::new(ArithExpr::Mul(
+					Arc::new(ArithExpr::Var(2)),
+					Arc::new(ArithExpr::Const(BinaryField128b::new(125))),
 				)),
 			)
 		}

--- a/crates/core/src/oracle/constraint.rs
+++ b/crates/core/src/oracle/constraint.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use binius_field::{Field, TowerField};
 use binius_macros::{DeserializeBytes, SerializeBytes};
-use binius_math::{ArithExpr, CompositionPoly};
+use binius_math::{ArithCircuit, ArithExpr, CompositionPoly};
 use binius_utils::bail;
 use itertools::Itertools;
 
@@ -19,7 +19,7 @@ pub type TypeErasedComposition<P> = Arc<dyn CompositionPoly<P>>;
 #[derive(Debug, Clone, SerializeBytes, DeserializeBytes)]
 pub struct Constraint<F: Field> {
 	pub name: String,
-	pub composition: ArithExpr<F>,
+	pub composition: ArithCircuit<F>,
 	pub predicate: ConstraintPredicate<F>,
 }
 
@@ -133,8 +133,7 @@ impl<F: Field> ConstraintSetBuilder<F> {
 				.into_iter()
 				.map(|constraint| Constraint {
 					name: constraint.name,
-					composition: constraint
-						.composition
+					composition: ArithCircuit::<F>::from(&constraint.composition)
 						.remap_vars(&positions(&constraint.oracle_ids, &oracle_ids).expect(
 							"precondition: oracle_ids is a superset of constraint.oracle_ids",
 						))
@@ -234,8 +233,7 @@ impl<F: Field> ConstraintSetBuilder<F> {
 					.into_iter()
 					.map(|constraint| Constraint {
 						name: constraint.name,
-						composition: constraint
-							.composition
+						composition: ArithCircuit::<F>::from(&constraint.composition)
 							.remap_vars(&positions(&constraint.oracle_ids, &oracle_ids).expect(
 								"precondition: oracle_ids is a superset of constraint.oracle_ids",
 							))

--- a/crates/core/src/oracle/multilinear.rs
+++ b/crates/core/src/oracle/multilinear.rs
@@ -816,7 +816,7 @@ impl<F: TowerField> CompositeMLE<F> {
 				}
 			})
 			.collect::<Result<Vec<_>, _>>()?;
-		let c = ArithCircuitPoly::with_n_vars(inner.len(), c)
+		let c = ArithCircuitPoly::with_n_vars(inner.len(), &c)
 			.map_err(|_| Error::CompositionMismatch)?; // occurs if `c` has more variables than `inner.len()`
 		Ok(Self { n_vars, inner, c })
 	}

--- a/crates/core/src/polynomial/arith_circuit.rs
+++ b/crates/core/src/polynomial/arith_circuit.rs
@@ -1207,7 +1207,7 @@ mod tests {
 
 		let (steps, retval) = convert_circuit(&(&expr).into());
 
-		assert_eq!(steps.len(), 3, "Expression should generate 4 computation steps");
+		assert_eq!(steps.len(), 3, "Expression should generate 3 computation steps");
 
 		assert!(
 			matches!(

--- a/crates/core/src/polynomial/arith_circuit.rs
+++ b/crates/core/src/polynomial/arith_circuit.rs
@@ -1,9 +1,11 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use std::{collections::HashMap, fmt::Debug, mem::MaybeUninit, sync::Arc};
+use std::{fmt::Debug, mem::MaybeUninit, sync::Arc};
 
 use binius_field::{ExtensionField, Field, PackedField, TowerField};
-use binius_math::{ArithExpr, CompositionPoly, Error, RowsBatchRef};
+use binius_math::{
+	ArithCircuit, ArithCircuitStep, ArithExpr, CompositionPoly, Error, RowsBatchRef,
+};
 use binius_utils::{bail, DeserializeBytes, SerializationError, SerializationMode, SerializeBytes};
 use stackalloc::{
 	helpers::{slice_assume_init, slice_assume_init_mut},
@@ -11,101 +13,102 @@ use stackalloc::{
 };
 
 /// Convert the expression to a sequence of arithmetic operations that can be evaluated in sequence.
-/// Convert the expression to a sequence of arithmetic operations that can be evaluated in sequence.
-fn circuit_steps_for_expr<F: Field>(
-	expr: &ArithExpr<F>,
+fn convert_circuit<F: Field>(
+	expr: &ArithCircuit<F>,
 ) -> (Vec<CircuitStep<F>>, CircuitStepArgument<F>) {
-	/// This struct is used to map nodes in the expressions to the steps in the circuit and back.
-	/// We use it to avoid recomputing the same expression multiple times.
-	#[derive(Default)]
-	struct NodeToStepMapping<F: Field> {
-		node_to_step: HashMap<Arc<ArithExpr<F>>, usize>,
-		// step index to node mapping
-		step_to_node: Vec<Option<Arc<ArithExpr<F>>>>,
+	/// This struct is used to the steps in the original circuit and the converted one and back.
+	struct StepsMapping {
+		original_to_converted: Vec<Option<usize>>,
+		converted_to_original: Vec<Option<usize>>,
 	}
 
-	impl<F: Field> NodeToStepMapping<F> {
-		fn register(&mut self, node: &Arc<ArithExpr<F>>, step: usize) {
-			self.node_to_step.insert(Arc::clone(node), step);
-
-			if step >= self.step_to_node.len() {
-				self.step_to_node.resize(step + 1, None);
+	impl StepsMapping {
+		fn new(original_size: usize) -> Self {
+			Self {
+				original_to_converted: vec![None; original_size],
+				// The size of this vector isn't known at the start, but that's a reasonable guess
+				converted_to_original: vec![None; original_size],
 			}
-			self.step_to_node[step] = Some(Arc::clone(node));
 		}
 
-		fn clear_step(&mut self, step: usize) {
-			if self.step_to_node.len() <= step {
+		fn register(&mut self, original_step: usize, converted_step: usize) {
+			self.original_to_converted[original_step] = Some(converted_step);
+
+			if converted_step >= self.converted_to_original.len() {
+				self.converted_to_original.resize(converted_step + 1, None);
+			}
+			self.converted_to_original[converted_step] = Some(original_step);
+		}
+
+		fn clear_step(&mut self, converted_step: usize) {
+			if self.converted_to_original.len() <= converted_step {
 				return;
 			}
 
-			if let Some(node_ptr) = self.step_to_node[step].take() {
-				self.node_to_step.remove(&node_ptr);
+			if let Some(original_step) = self.converted_to_original[converted_step].take() {
+				self.original_to_converted[original_step] = None;
 			}
 		}
 
-		fn get_step(&self, node: &Arc<ArithExpr<F>>) -> Option<usize> {
-			self.node_to_step.get(node).copied()
+		fn get_converted_step(&self, original_step: usize) -> Option<usize> {
+			self.original_to_converted[original_step]
 		}
 	}
 
-	fn to_circuit_inner<F: Field>(
-		expr: &Arc<ArithExpr<F>>,
+	fn convert_step<F: Field>(
+		original_step: usize,
+		original_steps: &[ArithCircuitStep<F>],
 		result: &mut Vec<CircuitStep<F>>,
-		node_to_step: &mut NodeToStepMapping<F>,
+		node_to_step: &mut StepsMapping,
 	) -> CircuitStepArgument<F> {
-		// Check if the expression is already registered, if so we can reuse the result
-		if let Some(step) = node_to_step.get_step(expr) {
-			return CircuitStepArgument::Expr(CircuitNode::Slot(step));
+		if let Some(converted_step) = node_to_step.get_converted_step(original_step) {
+			return CircuitStepArgument::Expr(CircuitNode::Slot(converted_step));
 		}
 
-		match &**expr {
-			ArithExpr::Const(value) => CircuitStepArgument::Const(*value),
-			ArithExpr::Var(index) => CircuitStepArgument::Expr(CircuitNode::Var(*index)),
-			ArithExpr::Add(left, right) => match &**right {
-				ArithExpr::Mul(mleft, mright) if left.is_composite() => {
-					// Only handling e1 + (e2 * e3), not (e1 * e2) + e3, as latter was not observed in practice
-					// (the former can be enforced by rewriting expression).
-					let left = to_circuit_inner(left, result, node_to_step);
-					let CircuitStepArgument::Expr(CircuitNode::Slot(left)) = left else {
-						unreachable!("guaranteed by `is_composite` check above")
-					};
-					let mleft = to_circuit_inner(mleft, result, node_to_step);
-					let mright = to_circuit_inner(mright, result, node_to_step);
-					result.push(CircuitStep::AddMul(left, mleft, mright));
+		match &original_steps[original_step] {
+			ArithCircuitStep::Const(constant) => CircuitStepArgument::Const(*constant),
+			ArithCircuitStep::Var(var) => CircuitStepArgument::Expr(CircuitNode::Var(*var)),
+			ArithCircuitStep::Add(left, right) => {
+				let left = convert_step(*left, original_steps, result, node_to_step);
 
-					// Since we'we changed the value of `left` to a new value, we need to clear the cache for it
-					node_to_step.clear_step(left);
+				if let CircuitStepArgument::Expr(CircuitNode::Slot(left)) = left {
+					if let ArithCircuitStep::Mul(mleft, mright) = &original_steps[*right] {
+						// Only handling e1 + (e2 * e3), not (e1 * e2) + e3, as latter was not observed in practice
+						// (the former can be enforced by rewriting expression)
+						let mleft = convert_step(*mleft, original_steps, result, node_to_step);
+						let mright = convert_step(*mright, original_steps, result, node_to_step);
 
-					CircuitStepArgument::Expr(CircuitNode::Slot(left))
+						// Since we'we changed the value of `left` to a new value, we need to clear the cache for it
+						node_to_step.clear_step(left);
+						node_to_step.register(original_step, left);
+						result.push(CircuitStep::AddMul(left, mleft, mright));
+
+						return CircuitStepArgument::Expr(CircuitNode::Slot(left));
+					}
 				}
-				_ => {
-					let left = to_circuit_inner(left, result, node_to_step);
-					let right = to_circuit_inner(right, result, node_to_step);
 
-					node_to_step.register(expr, result.len());
+				let right = convert_step(*right, original_steps, result, node_to_step);
 
-					result.push(CircuitStep::Add(left, right));
-					CircuitStepArgument::Expr(CircuitNode::Slot(result.len() - 1))
-				}
-			},
-			ArithExpr::Mul(left, right) => {
-				let left = to_circuit_inner(left, result, node_to_step);
-				let right = to_circuit_inner(right, result, node_to_step);
+				node_to_step.register(original_step, result.len());
+				result.push(CircuitStep::Add(left, right));
+				CircuitStepArgument::Expr(CircuitNode::Slot(result.len() - 1))
+			}
+			ArithCircuitStep::Mul(left, right) => {
+				let left = convert_step(*left, original_steps, result, node_to_step);
+				let right = convert_step(*right, original_steps, result, node_to_step);
 
-				node_to_step.register(expr, result.len());
-
+				node_to_step.register(original_step, result.len());
 				result.push(CircuitStep::Mul(left, right));
 				CircuitStepArgument::Expr(CircuitNode::Slot(result.len() - 1))
 			}
-			ArithExpr::Pow(base, exp) => {
-				let mut acc = to_circuit_inner(base, result, node_to_step);
+			ArithCircuitStep::Pow(base, exp) => {
+				let mut acc = convert_step(*base, original_steps, result, node_to_step);
 				let base_expr = acc;
 				let highest_bit = exp.ilog2();
 
 				for i in (0..highest_bit).rev() {
 					if i == 0 {
-						node_to_step.register(expr, result.len());
+						node_to_step.register(original_step, result.len());
 					}
 					result.push(CircuitStep::Square(acc));
 					acc = CircuitStepArgument::Expr(CircuitNode::Slot(result.len() - 1));
@@ -122,10 +125,11 @@ fn circuit_steps_for_expr<F: Field>(
 	}
 
 	let mut steps = Vec::new();
-	let ret =
-		to_circuit_inner(&Arc::new(expr.optimize()), &mut steps, &mut NodeToStepMapping::default());
+	let mut steps_mapping = StepsMapping::new(expr.steps().len());
+	let ret = convert_step(expr.steps().len() - 1, expr.steps(), &mut steps, &mut steps_mapping);
 	(steps, ret)
 }
+
 /// Input of the circuit calculation step
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CircuitNode {
@@ -177,7 +181,7 @@ enum CircuitStep<F: Field> {
 /// and the object representing different polnomials can be stored in a homogeneous collection.
 #[derive(Debug, Clone)]
 pub struct ArithCircuitPoly<F: Field> {
-	expr: ArithExpr<F>,
+	inner_circuit: ArithCircuit<F>,
 	steps: Arc<[CircuitStep<F>]>,
 	/// The "top level expression", which depends on circuit expression evaluations
 	retval: CircuitStepArgument<F>,
@@ -188,7 +192,7 @@ pub struct ArithCircuitPoly<F: Field> {
 
 impl<F: Field> PartialEq for ArithCircuitPoly<F> {
 	fn eq(&self, other: &Self) -> bool {
-		self.n_vars == other.n_vars && self.expr == other.expr
+		self.n_vars == other.n_vars && self.inner_circuit == other.inner_circuit
 	}
 }
 
@@ -200,7 +204,7 @@ impl<F: TowerField> SerializeBytes for ArithCircuitPoly<F> {
 		mut write_buf: impl bytes::BufMut,
 		mode: SerializationMode,
 	) -> Result<(), SerializationError> {
-		(&self.expr, self.n_vars).serialize(&mut write_buf, mode)
+		(&self.inner_circuit, self.n_vars).serialize(&mut write_buf, mode)
 	}
 }
 
@@ -212,22 +216,28 @@ impl<F: TowerField> DeserializeBytes for ArithCircuitPoly<F> {
 	where
 		Self: Sized,
 	{
-		let (expr, n_vars) = <(ArithExpr<F>, usize)>::deserialize(read_buf, mode)?;
-		Self::with_n_vars(n_vars, expr).map_err(|_| SerializationError::InvalidConstruction {
-			name: "ArithCircuitPoly",
+		let (circuit, n_vars) = <(ArithCircuit<F>, usize)>::deserialize(read_buf, mode)?;
+		Self::with_n_vars_circuit(n_vars, circuit).map_err(|_| {
+			SerializationError::InvalidConstruction {
+				name: "ArithCircuitPoly",
+			}
 		})
 	}
 }
 
 impl<F: TowerField> ArithCircuitPoly<F> {
-	pub fn new(expr: ArithExpr<F>) -> Self {
-		let degree = expr.degree();
-		let n_vars = expr.n_vars();
-		let tower_level = expr.binary_tower_level();
-		let (exprs, retval) = circuit_steps_for_expr(&expr);
+	pub fn new(expr: &ArithExpr<F>) -> Self {
+		Self::new_from_circuit((&expr.optimize()).into())
+	}
+
+	pub fn new_from_circuit(circuit: ArithCircuit<F>) -> Self {
+		let degree = circuit.degree();
+		let n_vars = circuit.n_vars();
+		let tower_level = circuit.binary_tower_level();
+		let (exprs, retval) = convert_circuit(&circuit);
 
 		Self {
-			expr,
+			inner_circuit: circuit,
 			steps: exprs.into(),
 			retval,
 			degree,
@@ -240,20 +250,27 @@ impl<F: TowerField> ArithCircuitPoly<F> {
 	///
 	/// The number of variables may be greater than the number of variables actually read in the
 	/// arithmetic expression.
-	pub fn with_n_vars(n_vars: usize, expr: ArithExpr<F>) -> Result<Self, Error> {
-		let degree = expr.degree();
-		let tower_level = expr.binary_tower_level();
-		if n_vars < expr.n_vars() {
+	pub fn with_n_vars(n_vars: usize, expr: &ArithExpr<F>) -> Result<Self, Error> {
+		Self::with_n_vars_circuit(n_vars, (&expr.optimize()).into())
+	}
+
+	pub fn with_n_vars_circuit(
+		n_vars: usize,
+		inner_circuit: ArithCircuit<F>,
+	) -> Result<Self, Error> {
+		let degree = inner_circuit.degree();
+		let tower_level = inner_circuit.binary_tower_level();
+		if n_vars < inner_circuit.n_vars() {
 			return Err(Error::IncorrectNumberOfVariables {
-				expected: expr.n_vars(),
+				expected: inner_circuit.n_vars(),
 				actual: n_vars,
 			});
 		}
-		let (exprs, retval) = circuit_steps_for_expr(&expr);
+		let (steps, retval) = convert_circuit(&inner_circuit);
 
 		Ok(Self {
-			expr,
-			steps: exprs.into(),
+			inner_circuit,
+			steps: steps.into(),
 			retval,
 			n_vars,
 			degree,
@@ -278,7 +295,7 @@ impl<F: TowerField, P: PackedField<Scalar: ExtensionField<F>>> CompositionPoly<P
 	}
 
 	fn expression(&self) -> ArithExpr<P::Scalar> {
-		self.expr.convert_field()
+		(&self.inner_circuit).into()
 	}
 
 	fn evaluate(&self, query: &[P]) -> Result<P, Error> {
@@ -536,7 +553,7 @@ mod tests {
 		type P = PackedBinaryField8x16b;
 
 		let expr = ArithExpr::Const(F::new(123));
-		let circuit = ArithCircuitPoly::<F>::new(expr);
+		let circuit = ArithCircuitPoly::<F>::new(&expr);
 
 		let typed_circuit: &dyn CompositionPoly<P> = &circuit;
 		assert_eq!(typed_circuit.binary_tower_level(), F::TOWER_LEVEL);
@@ -559,7 +576,7 @@ mod tests {
 
 		// x0
 		let expr = ArithExpr::Var(0);
-		let circuit = ArithCircuitPoly::<F>::new(expr);
+		let circuit = ArithCircuitPoly::<F>::new(&expr);
 
 		let typed_circuit: &dyn CompositionPoly<P> = &circuit;
 		assert_eq!(typed_circuit.binary_tower_level(), 0);
@@ -589,7 +606,7 @@ mod tests {
 
 		// 123 + x0
 		let expr = ArithExpr::Const(F::new(123)) + ArithExpr::Var(0);
-		let circuit = ArithCircuitPoly::<F>::new(expr);
+		let circuit = ArithCircuitPoly::<F>::new(&expr);
 
 		let typed_circuit: &dyn CompositionPoly<P> = &circuit;
 		assert_eq!(typed_circuit.binary_tower_level(), 3);
@@ -609,7 +626,7 @@ mod tests {
 
 		// 123 * x0
 		let expr = ArithExpr::Const(F::new(123)) * ArithExpr::Var(0);
-		let circuit = ArithCircuitPoly::<F>::new(expr);
+		let circuit = ArithCircuitPoly::<F>::new(&expr);
 
 		let typed_circuit: &dyn CompositionPoly<P> = &circuit;
 		assert_eq!(typed_circuit.binary_tower_level(), 3);
@@ -635,7 +652,7 @@ mod tests {
 
 		// x0^13
 		let expr = ArithExpr::Var(0).pow(13);
-		let circuit = ArithCircuitPoly::<F>::new(expr);
+		let circuit = ArithCircuitPoly::<F>::new(&expr);
 
 		let typed_circuit: &dyn CompositionPoly<P> = &circuit;
 		assert_eq!(typed_circuit.binary_tower_level(), 0);
@@ -661,7 +678,7 @@ mod tests {
 
 		// x0^2 * (x1 + 123)
 		let expr = ArithExpr::Var(0).pow(2) * (ArithExpr::Var(1) + ArithExpr::Const(F::new(123)));
-		let circuit = ArithCircuitPoly::<F>::new(expr);
+		let circuit = ArithCircuitPoly::<F>::new(&expr);
 
 		let typed_circuit: &dyn CompositionPoly<P> = &circuit;
 		assert_eq!(typed_circuit.binary_tower_level(), 3);
@@ -721,7 +738,7 @@ mod tests {
 			* ((ArithExpr::Const(F::new(122)) * ArithExpr::Const(F::new(123)))
 				+ (ArithExpr::Const(F::new(124)) + ArithExpr::Const(F::new(125))))
 			+ ArithExpr::Var(1);
-		let circuit = ArithCircuitPoly::<F>::new(expr);
+		let circuit = ArithCircuitPoly::<F>::new(&expr);
 		assert_eq!(circuit.steps.len(), 2);
 
 		let typed_circuit: &dyn CompositionPoly<P> = &circuit;
@@ -778,7 +795,7 @@ mod tests {
 
 		// x0 + 2^5
 		let expr = ArithExpr::Var(0) + ArithExpr::Const(F::from(2)).pow(4);
-		let circuit = ArithCircuitPoly::<F>::new(expr);
+		let circuit = ArithCircuitPoly::<F>::new(&expr);
 		assert_eq!(circuit.steps.len(), 1);
 
 		let typed_circuit: &dyn CompositionPoly<P> = &circuit;
@@ -805,7 +822,7 @@ mod tests {
 
 		// ((x0^2)^3)^4
 		let expr = ArithExpr::Var(0).pow(2).pow(3).pow(4);
-		let circuit = ArithCircuitPoly::<F>::new(expr);
+		let circuit = ArithCircuitPoly::<F>::new(&expr);
 		assert_eq!(circuit.steps.len(), 5);
 
 		let typed_circuit: &dyn CompositionPoly<P> = &circuit;
@@ -830,7 +847,7 @@ mod tests {
 		type F = BinaryField8b;
 
 		let expr = ArithExpr::Const(F::new(5));
-		let (steps, retval) = circuit_steps_for_expr(&expr);
+		let (steps, retval) = convert_circuit(&(&expr).into());
 
 		assert!(steps.is_empty(), "No steps should be generated for a constant");
 		assert_eq!(retval, CircuitStepArgument::Const(F::new(5)));
@@ -841,7 +858,7 @@ mod tests {
 		type F = BinaryField8b;
 
 		let expr = ArithExpr::<F>::Var(18);
-		let (steps, retval) = circuit_steps_for_expr(&expr);
+		let (steps, retval) = convert_circuit(&(&expr).into());
 
 		assert!(steps.is_empty(), "No steps should be generated for a variable");
 		assert!(matches!(retval, CircuitStepArgument::Expr(CircuitNode::Var(18))));
@@ -852,7 +869,7 @@ mod tests {
 		type F = BinaryField8b;
 
 		let expr = ArithExpr::<F>::Var(14) + ArithExpr::<F>::Var(56);
-		let (steps, retval) = circuit_steps_for_expr(&expr);
+		let (steps, retval) = convert_circuit(&(&expr).into());
 
 		assert_eq!(steps.len(), 1, "One addition step should be generated");
 		assert!(matches!(
@@ -870,7 +887,7 @@ mod tests {
 		type F = BinaryField8b;
 
 		let expr = ArithExpr::<F>::Var(36) * ArithExpr::Var(26);
-		let (steps, retval) = circuit_steps_for_expr(&expr);
+		let (steps, retval) = convert_circuit(&(&expr).into());
 
 		assert_eq!(steps.len(), 1, "One multiplication step should be generated");
 		assert!(matches!(
@@ -888,7 +905,7 @@ mod tests {
 		type F = BinaryField8b;
 
 		let expr = ArithExpr::<F>::Var(12).pow(1);
-		let (steps, retval) = circuit_steps_for_expr(&expr);
+		let (steps, retval) = convert_circuit(&(&expr).into());
 
 		// No steps should be generated for x^1
 		assert_eq!(steps.len(), 0, "Pow(1) should not generate any computation steps");
@@ -902,7 +919,7 @@ mod tests {
 		type F = BinaryField8b;
 
 		let expr = ArithExpr::<F>::Var(10).pow(2);
-		let (steps, retval) = circuit_steps_for_expr(&expr);
+		let (steps, retval) = convert_circuit(&(&expr).into());
 
 		assert_eq!(steps.len(), 1, "Pow(2) should generate one squaring step");
 		assert!(matches!(
@@ -917,7 +934,7 @@ mod tests {
 		type F = BinaryField8b;
 
 		let expr = ArithExpr::<F>::Var(5).pow(3);
-		let (steps, retval) = circuit_steps_for_expr(&expr);
+		let (steps, retval) = convert_circuit(&(&expr).into());
 
 		assert_eq!(
 			steps.len(),
@@ -943,7 +960,7 @@ mod tests {
 		type F = BinaryField8b;
 
 		let expr = ArithExpr::<F>::Var(7).pow(4);
-		let (steps, retval) = circuit_steps_for_expr(&expr);
+		let (steps, retval) = convert_circuit(&(&expr).into());
 
 		assert_eq!(steps.len(), 2, "Pow(4) should generate two squaring steps");
 		assert!(matches!(
@@ -964,7 +981,7 @@ mod tests {
 		type F = BinaryField8b;
 
 		let expr = ArithExpr::<F>::Var(3).pow(5);
-		let (steps, retval) = circuit_steps_for_expr(&expr);
+		let (steps, retval) = convert_circuit(&(&expr).into());
 
 		assert_eq!(
 			steps.len(),
@@ -995,7 +1012,7 @@ mod tests {
 		type F = BinaryField8b;
 
 		let expr = ArithExpr::<F>::Var(4).pow(8);
-		let (steps, retval) = circuit_steps_for_expr(&expr);
+		let (steps, retval) = convert_circuit(&(&expr).into());
 
 		assert_eq!(steps.len(), 3, "Pow(8) should generate three squaring steps");
 		assert!(matches!(
@@ -1019,7 +1036,7 @@ mod tests {
 		type F = BinaryField8b;
 
 		let expr = ArithExpr::<F>::Var(8).pow(9);
-		let (steps, retval) = circuit_steps_for_expr(&expr);
+		let (steps, retval) = convert_circuit(&(&expr).into());
 
 		assert_eq!(
 			steps.len(),
@@ -1053,7 +1070,7 @@ mod tests {
 	fn test_circuit_steps_for_expr_pow_12() {
 		type F = BinaryField8b;
 		let expr = ArithExpr::<F>::Var(6).pow(12);
-		let (steps, retval) = circuit_steps_for_expr(&expr);
+		let (steps, retval) = convert_circuit(&(&expr).into());
 
 		assert_eq!(steps.len(), 4, "Pow(12) should use 4 steps.");
 
@@ -1084,7 +1101,7 @@ mod tests {
 	fn test_circuit_steps_for_expr_pow_13() {
 		type F = BinaryField8b;
 		let expr = ArithExpr::<F>::Var(7).pow(13);
-		let (steps, retval) = circuit_steps_for_expr(&expr);
+		let (steps, retval) = convert_circuit(&(&expr).into());
 
 		assert_eq!(steps.len(), 5, "Pow(13) should use 5 steps.");
 		assert!(matches!(
@@ -1124,7 +1141,7 @@ mod tests {
 			+ (ArithExpr::Const(F::ONE) - ArithExpr::Var(0)) * ArithExpr::Var(2)
 			- ArithExpr::Var(3);
 
-		let (steps, retval) = circuit_steps_for_expr(&expr);
+		let (steps, retval) = convert_circuit(&(&expr).into());
 
 		assert_eq!(steps.len(), 4, "Expression should generate 4 computation steps");
 
@@ -1186,8 +1203,9 @@ mod tests {
 		let expr = (ArithExpr::<F>::Var(0) * ArithExpr::Var(1))
 			+ (ArithExpr::<F>::Var(0) * ArithExpr::Var(1)) * ArithExpr::Var(2)
 			- ArithExpr::Var(3);
+		let expr = expr.deduplicate_nodes();
 
-		let (steps, retval) = circuit_steps_for_expr(&expr);
+		let (steps, retval) = convert_circuit(&(&expr).into());
 
 		assert_eq!(steps.len(), 3, "Expression should generate 4 computation steps");
 

--- a/crates/core/src/polynomial/arith_circuit.rs
+++ b/crates/core/src/polynomial/arith_circuit.rs
@@ -15,11 +15,12 @@ use stackalloc::{
 fn circuit_steps_for_expr<F: Field>(
 	expr: &ArithExpr<F>,
 ) -> (Vec<CircuitStep<F>>, CircuitStepArgument<F>) {
-	let mut steps = Vec::new();
-
+	/// This struct is used to map nodes in the expressions to the steps in the circuit and back.
+	/// We use it to avoid recomputing the same expression multiple times.
 	#[derive(Default)]
 	struct NodeToStepMapping<F: Field> {
 		node_to_step: HashMap<Arc<ArithExpr<F>>, usize>,
+		// step index to node mapping
 		step_to_node: Vec<Option<Arc<ArithExpr<F>>>>,
 	}
 
@@ -120,6 +121,7 @@ fn circuit_steps_for_expr<F: Field>(
 		}
 	}
 
+	let mut steps = Vec::new();
 	let ret =
 		to_circuit_inner(&Arc::new(expr.optimize()), &mut steps, &mut NodeToStepMapping::default());
 	(steps, ret)

--- a/crates/core/src/polynomial/multivariate.rs
+++ b/crates/core/src/polynomial/multivariate.rs
@@ -302,7 +302,7 @@ mod tests {
 		//Complicated circuit for (x0 + x1) * x0 + x0^2
 		let expr =
 			(ArithExpr::Var(0) + ArithExpr::Var(1)) * ArithExpr::Var(0) + ArithExpr::Var(0).pow(2);
-		let circuit_poly = &crate::polynomial::ArithCircuitPoly::<BinaryField1b>::new(expr)
+		let circuit_poly = &crate::polynomial::ArithCircuitPoly::<BinaryField1b>::new(&expr)
 			as &dyn CompositionPoly<PackedBinaryField8x32b>;
 
 		let product_composition = crate::composition::ProductComposition::<2> {};
@@ -319,7 +319,7 @@ mod tests {
 
 		let expr = ArithExpr::Var(0) + ArithExpr::Var(1);
 
-		let circuit_poly = &crate::polynomial::ArithCircuitPoly::<BinaryField1b>::new(expr)
+		let circuit_poly = &crate::polynomial::ArithCircuitPoly::<BinaryField1b>::new(&expr)
 			as &dyn CompositionPoly<PackedBinaryField8x32b>;
 
 		let product_composition = crate::composition::ProductComposition::<2> {};
@@ -337,7 +337,7 @@ mod tests {
 		// Complicated circuit for (x0 + x1) * x0 + x0^2
 		let expr =
 			(ArithExpr::Var(0) + ArithExpr::Var(1)) * ArithExpr::Var(0) + ArithExpr::Var(0).pow(2);
-		let circuit_poly = &crate::polynomial::ArithCircuitPoly::<BinaryField1b>::new(expr)
+		let circuit_poly = &crate::polynomial::ArithCircuitPoly::<BinaryField1b>::new(&expr)
 			as &dyn CompositionPoly<PackedBinaryField4x64b>;
 
 		let product_composition = crate::composition::ProductComposition::<2> {};
@@ -353,7 +353,7 @@ mod tests {
 		use binius_field::{BinaryField1b, PackedBinaryField4x64b};
 
 		let expr = ArithExpr::Var(0) + ArithExpr::Var(1);
-		let circuit_poly = &crate::polynomial::ArithCircuitPoly::<BinaryField1b>::new(expr)
+		let circuit_poly = &crate::polynomial::ArithCircuitPoly::<BinaryField1b>::new(&expr)
 			as &dyn CompositionPoly<PackedBinaryField4x64b>;
 
 		let product_composition = crate::composition::ProductComposition::<2> {};
@@ -371,7 +371,7 @@ mod tests {
 		// Complicated circuit for (x0 + x1) * x0 + x0^2
 		let expr =
 			(ArithExpr::Var(0) + ArithExpr::Var(1)) * ArithExpr::Var(0) + ArithExpr::Var(0).pow(2);
-		let circuit_poly = &crate::polynomial::ArithCircuitPoly::<BinaryField1b>::new(expr)
+		let circuit_poly = &crate::polynomial::ArithCircuitPoly::<BinaryField1b>::new(&expr)
 			as &dyn CompositionPoly<PackedBinaryField2x128b>;
 
 		let product_composition = crate::composition::ProductComposition::<2> {};
@@ -387,7 +387,7 @@ mod tests {
 		use binius_field::{BinaryField1b, PackedBinaryField2x128b};
 
 		let expr = ArithExpr::Var(0) + ArithExpr::Var(1);
-		let circuit_poly = &crate::polynomial::ArithCircuitPoly::<BinaryField1b>::new(expr)
+		let circuit_poly = &crate::polynomial::ArithCircuitPoly::<BinaryField1b>::new(&expr)
 			as &dyn CompositionPoly<PackedBinaryField2x128b>;
 
 		let product_composition = crate::composition::ProductComposition::<2> {};

--- a/crates/core/src/protocols/evalcheck/tests.rs
+++ b/crates/core/src/protocols/evalcheck/tests.rs
@@ -412,7 +412,7 @@ where
 		.take(n_vars)
 		.collect::<Vec<_>>();
 
-	let eval = ArithCircuitPoly::new(comp)
+	let eval = ArithCircuitPoly::new(&comp)
 		.evaluate(&[
 			select_row1.evaluate(&eval_point).unwrap(),
 			select_row2.evaluate(&eval_point).unwrap(),

--- a/crates/core/src/protocols/gkr_exp/compositions.rs
+++ b/crates/core/src/protocols/gkr_exp/compositions.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
 use binius_field::{Field, PackedField};
 use binius_math::{ArithExpr, CompositionPoly};
@@ -48,7 +48,7 @@ where
 						+ ArithExpr::Var(1) * ArithExpr::Const(*base_power_static))
 			}
 			Self::DynamicBase => {
-				ArithExpr::Pow(Box::new(ArithExpr::Var(0)), 2)
+				ArithExpr::Pow(Arc::new(ArithExpr::Var(0)), 2)
 					* ((ArithExpr::Const(P::Scalar::ONE) - ArithExpr::Var(1))
 						+ ArithExpr::Var(1) * ArithExpr::Var(2))
 			}

--- a/crates/core/src/protocols/sumcheck/oracles.rs
+++ b/crates/core/src/protocols/sumcheck/oracles.rs
@@ -42,7 +42,7 @@ pub fn constraint_set_sumcheck_claim<F: TowerField>(
 	{
 		match predicate {
 			ConstraintPredicate::Sum(sum) => sums.push(CompositeSumClaim {
-				composition: ArithCircuitPoly::with_n_vars(n_multilinears, composition)?,
+				composition: ArithCircuitPoly::with_n_vars_circuit(n_multilinears, composition)?,
 				sum,
 			}),
 			_ => bail!(Error::MixedBatchingNotSupported),
@@ -71,7 +71,7 @@ pub fn constraint_set_zerocheck_claim<F: TowerField>(
 	{
 		match predicate {
 			ConstraintPredicate::Zero => {
-				zeros.push(ArithCircuitPoly::with_n_vars(n_multilinears, composition)?)
+				zeros.push(ArithCircuitPoly::with_n_vars_circuit(n_multilinears, composition)?)
 			}
 			_ => bail!(Error::MixedBatchingNotSupported),
 		}

--- a/crates/core/src/protocols/sumcheck/prove/eq_ind.rs
+++ b/crates/core/src/protocols/sumcheck/prove/eq_ind.rs
@@ -537,7 +537,7 @@ where
 			.iter_mut()
 			.map(|(composition, const_eval_suffix)| {
 				let composition_at_infinity =
-					ArithCircuitPoly::new(composition.expression().leading_term());
+					ArithCircuitPoly::new(&composition.expression().leading_term());
 
 				const_eval_suffix.update(self.state.evaluation_order(), n_rounds_remaining);
 

--- a/crates/core/src/protocols/sumcheck/prove/oracles.rs
+++ b/crates/core/src/protocols/sumcheck/prove/oracles.rs
@@ -87,15 +87,14 @@ where
 	} in constraints
 	{
 		let composition_base = composition
-			.clone()
 			.try_convert_field::<FBase>()
 			.map_err(|_| Error::CircuitFieldDowncastFailed)?;
 		match predicate {
 			ConstraintPredicate::Zero => {
 				zeros.push((
 					name,
-					ArithCircuitPoly::with_n_vars(multilinears.len(), composition_base)?,
-					ArithCircuitPoly::with_n_vars(multilinears.len(), composition)?,
+					ArithCircuitPoly::with_n_vars_circuit(multilinears.len(), composition_base)?,
+					ArithCircuitPoly::with_n_vars_circuit(multilinears.len(), composition)?,
 				));
 			}
 			_ => bail!(Error::MixedBatchingNotSupported),
@@ -141,7 +140,10 @@ where
 	{
 		match predicate {
 			ConstraintPredicate::Sum(sum) => sums.push(CompositeSumClaim {
-				composition: ArithCircuitPoly::with_n_vars(multilinears.len(), composition)?,
+				composition: ArithCircuitPoly::with_n_vars_circuit(
+					multilinears.len(),
+					composition,
+				)?,
 				sum,
 			}),
 			_ => bail!(Error::MixedBatchingNotSupported),

--- a/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
@@ -196,7 +196,7 @@ where
 		let evaluators = izip!(&self.compositions, &self.domains)
 			.map(|(composition, interpolation_domain)| {
 				let composition_at_infinity =
-					ArithCircuitPoly::new(composition.expression().leading_term());
+					ArithCircuitPoly::new(&composition.expression().leading_term());
 
 				RegularSumcheckEvaluator {
 					composition,

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -287,7 +287,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 						.iter()
 						.map(|zero_constraint| Constraint {
 							name: zero_constraint.name.clone(),
-							composition: zero_constraint.expr.clone(),
+							composition: (&zero_constraint.expr).into(),
 							predicate: ConstraintPredicate::Zero,
 						})
 						.collect::<Vec<_>>();

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -1048,7 +1048,7 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegment<'a, P> {
 		// get split up in practice, it's not a problem yet. If we see stack overflows, we should
 		// split up the evaluation into multiple batches.
 		let mut evals = zeroed_vec(1 << log_packed_elems);
-		ArithCircuitPoly::new(expr.expr().clone()).batch_evaluate(&cols, &mut evals)?;
+		ArithCircuitPoly::new(expr.expr()).batch_evaluate(&cols, &mut evals)?;
 		Ok(evals.into_iter())
 	}
 

--- a/crates/macros/src/arith_circuit_poly.rs
+++ b/crates/macros/src/arith_circuit_poly.rs
@@ -18,7 +18,7 @@ impl ToTokens for ArithCircuitPolyItem {
 				use binius_field::Field;
 				use binius_math::ArithExpr as Expr;
 
-				binius_core::polynomial::ArithCircuitPoly::<binius_field::#field_name>::new(#poly)
+				binius_core::polynomial::ArithCircuitPoly::<binius_field::#field_name>::new(&#poly)
 			}
 		});
 	}

--- a/crates/math/Cargo.toml
+++ b/crates/math/Cargo.toml
@@ -8,12 +8,13 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+auto_impl.workspace = true
 binius_field = { path = "../field", default-features = false }
 binius_macros = { path = "../macros", default-features = false }
 binius_maybe_rayon = { path = "../maybe_rayon", default-features = false }
 binius_utils = { path = "../utils", default-features = false }
-auto_impl.workspace = true
 bytemuck.workspace = true
+bytes.workspace = true
 either.workspace = true
 getset.workspace = true
 itertools.workspace = true

--- a/crates/math/src/arith_expr.rs
+++ b/crates/math/src/arith_expr.rs
@@ -740,9 +740,9 @@ impl<F: Field> ArithCircuit<F> {
 							expected: *index,
 						}
 					})?;
-					return Ok(ArithCircuitStep::Var(new_index));
+					Ok(ArithCircuitStep::Var(new_index))
 				} else {
-					return Ok(step.clone());
+					Ok(*step)
 				}
 			})
 			.collect::<Result<Vec<_>, _>>()?;
@@ -810,7 +810,7 @@ impl<F: Field> From<&ArithExpr<F>> for ArithCircuit<F> {
 			}
 		}
 
-		ArithCircuit { steps }
+		Self { steps }
 	}
 }
 

--- a/crates/utils/src/serialization.rs
+++ b/crates/utils/src/serialization.rs
@@ -290,7 +290,7 @@ impl DeserializeBytes for String {
 	}
 }
 
-impl<T: SerializeBytes> SerializeBytes for Vec<T> {
+impl<T: SerializeBytes> SerializeBytes for [T] {
 	fn serialize(
 		&self,
 		mut write_buf: impl BufMut,
@@ -299,6 +299,16 @@ impl<T: SerializeBytes> SerializeBytes for Vec<T> {
 		SerializeBytes::serialize(&self.len(), &mut write_buf, mode)?;
 		self.iter()
 			.try_for_each(|item| SerializeBytes::serialize(item, &mut write_buf, mode))
+	}
+}
+
+impl<T: SerializeBytes> SerializeBytes for Vec<T> {
+	fn serialize(
+		&self,
+		mut write_buf: impl BufMut,
+		mode: SerializationMode,
+	) -> Result<(), SerializationError> {
+		SerializeBytes::serialize(self.as_slice(), &mut write_buf, mode)
 	}
 }
 


### PR DESCRIPTION
Several changes to support sub-expression deduplication in `ExprTree` and ArithCircuitPoly:
1. Use `Arc` in `ArithExpr`
2. Introduce `ArithCircuit` as an intermediate object during `ArithExpr` serialization/deserialization of `ArithExpr` to preserve the `Arc`s keep pointing the same nodes after serialization roundtrip. This structure is not public.
3. At the moment of creation `ArithCircuitPoly` automatically deduplicates the nodes, reusing already created steps if possible. This seems to be of almost the same code complexity, so IMO there is no reason to introduce a new public entity `ArithExpr`.