### PR TITLE
[Evalcheck] fix ZeroPadded

### DIFF
--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -520,7 +520,7 @@ where
 
 				let subclaim = EvalcheckMultilinearClaim {
 					id,
-					eval_point: eval_point.clone(),
+					eval_point: inner_eval_point.into(),
 					eval,
 				};
 


### PR DESCRIPTION
The subclaim of `ZeroPadded` must use inner_eval_point instead of eval_point