### PR TITLE
Remove overly conservative domain size check in AdditiveNTT

### DIFF
--- a/crates/core/src/protocols/sumcheck/prove/univariate.rs
+++ b/crates/core/src/protocols/sumcheck/prove/univariate.rs
@@ -357,11 +357,9 @@ where
 
 	// Batching factors for strided NTTs.
 	let log_extension_degree_base_domain = <FBase as ExtensionField<FDomain>>::LOG_DEGREE;
-	let pdomain_log_width = <P as PackedExtension<FDomain>>::PackedSubfield::LOG_WIDTH;
 
-	// The lower bound is due to SingleThreadedNTT implementation quirk, which requires
-	// at least two packed field elements to be able to use PackedField::interleave.
-	let min_domain_bits = log2_ceil_usize(max_domain_size).max(pdomain_log_width + 1);
+	// Check that domain field contains the required NTT cosets.
+	let min_domain_bits = log2_ceil_usize(max_domain_size);
 	if min_domain_bits > FDomain::N_BITS {
 		bail!(MathError::DomainSizeTooLarge);
 	}

--- a/crates/ntt/src/single_threaded.rs
+++ b/crates/ntt/src/single_threaded.rs
@@ -319,13 +319,8 @@ pub fn check_batch_transform_inputs_and_params<PB: PackedField>(
 
 	let coset_bits = 32 - coset.leading_zeros() as usize;
 
-	// The domain size should be at least large enough to represent the given coset;
-	// on the lower end, there is a fallback for data.len() == 1 which reduces to
-	// a forward/inverse NTT on the [PB; 2], which demands log_domain_size of
-	// at least min(PB::LOG_WIDTH + 1 - log_batch_size, 0).
-	// Not enforcing this bound makes some twiddle values unavailable.
-	let log_required_domain_size =
-		(log_y + coset_bits).max((PB::LOG_WIDTH + 1).saturating_sub(log_x));
+	// The domain size should be at least large enough to represent the given coset.
+	let log_required_domain_size = log_y + coset_bits;
 	if log_required_domain_size > log_domain_size {
 		return Err(Error::DomainTooSmall {
 			log_required_domain_size,

--- a/crates/ntt/src/tests/ntt_tests.rs
+++ b/crates/ntt/src/tests/ntt_tests.rs
@@ -10,9 +10,9 @@ use binius_field::{
 		packed_8::PackedBinaryField1x8b,
 	},
 	underlier::{NumCast, WithUnderlier},
-	AESTowerField8b, BinaryField, BinaryField8b, ByteSlicedAES8x16x16b, PackedBinaryField16x32b,
-	PackedBinaryField32x16b, PackedBinaryField8x32b, PackedExtension, PackedField,
-	RepackedExtension,
+	AESTowerField8b, BinaryField, BinaryField8b, ByteSlicedAES16x32x8b, ByteSlicedAES8x16x16b,
+	PackedBinaryField16x32b, PackedBinaryField32x16b, PackedBinaryField8x32b, PackedExtension,
+	PackedField, RepackedExtension,
 };
 use rand::{rngs::StdRng, SeedableRng};
 
@@ -104,7 +104,7 @@ fn check_roundtrip_all_ntts<P>(
 		.collect::<Vec<_>>();
 
 	let cosets = 0..1 << max_log_coset;
-	for log_stride_batch in 0..max_log_stride_batch {
+	for log_stride_batch in 0..=max_log_stride_batch {
 		let log_n_b_range = if data.len() > 1 {
 			let single_log_n = data.len().ilog2() as usize + P::LOG_WIDTH - log_stride_batch;
 			single_log_n..single_log_n + 1
@@ -207,6 +207,11 @@ fn test_sub_packing_width() {
 #[test]
 fn test_3d_bytesliced_sub_packing_width() {
 	check_roundtrip_all_ntts::<ByteSlicedAES8x16x16b>(12, 0, 2, 1);
+}
+
+#[test]
+fn test_3d_bytesliced_larger_than_domain() {
+	check_roundtrip_all_ntts::<ByteSlicedAES16x32x8b>(8, 0, 0, 0);
 }
 
 fn check_packed_extension_roundtrip_with_reference<F, PE>(


### PR DESCRIPTION
Changes in #200 removed the need for the domain size to be at least twice the packed field width, but the check remained. This followup PR removes this overly conservative restriction.