### PR TITLE
SYS-110:: define ComputeAllocator trait

### DIFF
--- a/crates/compute/src/alloc.rs
+++ b/crates/compute/src/alloc.rs
@@ -5,6 +5,22 @@ use std::cell::Cell;
 use super::memory::{ComputeMemory, DevSlice};
 use crate::cpu::CpuMemory;
 
+pub trait ComputeAllocator<'a, F, Mem: ComputeMemory<F>> {
+	/// Allocates a slice of elements.
+	///
+	/// This method operates on an immutable self reference so that multiple allocator references
+	/// can co-exist. This follows how the `bumpalo` crate's `Bump` interface works. It may not be
+	/// necessary actually (since this partitions a borrowed slice, whereas `Bump` owns its memory).
+	///
+	/// ## Pre-conditions
+	///
+	/// - `n` must be a multiple of `Mem::MIN_SLICE_LEN`
+	fn alloc(&self, n: usize) -> Result<Mem::FSliceMut<'a>, Error>;
+
+	/// Returns the remaining number of elements that can be allocated.
+	fn capacity(&self) -> usize;
+}
+
 /// Basic bump allocator that allocates slices from an underlying memory buffer provided at
 /// construction.
 pub struct BumpAllocator<'a, F, Mem: ComputeMemory<F>> {
@@ -28,28 +44,10 @@ where
 			buffer: Cell::new(Some(buffer)),
 		}
 	}
+}
 
-	/// Returns the remaining number of elements that can be allocated.
-	pub fn capacity(&self) -> usize {
-		let buffer = self
-			.buffer
-			.take()
-			.expect("buffer is always Some by invariant");
-		let ret = buffer.len();
-		self.buffer.set(Some(buffer));
-		ret
-	}
-
-	/// Allocates a slice of elements.
-	///
-	/// This method operates on an immutable self reference so that multiple allocator references
-	/// can co-exist. This follows how the `bumpalo` crate's `Bump` interface works. It may not be
-	/// necessary actually (since this partitions a borrowed slice, whereas `Bump` owns its memory).
-	///
-	/// ## Pre-conditions
-	///
-	/// - `n` must be a multiple of `Mem::MIN_SLICE_LEN`
-	pub fn alloc(&self, n: usize) -> Result<Mem::FSliceMut<'a>, Error> {
+impl<'a, F, Mem: ComputeMemory<F>> ComputeAllocator<'a, F, Mem> for BumpAllocator<'a, F, Mem> {
+	fn alloc(&self, n: usize) -> Result<Mem::FSliceMut<'a>, Error> {
 		let buffer = self
 			.buffer
 			.take()
@@ -65,6 +63,16 @@ where
 			// buffer contains Some, invariant restored
 			Ok(lhs)
 		}
+	}
+
+	fn capacity(&self) -> usize {
+		let buffer = self
+			.buffer
+			.take()
+			.expect("buffer is always Some by invariant");
+		let ret = buffer.len();
+		self.buffer.set(Some(buffer));
+		ret
 	}
 }
 

--- a/crates/compute/src/layer.rs
+++ b/crates/compute/src/layer.rs
@@ -67,7 +67,7 @@ mod tests {
 
 	use super::*;
 	use crate::{
-		alloc::{BumpAllocator, Error as AllocError, HostBumpAllocator},
+		alloc::{BumpAllocator, ComputeAllocator, Error as AllocError, HostBumpAllocator},
 		cpu::CpuLayer,
 	};
 


### PR DESCRIPTION
Accelerated compute backends will provide custom implementations for host and device allocations. Define a trait for bump allocators that will be used throughout Binius for compute buffer allocations.