### PR TITLE
Fix typos: correct spelling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ domain, and `FEncode` is used as the field of an encoding matrix.
 
 #### Use namespacing
 
-If an identifier is defined in a module and is unambigious in the context of that module, it does _not_ need to
+If an identifier is defined in a module and is unambiguous in the context of that module, it does _not_ need to
 duplicate the module name into the identifier. For example, we have many protocols defined in `binius_core::protocols`
 that expose a `prove` and `verify` method. Because they are namespaced within the protocol modules, for example the
 `sumcheck` module, these identifiers do not need to be named `sumcheck_verify` and `sumcheck_prove`. The caller has the

--- a/crates/circuits/src/lasso/sha256.rs
+++ b/crates/circuits/src/lasso/sha256.rs
@@ -107,7 +107,7 @@ impl SeveralBitwise {
 			let zin_u32 = witness.get::<B1>(zin)?.as_slice::<u32>();
 
 			// The following code works only if packed width is at least 8.
-			// Which should be true in real life cases, becasue we don't use
+			// Which should be true in real life cases, because we don't use
 			// packed types with less than 128 bits size.
 			if PackedType::<U, B16>::LOG_WIDTH < 3 {
 				return Err(anyhow::anyhow!(

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -168,7 +168,7 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 			.expr()
 			.convert_field()
 			.remap_vars(&var_remapping)
-			.expect("var_remapping should be large enought");
+			.expect("var_remapping should be large enough");
 
 		self.table.new_column(
 			self.namespaced_name(name),


### PR DESCRIPTION
This PR fixes three minor typos across different files:

1. In CONTRIBUTING.md:
- Fixed word spacing (no functional change)

2. In crates/circuits/src/lasso/sha256.rs:
- Fixed spelling of "becasue" to "because" in comments

3. In crates/m3/src/builder/table.rs:
- Fixed spelling of "enought" to "enough" in expect message

These are simple spelling corrections that improve code readability without any functional changes.