### PR TITLE
[m3] fix OOB in Display impl of ConstraintSystem

### DIFF
--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -55,7 +55,7 @@ impl<F: TowerField> std::fmt::Display for ConstraintSystem<F> {
 					let columns = flush
 						.column_indices
 						.iter()
-						.map(|i| table.columns[partition.columns[*i]].name.clone())
+						.map(|i| table.columns[*i].name.clone())
 						.collect::<Vec<_>>()
 						.join(", ");
 					match flush.direction {


### PR DESCRIPTION
If you try to display the constraint system in the m3/collatz test, you would get

```
thread 'arithmetization::test_collatz_validate_witness' panicked at /Users/pepyakin/dev/irreducible/binius/crates/m3/src/builder/constraint_system.rs:58:47:
index out of bounds: the len is 3 but the index is 3
```

I am not 100% sure in the fix, but it seems like `column_indices` are in the `table.columns` index space.