### PR TITLE
[M3] fix One element tables

### DIFF
--- a/crates/core/src/protocols/evalcheck/subclaims.rs
+++ b/crates/core/src/protocols/evalcheck/subclaims.rs
@@ -144,11 +144,11 @@ pub fn add_bivariate_sumcheck_to_constraints<F: TowerField>(
 	n_vars: usize,
 	eval: F,
 ) {
-	if n_vars > constraint_builders.len() {
-		constraint_builders.resize_with(n_vars, || ConstraintSetBuilder::new());
+	if n_vars >= constraint_builders.len() {
+		constraint_builders.resize_with(n_vars + 1, || ConstraintSetBuilder::new());
 	}
 	let bivariate_product = ArithExpr::Var(0) * ArithExpr::Var(1);
-	constraint_builders[n_vars - 1].add_sumcheck(meta.oracle_ids(), bivariate_product, eval);
+	constraint_builders[n_vars].add_sumcheck(meta.oracle_ids(), bivariate_product, eval);
 }
 
 pub fn add_composite_sumcheck_to_constraints<F: TowerField>(
@@ -163,10 +163,10 @@ pub fn add_composite_sumcheck_to_constraints<F: TowerField>(
 
 	// Var(comp.n_polys()) corresponds to the eq MLE (meta.multiplier_id)
 	let expr = <_ as CompositionPoly<F>>::expression(comp.c()) * ArithExpr::Var(comp.n_polys());
-	if n_vars > constraint_builders.len() {
-		constraint_builders.resize_with(n_vars, || ConstraintSetBuilder::new());
+	if n_vars >= constraint_builders.len() {
+		constraint_builders.resize_with(n_vars + 1, || ConstraintSetBuilder::new());
 	}
-	constraint_builders[n_vars - 1].add_sumcheck(oracle_ids, expr, eval);
+	constraint_builders[n_vars].add_sumcheck(oracle_ids, expr, eval);
 }
 
 /// Creates bivariate witness and adds them to the witness index, and add bivariate sumcheck constraint to the [`ConstraintSetBuilder`]

--- a/crates/core/src/protocols/gkr_gpa/verify.rs
+++ b/crates/core/src/protocols/gkr_gpa/verify.rs
@@ -87,7 +87,7 @@ fn process_finished_claims<F: Field>(
 			break;
 		}
 
-		debug_assert!(layer_no > 0);
+		debug_assert!(!layer_claims.is_empty());
 		debug_assert_eq!(sorted_claims.len(), layer_claims.len());
 		let finished_layer_claim = layer_claims.pop().expect("must exist");
 		let _ = sorted_claims.pop().expect("must exist");

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -182,11 +182,20 @@ impl<F: TowerField> ConstraintSystem<F> {
 			if count == 0 {
 				continue;
 			}
-			if table.power_of_two_sized && !count.is_power_of_two() {
-				return Err(Error::TableSizePowerOfTwoRequired {
-					table_id: table.id,
-					size: count,
-				});
+			if table.power_of_two_sized {
+				if !count.is_power_of_two() {
+					return Err(Error::TableSizePowerOfTwoRequired {
+						table_id: table.id,
+						size: count,
+					});
+				}
+				if count != 1 << table.log_capacity(count) {
+					panic!(
+						"Tables with required power-of-two size currently cannot have capacity \
+						exceeding their count. This is because the flushes do not have automatic \
+						selectors applied, and so the table would flush invalid events"
+					);
+				}
 			}
 
 			let mut oracle_lookup = Vec::new();

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -546,25 +546,6 @@ impl<F: TowerField> Table<F> {
 		self.id
 	}
 
-	/// Returns the binary logarithm of the minimum capacity.
-	///
-	/// This value is chosen so that every committed column fills at least one large field element
-	/// in packed representation. This is because the polynomial commitment scheme requires full
-	/// packed field elements.
-	pub fn min_log_capacity(&self) -> usize {
-		let min_cell_size = self
-			.columns
-			.iter()
-			.filter_map(|col| match col.col {
-				ColumnDef::Committed { .. } => Some(col.shape.log_cell_size()),
-				_ => None,
-			})
-			.min()
-			// return 0 if table has no columns
-			.unwrap_or(F::TOWER_LEVEL);
-		F::TOWER_LEVEL.saturating_sub(min_cell_size)
-	}
-
 	/// Returns the binary logarithm of the table capacity required to accommodate the given number
 	/// of rows.
 	///
@@ -573,7 +554,7 @@ impl<F: TowerField> Table<F> {
 	/// This will normally be the next power of two greater than the table size, but could require
 	/// more padding to get a minimum capacity.
 	pub fn log_capacity(&self, table_size: usize) -> usize {
-		log2_ceil_usize(table_size).max(self.min_log_capacity())
+		log2_ceil_usize(table_size)
 	}
 
 	fn new_column<FSub, const V: usize>(

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -1255,18 +1255,18 @@ mod tests {
 		)
 		.unwrap();
 
-		assert_eq!(index.log_capacity(), 4);
-		assert_eq!(index.min_log_segment_size(), 4);
+		assert_eq!(index.log_capacity(), 3);
+		assert_eq!(index.min_log_segment_size(), 3);
 
 		let mut iter = index.segments(5);
 		// Check that the segment size is clamped to the capacity.
-		assert_eq!(iter.next().unwrap().log_size(), 4);
+		assert_eq!(iter.next().unwrap().log_size(), 3);
 		assert!(iter.next().is_none());
 		drop(iter);
 
 		let mut iter = index.segments(2);
 		// Check that the segment size is clamped to the minimum segment size.
-		assert_eq!(iter.next().unwrap().log_size(), 4);
+		assert_eq!(iter.next().unwrap().log_size(), 3);
 		assert!(iter.next().is_none());
 		drop(iter);
 	}

--- a/crates/m3/src/gadgets/lookup.rs
+++ b/crates/m3/src/gadgets/lookup.rs
@@ -206,9 +206,7 @@ mod tests {
 		});
 	}
 
-	// TODO: Fix this test
 	#[test]
-	#[ignore]
 	fn test_lookup_producer_no_zero_counts() {
 		with_lookup_test_instance(true, |cs, witness| {
 			validate_system_witness::<OptimalUnderlier128b>(cs, witness, vec![])


### PR DESCRIPTION
update `evalcheck` and `gkr_gpa` to correctly handle the case where n_vars = 0 