### PR TITLE
[m3] Add structured column type

### DIFF
--- a/crates/core/src/polynomial/multivariate.rs
+++ b/crates/core/src/polynomial/multivariate.rs
@@ -3,9 +3,10 @@
 use std::{borrow::Borrow, fmt::Debug, iter::repeat_with, marker::PhantomData, sync::Arc};
 
 use auto_impl::auto_impl;
-use binius_field::{Field, PackedField};
+use binius_field::{Field, PackedField, TowerField};
 use binius_math::{
-	ArithExpr, CompositionPoly, MLEDirectAdapter, MultilinearPoly, MultilinearQueryRef,
+	ArithCircuit, ArithExpr, CompositionPoly, MLEDirectAdapter, MultilinearPoly,
+	MultilinearQueryRef,
 };
 use binius_utils::{bail, SerializationError, SerializationMode};
 use bytes::BufMut;
@@ -70,6 +71,24 @@ impl<P: PackedField> CompositionPoly<P> for IdentityCompositionPoly {
 
 	fn binary_tower_level(&self) -> usize {
 		0
+	}
+}
+
+impl<F: TowerField> MultivariatePoly<F> for ArithCircuit<F> {
+	fn n_vars(&self) -> usize {
+		self.n_vars()
+	}
+
+	fn degree(&self) -> usize {
+		self.degree()
+	}
+
+	fn evaluate(&self, query: &[F]) -> Result<F, Error> {
+		self.evaluate(query).map_err(Error::from)
+	}
+
+	fn binary_tower_level(&self) -> usize {
+		self.binary_tower_level()
 	}
 }
 

--- a/crates/m3/Cargo.toml
+++ b/crates/m3/Cargo.toml
@@ -21,6 +21,7 @@ either.workspace = true
 getset.workspace = true
 itertools.workspace = true
 thiserror.workspace = true
+log = "0.4.27"
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/crates/m3/Cargo.toml
+++ b/crates/m3/Cargo.toml
@@ -21,7 +21,6 @@ either.workspace = true
 getset.workspace = true
 itertools.workspace = true
 thiserror.workspace = true
-log = "0.4.27"
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/crates/m3/src/builder/column.rs
+++ b/crates/m3/src/builder/column.rs
@@ -6,7 +6,7 @@ use binius_core::{oracle::ShiftVariant, polynomial::MultivariatePoly};
 use binius_field::{ExtensionField, TowerField};
 use binius_math::ArithExpr;
 
-use super::{table::TableId, types::B128};
+use super::{structured::StructuredDynSize, table::TableId, types::B128};
 
 /// An index of a column within a table.
 pub type ColumnIndex = usize;
@@ -152,6 +152,7 @@ pub enum ColumnDef<F: TowerField = B128> {
 	Constant {
 		poly: Arc<dyn MultivariatePoly<F>>,
 	},
+	StructuredDynSize(StructuredDynSize),
 	StaticExp {
 		bit_cols: Vec<ColumnIndex>,
 		base: F,

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -13,7 +13,7 @@ use binius_core::{
 	transparent::step_down::StepDown,
 };
 use binius_field::{PackedField, TowerField};
-use binius_math::LinearNormalForm;
+use binius_math::{ArithCircuit, LinearNormalForm};
 use binius_utils::checked_arithmetics::log2_strict_usize;
 use bumpalo::Bump;
 use itertools::chain;
@@ -435,6 +435,10 @@ fn add_oracle_for_column<F: TowerField>(
 			transparent_single[id.table_index].unwrap(),
 			n_vars - shape.log_values_per_row,
 		)?,
+		ColumnDef::StructuredDynSize(structured) => {
+			let expr = structured.expr(n_vars)?;
+			addition.transparent(ArithCircuit::from(&expr))?
+		}
 		ColumnDef::StaticExp {
 			base_tower_level, ..
 		} => addition.committed(n_vars, *base_tower_level),

--- a/crates/m3/src/builder/error.rs
+++ b/crates/m3/src/builder/error.rs
@@ -5,7 +5,7 @@ use std::cell::{BorrowError, BorrowMutError};
 use binius_core::{oracle::Error as OracleError, polynomial::Error as PolynomialError};
 use binius_math::Error as MathError;
 
-use super::{column::ColumnId, table::TableId};
+use super::{column::ColumnId, structured::Error as StructuredError, table::TableId};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -22,6 +22,8 @@ pub enum Error {
 	},
 	#[error("cannot construct witness index for empty table {table_id}")]
 	EmptyTable { table_id: TableId },
+	#[error("structured column error: {0}")]
+	Structured(#[from] StructuredError),
 	#[error("table {table_id} index has already been initialized")]
 	TableIndexAlreadyInitialized { table_id: TableId },
 	#[error("column is not in table; column table ID: {column_table_id}, witness table ID: {witness_table_id}")]

--- a/crates/m3/src/builder/mod.rs
+++ b/crates/m3/src/builder/mod.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod expr;
 mod multi_iter;
 pub mod statement;
+pub mod structured;
 pub mod table;
 #[cfg(feature = "test_utils")]
 pub mod test_utils;
@@ -19,6 +20,7 @@ pub use constraint_system::*;
 pub use error::*;
 pub use expr::*;
 pub use statement::*;
+pub use structured::StructuredDynSize;
 pub use table::*;
 pub use types::*;
 pub use witness::*;

--- a/crates/m3/src/builder/structured.rs
+++ b/crates/m3/src/builder/structured.rs
@@ -1,0 +1,120 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_field::{ExtensionField, TowerField};
+use binius_math::ArithExpr;
+
+use crate::builder::B1;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	#[error("log_size must be less than or equal to F::N_BITS")]
+	ColumnSizeTooLarge,
+	#[error("math error: {0}")]
+	Math(#[from] binius_math::Error),
+}
+
+/// Specifications of structured columns that generated from a dynamic table size.
+///
+/// A structured column is one that has sufficient structure that its multilinear extension
+/// can be evaluated succinctly. These are referred to as "MLE-structured" tables in [Lasso].
+///
+/// [Lasso]: <https://eprint.iacr.org/2023/1216>
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StructuredDynSize {
+	/// A column whose values are incrementing binary field elements in lexicographic order.
+	Incrementing,
+}
+
+impl StructuredDynSize {
+	/// Returns an arithmetic expression that represents the multilinear extension of the
+	/// structured column.
+	pub fn expr<F: TowerField>(self, log_size: usize) -> Result<ArithExpr<F>, Error> {
+		match self {
+			StructuredDynSize::Incrementing => incrementing_expr::<F>(log_size),
+		}
+	}
+}
+
+/// Returns the arithmetic expression for an incrementing column.
+///
+/// The multilinear expression is
+///
+/// $$
+/// \sum_{v \in B_n} X_i \beta_i,
+/// $$
+///
+/// where $\beta_i$ is the $i$-th basis element of the field $F$ as an $\mathbb{F}_2$ vector space.
+pub fn incrementing_expr<F: TowerField>(log_size: usize) -> Result<ArithExpr<F>, Error> {
+	if log_size > F::N_BITS {
+		return Err(Error::ColumnSizeTooLarge);
+	}
+	let expr = (0..log_size)
+		.map(|i| ArithExpr::Var(i) * ArithExpr::Const(<F as ExtensionField<B1>>::basis(i)))
+		.sum::<ArithExpr<F>>();
+	Ok(expr)
+}
+
+#[cfg(test)]
+mod tests {
+	use std::iter;
+
+	use binius_core::polynomial::{
+		test_utils::decompose_index_to_hypercube_point, ArithCircuitPoly,
+	};
+	use binius_field::{arch::OptimalUnderlier128b, as_packed_field::PackedType, BinaryField32b};
+	use binius_math::CompositionPoly;
+	use bumpalo::Bump;
+
+	use super::*;
+	use crate::{
+		builder::{
+			test_utils::{validate_system_witness, ClosureFiller},
+			ConstraintSystem, WitnessIndex, B128, B32,
+		},
+		gadgets::structured::fill_incrementing_b32,
+	};
+
+	#[test]
+	fn test_incrementing_expr() {
+		let expr = incrementing_expr::<B32>(5).unwrap();
+		let evaluator = ArithCircuitPoly::new(&expr);
+		for i in 0..1 << 5 {
+			let bits = decompose_index_to_hypercube_point::<B32>(5, i);
+			assert_eq!(evaluator.evaluate(&bits).unwrap(), B32::new(i as u32));
+		}
+	}
+
+	#[test]
+	fn test_fill_incrementing() {
+		let mut cs = ConstraintSystem::new();
+		let mut table = cs.add_table("test");
+		table.require_power_of_two_size();
+		let test_table_id = table.id();
+		let expected_col = table.add_committed::<B32, 1>("reference");
+		let structured_col =
+			table.add_structured::<B32>("incrementing", StructuredDynSize::Incrementing);
+		table.assert_zero("reference = structured", expected_col - structured_col);
+
+		let allocator = Bump::new();
+		let mut witness =
+			WitnessIndex::<PackedType<OptimalUnderlier128b, B128>>::new(&cs, &allocator);
+		witness
+			.fill_table_sequential(
+				&ClosureFiller::new(test_table_id, |events, index| {
+					{
+						let mut expected_col = index.get_scalars_mut::<B32, 1>(expected_col)?;
+						for (&&i, col_i) in iter::zip(events, &mut *expected_col) {
+							*col_i = BinaryField32b::new(i);
+						}
+					}
+
+					fill_incrementing_b32(index, structured_col)?;
+					Ok(())
+				}),
+				&(0..1 << 5).collect::<Vec<_>>(),
+			)
+			.unwrap();
+
+		validate_system_witness::<OptimalUnderlier128b>(&cs, witness, vec![]);
+	}
+}

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -426,6 +426,7 @@ impl<'cs, 'alloc, F: TowerField, P: PackedField<Scalar = F>> TableWitnessIndex<'
 			table: self.table,
 			cols,
 			log_size: self.log_capacity,
+			index: 0,
 			oracle_offset: self.oracle_offset,
 		}
 	}
@@ -793,10 +794,12 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegmentedView<'a
 					})
 					.collect(),
 			)
-			.map(move |cols| TableWitnessSegment {
+			.enumerate()
+			.map(move |(index, cols)| TableWitnessSegment {
 				table,
 				cols,
 				log_size: log_segment_size,
+				index,
 				oracle_offset,
 			});
 			itertools::Either::Right(iter)
@@ -860,6 +863,7 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegmentedView<'a
 				table,
 				cols: col_strides,
 				log_size: log_segment_size,
+				index: i,
 				oracle_offset,
 			}
 		})
@@ -880,6 +884,9 @@ where
 	cols: Vec<RefCellData<'a, P>>,
 	#[get_copy = "pub"]
 	log_size: usize,
+	/// The index of the segment in the segmented table witness.
+	#[get_copy = "pub"]
+	index: usize,
 	oracle_offset: usize,
 }
 

--- a/crates/m3/src/gadgets/mod.rs
+++ b/crates/m3/src/gadgets/mod.rs
@@ -3,6 +3,6 @@
 pub mod barrel_shifter;
 pub mod hash;
 pub mod lookup;
-pub mod u32;
-
 pub mod mul;
+pub mod structured;
+pub mod u32;

--- a/crates/m3/src/gadgets/structured.rs
+++ b/crates/m3/src/gadgets/structured.rs
@@ -1,0 +1,26 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_field::{PackedExtension, PackedField, PackedFieldIndexable, PackedSubfield};
+
+use crate::builder::{column::Col, error::Error, witness::TableWitnessSegment, B128, B32};
+
+/// Fills a structured [`crate::builder::structured::StructuredDynSize::Incrementing`] B32 column
+/// with values.
+///
+/// This is specialized for B32 because that is a common case, which can be implemented
+/// efficiently.
+pub fn fill_incrementing_b32<P>(
+	witness: &mut TableWitnessSegment<P>,
+	col: Col<B32>,
+) -> Result<(), Error>
+where
+	P: PackedField<Scalar = B128> + PackedExtension<B32>,
+	PackedSubfield<P, B32>: PackedFieldIndexable,
+{
+	let mut col_data = witness.get_scalars_mut(col)?;
+	let start_index = witness.index() << witness.log_size();
+	for (i, col_data_i) in col_data.iter_mut().enumerate() {
+		*col_data_i = B32::new((start_index + i) as u32);
+	}
+	Ok(())
+}

--- a/crates/math/src/arith_expr.rs
+++ b/crates/math/src/arith_expr.rs
@@ -668,6 +668,24 @@ impl<F: Field> ArithCircuit<F> {
 			.unwrap_or(0)
 	}
 
+	pub fn evaluate(&self, query: &[F]) -> Result<F, Error> {
+		let mut step_evals = Vec::with_capacity(self.steps.len());
+		for step in &self.steps {
+			match step {
+				ArithCircuitStep::Add(left, right) => {
+					step_evals.push(step_evals[*left] + step_evals[*right])
+				}
+				ArithCircuitStep::Mul(left, right) => {
+					step_evals.push(step_evals[*left] * step_evals[*right])
+				}
+				ArithCircuitStep::Pow(base, exp) => step_evals.push(query[*base].pow(*exp)),
+				ArithCircuitStep::Const(value) => step_evals.push(*value),
+				ArithCircuitStep::Var(index) => step_evals.push(query[*index]),
+			}
+		}
+		Ok(step_evals.pop().unwrap_or_default())
+	}
+
 	pub fn convert_field<FTgt: Field + From<F>>(&self) -> ArithCircuit<FTgt> {
 		ArithCircuit {
 			steps: self


### PR DESCRIPTION
This adds dynamically-sized structured columns. In a future change, I will add fixed-size structured columns as well.

The first structured column type is incremented value columns. These will be used for zCray address spaces.