### PR TITLE
SYS-110: support alignment requirements for ComputeMemory slices

### DIFF
--- a/crates/compute/src/alloc.rs
+++ b/crates/compute/src/alloc.rs
@@ -2,7 +2,7 @@
 
 use std::cell::Cell;
 
-use super::memory::{ComputeMemory, DevSlice};
+use super::memory::{ComputeMemory, OpaqueSlice};
 use crate::cpu::CpuMemory;
 
 pub trait ComputeAllocator<'a, F, Mem: ComputeMemory<F>> {

--- a/crates/compute/src/cpu/memory.rs
+++ b/crates/compute/src/cpu/memory.rs
@@ -9,6 +9,7 @@ pub struct CpuMemory;
 
 impl<F: 'static> ComputeMemory<F> for CpuMemory {
 	const MIN_SLICE_LEN: usize = 1;
+	const REQUIRED_SLICE_ALIGNMENT: usize = 1;
 
 	type FSlice<'a> = &'a [F];
 	type FSliceMut<'a> = &'a mut [F];


### PR DESCRIPTION
Accelerated backends may require slices to be aligned to addresses that are multiples of a value larger than `MIN_SLICE_LEN`. Require compute memory implementations to define a required slice alignment. Binius operations transforming device slices must preserve the required alignment for compatibility with accelerated kernels accepting device slices.