### PR TITLE
[compute] Interface for host memory allocation

### DIFF
--- a/crates/compute/Cargo.toml
+++ b/crates/compute/Cargo.toml
@@ -13,3 +13,4 @@ thiserror.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
+rand = { workspace = true, features = ["std"] }

--- a/crates/compute/Cargo.toml
+++ b/crates/compute/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+binius_field = { path = "../field", default-features = false }
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/compute/src/alloc.rs
+++ b/crates/compute/src/alloc.rs
@@ -21,6 +21,13 @@ where
 		}
 	}
 
+	pub fn from_ref<'b>(buffer: &'b mut Mem::FSliceMut<'a>) -> BumpAllocator<'b, F, Mem> {
+		let buffer = Mem::slice_mut(buffer, ..);
+		BumpAllocator {
+			buffer: Cell::new(Some(buffer)),
+		}
+	}
+
 	/// Returns the remaining number of elements that can be allocated.
 	pub fn capacity(&self) -> usize {
 		let buffer = self

--- a/crates/compute/src/alloc.rs
+++ b/crates/compute/src/alloc.rs
@@ -21,6 +21,17 @@ where
 		}
 	}
 
+	/// Returns the remaining number of elements that can be allocated.
+	pub fn capacity(&self) -> usize {
+		let buffer = self
+			.buffer
+			.take()
+			.expect("buffer is always Some by invariant");
+		let ret = buffer.len();
+		self.buffer.set(Some(buffer));
+		ret
+	}
+
 	/// Allocates a slice of elements.
 	///
 	/// This method operates on an immutable self reference so that multiple allocator references

--- a/crates/compute/src/cpu/layer.rs
+++ b/crates/compute/src/cpu/layer.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use binius_field::TowerField;
 
 use super::memory::CpuMemory;
-use crate::layer::ComputeLayer;
+use crate::layer::{ComputeLayer, Error, FSlice, FSliceMut};
 
 #[derive(Debug, Default)]
 pub struct CpuLayer<F: TowerField>(PhantomData<F>);
@@ -15,5 +15,39 @@ impl<F: TowerField> ComputeLayer<F> for CpuLayer<F> {
 
 	fn host_alloc(&self, n: usize) -> impl AsMut<[F]> + '_ {
 		vec![F::ZERO; n]
+	}
+
+	fn copy_h2d(&self, src: &[F], dst: &mut FSliceMut<'_, F, Self>) -> Result<(), Error> {
+		assert_eq!(
+			src.len(),
+			dst.len(),
+			"precondition: src and dst buffers must have the same length"
+		);
+		dst.copy_from_slice(src);
+		Ok(())
+	}
+
+	fn copy_d2h(&self, src: FSlice<'_, F, Self>, dst: &mut [F]) -> Result<(), Error> {
+		assert_eq!(
+			src.len(),
+			dst.len(),
+			"precondition: src and dst buffers must have the same length"
+		);
+		dst.copy_from_slice(src);
+		Ok(())
+	}
+
+	fn copy_d2d(
+		&self,
+		src: FSlice<'_, F, Self>,
+		dst: &mut FSliceMut<'_, F, Self>,
+	) -> Result<(), Error> {
+		assert_eq!(
+			src.len(),
+			dst.len(),
+			"precondition: src and dst buffers must have the same length"
+		);
+		dst.copy_from_slice(src);
+		Ok(())
 	}
 }

--- a/crates/compute/src/cpu/layer.rs
+++ b/crates/compute/src/cpu/layer.rs
@@ -1,0 +1,19 @@
+// Copyright 2025 Irreducible Inc.
+
+use std::marker::PhantomData;
+
+use binius_field::TowerField;
+
+use super::memory::CpuMemory;
+use crate::layer::ComputeLayer;
+
+#[derive(Debug, Default)]
+pub struct CpuLayer<F: TowerField>(PhantomData<F>);
+
+impl<F: TowerField> ComputeLayer<F> for CpuLayer<F> {
+	type DevMem = CpuMemory;
+
+	fn host_alloc(&self, n: usize) -> impl AsMut<[F]> + '_ {
+		vec![F::ZERO; n]
+	}
+}

--- a/crates/compute/src/cpu/mod.rs
+++ b/crates/compute/src/cpu/mod.rs
@@ -6,4 +6,8 @@
 //! for readability, used to validate the abstract interfaces and provide algorithmic references
 //! for optimized implementations.
 
+pub mod layer;
 pub mod memory;
+
+pub use layer::CpuLayer;
+pub use memory::CpuMemory;

--- a/crates/compute/src/layer.rs
+++ b/crates/compute/src/layer.rs
@@ -1,0 +1,48 @@
+// Copyright 2025 Irreducible Inc.
+
+use crate::memory::ComputeMemory;
+
+pub trait ComputeLayer<F> {
+	/// The device memory.
+	type DevMem: ComputeMemory<F>;
+
+	/// Allocates a slice of memory on the host that is prepared for transfers to/from the device.
+	///
+	/// Depending on the compute layer, this may perform steps beyond just allocating memory. For
+	/// example, it may allocate huge pages or map the allocated memory to the IOMMU.
+	///
+	/// The returned buffer is lifetime bound to the compute layer, allowing return types to have
+	/// drop methods referencing data in the compute layer.
+	fn host_alloc(&self, n: usize) -> impl AsMut<[F]> + '_;
+}
+
+// Convenience types for the device memory.
+pub type FSlice<'a, F, L> = <<L as ComputeLayer<F>>::DevMem as ComputeMemory<F>>::FSlice<'a>;
+pub type FSliceMut<'a, F, L> = <<L as ComputeLayer<F>>::DevMem as ComputeMemory<F>>::FSliceMut<'a>;
+
+#[cfg(test)]
+mod tests {
+	use assert_matches::assert_matches;
+	use binius_field::{BinaryField128b, TowerField};
+
+	use super::*;
+	use crate::{
+		alloc::{BumpAllocator, Error as AllocError},
+		cpu::{CpuLayer, CpuMemory},
+	};
+
+	/// Test showing how to allocate host memory and create a sub-allocator over it.
+	fn test_host_alloc<F: TowerField, CL: ComputeLayer<F>>(layer: CL) {
+		let mut host_slice = layer.host_alloc(256);
+
+		let bump = BumpAllocator::<F, CpuMemory>::new(host_slice.as_mut());
+		assert_eq!(bump.alloc(100).unwrap().len(), 100);
+		assert_eq!(bump.alloc(100).unwrap().len(), 100);
+		assert_matches!(bump.alloc(100), Err(AllocError::OutOfMemory));
+	}
+
+	#[test]
+	fn test_cpu_layer() {
+		test_host_alloc(CpuLayer::<BinaryField128b>::default());
+	}
+}

--- a/crates/compute/src/layer.rs
+++ b/crates/compute/src/layer.rs
@@ -1,7 +1,8 @@
 // Copyright 2025 Irreducible Inc.
 
-use crate::memory::ComputeMemory;
+use super::{alloc::Error as AllocError, memory::ComputeMemory};
 
+/// A hardware abstraction layer (HAL) for compute operations.
 pub trait ComputeLayer<F> {
 	/// The device memory.
 	type DevMem: ComputeMemory<F>;
@@ -14,16 +15,55 @@ pub trait ComputeLayer<F> {
 	/// The returned buffer is lifetime bound to the compute layer, allowing return types to have
 	/// drop methods referencing data in the compute layer.
 	fn host_alloc(&self, n: usize) -> impl AsMut<[F]> + '_;
+
+	/// Copy data from the host to the device.
+	///
+	/// ## Preconditions
+	///
+	/// * `src` and `dst` must have the same length.
+	/// * `src` must be a slice of a buffer returned by [`Self::host_alloc`].
+	fn copy_h2d(&self, src: &[F], dst: &mut FSliceMut<'_, F, Self>) -> Result<(), Error>;
+
+	/// Copy data from the device to the host.
+	///
+	/// ## Preconditions
+	///
+	/// * `src` and `dst` must have the same length.
+	/// * `dst` must be a slice of a buffer returned by [`Self::host_alloc`].
+	fn copy_d2h(&self, src: FSlice<'_, F, Self>, dst: &mut [F]) -> Result<(), Error>;
+
+	/// Copy data between disjoint device buffers.
+	///
+	/// ## Preconditions
+	///
+	/// * `src` and `dst` must have the same length.
+	fn copy_d2d(
+		&self,
+		src: FSlice<'_, F, Self>,
+		dst: &mut FSliceMut<'_, F, Self>,
+	) -> Result<(), Error>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	#[error("input validation: {0}")]
+	InputValidation(String),
+	#[error("allocation error: {0}")]
+	Alloc(#[from] AllocError),
+	#[error("device error: {0}")]
+	DeviceError(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
 // Convenience types for the device memory.
-pub type FSlice<'a, F, L> = <<L as ComputeLayer<F>>::DevMem as ComputeMemory<F>>::FSlice<'a>;
-pub type FSliceMut<'a, F, L> = <<L as ComputeLayer<F>>::DevMem as ComputeMemory<F>>::FSliceMut<'a>;
+pub type FSlice<'a, F, HAL> = <<HAL as ComputeLayer<F>>::DevMem as ComputeMemory<F>>::FSlice<'a>;
+pub type FSliceMut<'a, F, HAL> =
+	<<HAL as ComputeLayer<F>>::DevMem as ComputeMemory<F>>::FSliceMut<'a>;
 
 #[cfg(test)]
 mod tests {
 	use assert_matches::assert_matches;
-	use binius_field::{BinaryField128b, TowerField};
+	use binius_field::{BinaryField128b, Field, TowerField};
+	use rand::{prelude::StdRng, SeedableRng};
 
 	use super::*;
 	use crate::{
@@ -32,8 +72,8 @@ mod tests {
 	};
 
 	/// Test showing how to allocate host memory and create a sub-allocator over it.
-	fn test_host_alloc<F: TowerField, CL: ComputeLayer<F>>(layer: CL) {
-		let mut host_slice = layer.host_alloc(256);
+	fn test_host_alloc<F: TowerField, HAL: ComputeLayer<F>>(hal: HAL) {
+		let mut host_slice = hal.host_alloc(256);
 
 		let bump = BumpAllocator::<F, CpuMemory>::new(host_slice.as_mut());
 		assert_eq!(bump.alloc(100).unwrap().len(), 100);
@@ -41,8 +81,45 @@ mod tests {
 		assert_matches!(bump.alloc(100), Err(AllocError::OutOfMemory));
 	}
 
+	/// Test showing how to allocate host memory and create a sub-allocator over it.
+	// TODO: This 'a lifetime bound on HAL is pretty annoying. I'd like to get rid of it.
+	fn test_copy_host_device<'a, F: TowerField, HAL: ComputeLayer<F> + 'a>(
+		hal: HAL,
+		mut dev_mem: FSliceMut<'a, F, HAL>,
+	) {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		let mut host_slice = hal.host_alloc(256);
+
+		let host_alloc = BumpAllocator::<F, CpuMemory>::new(host_slice.as_mut());
+		let dev_alloc = BumpAllocator::<F, HAL::DevMem>::from_ref(&mut dev_mem);
+
+		let host_buf_1 = host_alloc.alloc(128).unwrap();
+		let host_buf_2 = host_alloc.alloc(128).unwrap();
+		let mut dev_buf_1 = dev_alloc.alloc(128).unwrap();
+		let mut dev_buf_2 = dev_alloc.alloc(128).unwrap();
+
+		for elem in &mut *host_buf_1 {
+			*elem = F::random(&mut rng);
+		}
+
+		hal.copy_h2d(&host_buf_1, &mut dev_buf_1).unwrap();
+		hal.copy_d2d(HAL::DevMem::as_const(&dev_buf_1), &mut dev_buf_2)
+			.unwrap();
+		hal.copy_d2h(HAL::DevMem::as_const(&dev_buf_2), host_buf_2)
+			.unwrap();
+
+		assert_eq!(host_buf_1, host_buf_2);
+	}
+
 	#[test]
-	fn test_cpu_layer() {
+	fn test_cpu_host_alloc() {
 		test_host_alloc(CpuLayer::<BinaryField128b>::default());
+	}
+
+	#[test]
+	fn test_cpu_copy_host_device() {
+		let mut dev_mem = vec![BinaryField128b::ZERO; 256];
+		test_copy_host_device(CpuLayer::<BinaryField128b>::default(), dev_mem.as_mut_slice());
 	}
 }

--- a/crates/compute/src/layer.rs
+++ b/crates/compute/src/layer.rs
@@ -103,7 +103,7 @@ mod tests {
 			*elem = F::random(&mut rng);
 		}
 
-		hal.copy_h2d(&host_buf_1, &mut dev_buf_1).unwrap();
+		hal.copy_h2d(host_buf_1, &mut dev_buf_1).unwrap();
 		hal.copy_d2d(HAL::DevMem::as_const(&dev_buf_1), &mut dev_buf_2)
 			.unwrap();
 		hal.copy_d2h(HAL::DevMem::as_const(&dev_buf_2), host_buf_2)

--- a/crates/compute/src/lib.rs
+++ b/crates/compute/src/lib.rs
@@ -8,4 +8,5 @@
 
 pub mod alloc;
 pub mod cpu;
+pub mod layer;
 pub mod memory;


### PR DESCRIPTION
This is an alternate design to https://github.com/IrreducibleOSS/binius/pull/228 that I find much simpler. Instead of abstracting host memory behind a type, we allow host memory to be represented with simple slices. The `BumpAllocator` is reused for host memory allocation using the `CpuMemory` implementation, which uses regular slices for `FSlice` & `FSliceMut`.

There are some other good changes to the documentation in https://github.com/IrreducibleOSS/binius/pull/228 that I'd still like to port over, even if we go with this approach.