### PR TITLE
[reed_solomon] Extract NTT from ReedSolomonCode

### DIFF
--- a/crates/core/benches/poly_commit.rs
+++ b/crates/core/benches/poly_commit.rs
@@ -64,15 +64,6 @@ where
 {
 	let (fri_params, merkle_prover, committed_multilins) =
 		create_poly_commit::<F, P, FEncode>(LOG_SIZE);
-	// let rs_code = ReedSolomonCode::new(
-	// 	fri_params.rs_code().log_dim(),
-	// 	fri_params.rs_code().log_inv_rate(),
-	// 	&NTTOptions {
-	// 		precompute_twiddles: true,
-	// 		thread_settings: ThreadingSettings::MultithreadedDefault,
-	// 	},
-	// )
-	// .unwrap();
 	let ntt = SingleThreadedNTT::new(fri_params.rs_code().log_len())
 		.unwrap()
 		.precompute_twiddles()

--- a/crates/core/src/constraint_system/error.rs
+++ b/crates/core/src/constraint_system/error.rs
@@ -79,6 +79,9 @@ pub enum Error {
 	#[error("math error: {0}")]
 	MathError(#[from] binius_math::Error),
 
+	#[error("ntt error: {0}")]
+	NTTError(#[from] binius_ntt::Error),
+
 	#[error("polynomial commitment error: {0}")]
 	PolyCommitError(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 

--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -463,8 +463,9 @@ where
 		perfetto_category = "phase.main"
 	)
 	.entered();
-	piop::prove::<_, FDomain<Tower>, _, _, _, _, _, _, _, _>(
+	piop::prove::<_, FDomain<Tower>, _, _, _, _, _, _, _, _, _>(
 		&fri_params,
+		&ntt,
 		&merkle_prover,
 		domain_factory,
 		&commit_meta,

--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -16,6 +16,7 @@ use binius_math::{
 	IsomorphicEvaluationDomainFactory, MLEDirectAdapter, MultilinearExtension, MultilinearPoly,
 };
 use binius_maybe_rayon::prelude::*;
+use binius_ntt::{DynamicDispatchNTT, NTTOptions, ThreadingSettings};
 use binius_utils::bail;
 use digest::{core_api::BlockSizeUser, Digest, FixedOutputReset, Output};
 use itertools::{chain, izip};
@@ -135,6 +136,14 @@ where
 		security_bits,
 		log_inv_rate,
 	)?;
+	let ntt = DynamicDispatchNTT::new(
+		fri_params.rs_code().log_len(),
+		&NTTOptions {
+			thread_settings: ThreadingSettings::MultithreadedDefault,
+			precompute_twiddles: true,
+		},
+	)?;
+
 	let commit_span =
 		tracing::info_span!("[phase] Commit", phase = "commit", perfetto_category = "phase.main")
 			.entered();
@@ -142,7 +151,7 @@ where
 		commitment,
 		committed,
 		codeword,
-	} = piop::commit(&fri_params, &merkle_prover, &committed_multilins)?;
+	} = piop::commit(&fri_params, &ntt, &merkle_prover, &committed_multilins)?;
 	drop(commit_span);
 
 	// Observe polynomial commitment

--- a/crates/core/src/piop/error.rs
+++ b/crates/core/src/piop/error.rs
@@ -4,7 +4,7 @@ use crate::{
 	oracle::OracleId,
 	polynomial,
 	protocols::{fri, sumcheck},
-	transcript, witness,
+	reed_solomon, transcript, witness,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -25,6 +25,8 @@ pub enum Error {
 	SumcheckClaimVariablesMismatch { index: usize },
 	#[error("binius_math error: {0}")]
 	Math(#[from] binius_math::Error),
+	#[error("Reed-Solomon error: {0}")]
+	ReedSolomon(#[from] reed_solomon::Error),
 	#[error("Polynomial error: {0}")]
 	Polynomial(#[from] polynomial::Error),
 	#[error("FRI error: {0}")]

--- a/crates/core/src/piop/tests.rs
+++ b/crates/core/src/piop/tests.rs
@@ -157,6 +157,7 @@ fn commit_prove_verify<F, FDomain, FEncode, P, MTScheme>(
 	let domain_factory = DefaultEvaluationDomainFactory::<FDomain>::default();
 	prove(
 		&fri_params,
+		&ntt,
 		merkle_prover,
 		domain_factory,
 		commit_meta,

--- a/crates/core/src/piop/tests.rs
+++ b/crates/core/src/piop/tests.rs
@@ -11,6 +11,7 @@ use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_math::{
 	DefaultEvaluationDomainFactory, MLEDirectAdapter, MultilinearExtension, MultilinearPoly,
 };
+use binius_ntt::SingleThreadedNTT;
 use binius_utils::{DeserializeBytes, SerializeBytes};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
@@ -121,6 +122,7 @@ fn commit_prove_verify<F, FDomain, FEncode, P, MTScheme>(
 		log_inv_rate,
 	)
 	.unwrap();
+	let ntt = SingleThreadedNTT::new(fri_params.rs_code().log_len()).unwrap();
 
 	let backend = make_portable_backend();
 	let mut rng = StdRng::seed_from_u64(0);
@@ -133,7 +135,7 @@ fn commit_prove_verify<F, FDomain, FEncode, P, MTScheme>(
 		commitment,
 		committed,
 		codeword,
-	} = commit(&fri_params, merkle_prover, &committed_multilins).unwrap();
+	} = commit(&fri_params, &ntt, merkle_prover, &committed_multilins).unwrap();
 
 	let transparent_multilins_by_vars = commit_meta
 		.n_multilins_by_vars()

--- a/crates/core/src/piop/verify.rs
+++ b/crates/core/src/piop/verify.rs
@@ -4,7 +4,6 @@ use std::{borrow::Borrow, cmp::Ordering, iter, ops::Range};
 
 use binius_field::{BinaryField, ExtensionField, Field, TowerField};
 use binius_math::evaluate_piecewise_multilinear;
-use binius_ntt::NTTOptions;
 use binius_utils::{bail, DeserializeBytes};
 use getset::CopyGetters;
 use tracing::instrument;
@@ -136,7 +135,7 @@ where
 	let log_batch_size = fold_arities.first().copied().unwrap_or(0);
 	let log_dim = commit_meta.total_vars - log_batch_size;
 
-	let rs_code = ReedSolomonCode::new(log_dim, log_inv_rate, &NTTOptions::default())?;
+	let rs_code = ReedSolomonCode::new(log_dim, log_inv_rate)?;
 	let n_test_queries = fri::calculate_n_test_queries::<F, _>(security_bits, &rs_code)?;
 	let fri_params = FRIParams::new(rs_code, log_batch_size, fold_arities, n_test_queries)?;
 	Ok(fri_params)

--- a/crates/core/src/protocols/fri/common.rs
+++ b/crates/core/src/protocols/fri/common.rs
@@ -279,13 +279,13 @@ pub type TerminateCodeword<F> = Vec<F>;
 ///
 /// Throws [`Error::ParameterError`] if the security level is unattainable given the code
 /// parameters.
-pub fn calculate_n_test_queries<F, PS>(
+pub fn calculate_n_test_queries<F, FEncode>(
 	security_bits: usize,
-	code: &ReedSolomonCode<PS>,
+	code: &ReedSolomonCode<FEncode>,
 ) -> Result<usize, Error>
 where
-	F: BinaryField + ExtensionField<PS::Scalar>,
-	PS: PackedField<Scalar: BinaryField>,
+	F: BinaryField + ExtensionField<FEncode>,
+	FEncode: BinaryField,
 {
 	let field_size = 2.0_f64.powi(F::N_BITS as i32);
 	let sumcheck_err = (2 * code.log_dim()) as f64 / field_size;

--- a/crates/core/src/protocols/fri/common.rs
+++ b/crates/core/src/protocols/fri/common.rs
@@ -260,15 +260,12 @@ where
 	F: BinaryField + ExtensionField<FA>,
 	FA: BinaryField,
 {
-	<FRIParams<F, FA>>::fold_arities(fri_params)
-		//.fold_arities()
+	fri_params
+		.fold_arities()
 		.iter()
-		.scan(<FRIParams<F, FA>>::log_len(fri_params), |log_n_cosets, arity| {
+		.scan(fri_params.log_len(), |log_n_cosets, arity| {
 			*log_n_cosets -= arity;
-			Some(vcs.optimal_verify_layer(
-				<FRIParams<F, FA>>::n_test_queries(fri_params),
-				*log_n_cosets,
-			))
+			Some(vcs.optimal_verify_layer(fri_params.n_test_queries(), *log_n_cosets))
 		})
 }
 

--- a/crates/core/src/protocols/fri/common.rs
+++ b/crates/core/src/protocols/fri/common.rs
@@ -22,19 +22,14 @@ use crate::{
 ///
 /// [DP24]: <https://eprint.iacr.org/2024/504>
 #[inline]
-fn fold_pair<F, FS>(
-	rs_code: &ReedSolomonCode<FS>,
-	round: usize,
-	index: usize,
-	values: (F, F),
-	r: F,
-) -> F
+fn fold_pair<F, FS, NTT>(ntt: &NTT, round: usize, index: usize, values: (F, F), r: F) -> F
 where
 	F: BinaryField + ExtensionField<FS>,
 	FS: BinaryField,
+	NTT: AdditiveNTT<FS>,
 {
 	// Perform inverse additive NTT butterfly
-	let t = rs_code.get_ntt().get_subspace_eval(round, index);
+	let t = ntt.get_subspace_eval(round, index);
 	let (mut u, mut v) = values;
 	v += u;
 	u += v * t;
@@ -56,8 +51,8 @@ where
 ///
 /// [DP24]: <https://eprint.iacr.org/2024/504>
 #[inline]
-pub fn fold_chunk<F, FS>(
-	rs_code: &ReedSolomonCode<FS>,
+pub fn fold_chunk<F, FS, NTT>(
+	ntt: &NTT,
 	start_round: usize,
 	chunk_index: usize,
 	values: &[F],
@@ -67,10 +62,11 @@ pub fn fold_chunk<F, FS>(
 where
 	F: BinaryField + ExtensionField<FS>,
 	FS: BinaryField,
+	NTT: AdditiveNTT<FS>,
 {
 	// Preconditions
 	debug_assert!(!folding_challenges.is_empty());
-	debug_assert!(start_round + folding_challenges.len() <= rs_code.log_dim());
+	debug_assert!(start_round + folding_challenges.len() <= ntt.log_domain_size());
 	debug_assert_eq!(values.len(), 1 << folding_challenges.len());
 	debug_assert!(scratch_buffer.len() >= values.len());
 
@@ -89,14 +85,14 @@ where
 				let values =
 					(scratch_buffer[index_offset << 1], scratch_buffer[(index_offset << 1) + 1]);
 				scratch_buffer[index_offset] =
-					fold_pair(rs_code, round, index_start + index_offset, values, r)
+					fold_pair(ntt, round, index_start + index_offset, values, r)
 			});
 		} else {
 			// For the first round, we read values directly from the `values` slice.
 			(0..new_scratch_buffer_len).for_each(|index_offset| {
 				let values = (values[index_offset << 1], values[(index_offset << 1) + 1]);
 				scratch_buffer[index_offset] =
-					fold_pair(rs_code, round, index_start + index_offset, values, r)
+					fold_pair(ntt, round, index_start + index_offset, values, r)
 			});
 		}
 	}
@@ -127,8 +123,8 @@ where
 ///
 /// [DP24]: <https://eprint.iacr.org/2024/504>
 #[inline]
-pub fn fold_interleaved_chunk<F, FS, P>(
-	rs_code: &ReedSolomonCode<FS>,
+pub fn fold_interleaved_chunk<F, FS, P, NTT>(
+	ntt: &NTT,
 	log_batch_size: usize,
 	chunk_index: usize,
 	values: &[P],
@@ -139,10 +135,11 @@ pub fn fold_interleaved_chunk<F, FS, P>(
 where
 	F: BinaryField + ExtensionField<FS>,
 	FS: BinaryField,
+	NTT: AdditiveNTT<FS>,
 	P: PackedField<Scalar = F>,
 {
 	// Preconditions
-	debug_assert!(fold_challenges.len() <= rs_code.log_dim());
+	debug_assert!(fold_challenges.len() <= ntt.log_domain_size() + log_batch_size);
 	debug_assert_eq!(len_packed_slice(values), 1 << (log_batch_size + fold_challenges.len()));
 	debug_assert_eq!(tensor.len(), 1 << log_batch_size);
 	debug_assert!(scratch_buffer.len() >= 2 * (values.len() >> log_batch_size));
@@ -170,7 +167,7 @@ where
 	if fold_challenges.is_empty() {
 		buffer1[0]
 	} else {
-		fold_chunk(rs_code, 0, chunk_index, buffer1, fold_challenges, buffer2)
+		fold_chunk(ntt, 0, chunk_index, buffer1, fold_challenges, buffer2)
 	}
 }
 
@@ -263,12 +260,15 @@ where
 	F: BinaryField + ExtensionField<FA>,
 	FA: BinaryField,
 {
-	fri_params
-		.fold_arities()
+	<FRIParams<F, FA>>::fold_arities(fri_params)
+		//.fold_arities()
 		.iter()
-		.scan(fri_params.log_len(), |log_n_cosets, arity| {
+		.scan(<FRIParams<F, FA>>::log_len(fri_params), |log_n_cosets, arity| {
 			*log_n_cosets -= arity;
-			Some(vcs.optimal_verify_layer(fri_params.n_test_queries(), *log_n_cosets))
+			Some(vcs.optimal_verify_layer(
+				<FRIParams<F, FA>>::n_test_queries(fri_params),
+				*log_n_cosets,
+			))
 		})
 }
 
@@ -336,20 +336,19 @@ pub fn estimate_optimal_arity(
 mod tests {
 	use assert_matches::assert_matches;
 	use binius_field::{BinaryField128b, BinaryField32b};
-	use binius_ntt::NTTOptions;
 
 	use super::*;
 
 	#[test]
 	fn test_calculate_n_test_queries() {
 		let security_bits = 96;
-		let rs_code = ReedSolomonCode::new(28, 1, &NTTOptions::default()).unwrap();
+		let rs_code = ReedSolomonCode::new(28, 1).unwrap();
 		let n_test_queries =
 			calculate_n_test_queries::<BinaryField128b, BinaryField32b>(security_bits, &rs_code)
 				.unwrap();
 		assert_eq!(n_test_queries, 232);
 
-		let rs_code = ReedSolomonCode::new(28, 2, &NTTOptions::default()).unwrap();
+		let rs_code = ReedSolomonCode::new(28, 2).unwrap();
 		let n_test_queries =
 			calculate_n_test_queries::<BinaryField128b, BinaryField32b>(security_bits, &rs_code)
 				.unwrap();
@@ -359,9 +358,9 @@ mod tests {
 	#[test]
 	fn test_calculate_n_test_queries_unsatisfiable() {
 		let security_bits = 128;
-		let rs_code = ReedSolomonCode::new(28, 1, &NTTOptions::default()).unwrap();
+		let rs_code = ReedSolomonCode::<BinaryField32b>::new(28, 1).unwrap();
 		assert_matches!(
-			calculate_n_test_queries::<BinaryField128b, BinaryField32b>(security_bits, &rs_code),
+			calculate_n_test_queries::<BinaryField128b, _>(security_bits, &rs_code),
 			Err(Error::ParameterError)
 		);
 	}

--- a/crates/core/src/protocols/fri/error.rs
+++ b/crates/core/src/protocols/fri/error.rs
@@ -2,7 +2,7 @@
 
 use binius_ntt::Error as NttError;
 
-use crate::transcript;
+use crate::{reed_solomon, transcript};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -28,6 +28,8 @@ pub enum Error {
 	RoundVCSLengthsOutOfRange,
 	#[error("round VCS vector_length must be a power of two")]
 	RoundVCSLengthsNotPowerOfTwo,
+	#[error("Reed-Solomon encoding error: {0}")]
+	CodeError(#[from] reed_solomon::Error),
 	#[error("Reed-Solomon encoding error: {0}")]
 	EncodeError(#[from] NttError),
 	#[error("vector commit error: {0}")]

--- a/crates/core/src/protocols/fri/prove.rs
+++ b/crates/core/src/protocols/fri/prove.rs
@@ -172,7 +172,7 @@ where
 /// * `message` - the interleaved message to encode and commit
 #[instrument(skip_all, level = "debug")]
 pub fn commit_interleaved<F, FA, P, PA, MerkleProver, VCS>(
-	rs_code: &ReedSolomonCode<PA>,
+	rs_code: &ReedSolomonCode<FA>,
 	params: &FRIParams<F, FA>,
 	merkle_prover: &MerkleProver,
 	message: &[P],
@@ -206,7 +206,7 @@ where
 /// * `merkle_prover` - the Merkle tree prover to use for committing
 /// * `message_writer` - a closure that writes the interleaved message to encode and commit
 pub fn commit_interleaved_with<F, FA, P, PA, MerkleProver, VCS>(
-	rs_code: &ReedSolomonCode<PA>,
+	rs_code: &ReedSolomonCode<FA>,
 	params: &FRIParams<F, FA>,
 	merkle_prover: &MerkleProver,
 	message_writer: impl FnOnce(&mut [P]),

--- a/crates/core/src/protocols/fri/prove.rs
+++ b/crates/core/src/protocols/fri/prove.rs
@@ -27,7 +27,8 @@ use crate::{
 };
 
 #[instrument(skip_all, level = "debug")]
-pub fn fold_codeword<F, FS>(
+pub fn fold_codeword<F, FS, NTT>(
+	ntt: &NTT,
 	rs_code: &ReedSolomonCode<FS>,
 	codeword: &[F],
 	// Round is the number of total folding challenges received so far.
@@ -37,6 +38,7 @@ pub fn fold_codeword<F, FS>(
 where
 	F: BinaryField + ExtensionField<FS>,
 	FS: BinaryField,
+	NTT: AdditiveNTT<FS> + Sync,
 {
 	// Preconditions
 	assert_eq!(codeword.len() % (1 << folding_challenges.len()), 0);
@@ -57,14 +59,7 @@ where
 		.map_init(
 			|| vec![F::default(); chunk_size],
 			|scratch_buffer, (chunk_index, chunk)| {
-				fold_chunk(
-					rs_code,
-					start_round,
-					chunk_index,
-					chunk,
-					folding_challenges,
-					scratch_buffer,
-				)
+				fold_chunk(ntt, start_round, chunk_index, chunk, folding_challenges, scratch_buffer)
 			},
 		)
 		.collect()
@@ -79,7 +74,8 @@ where
 /// * `challenges` - the folding challenges. The length must be at least `log_batch_size`.
 /// * `log_batch_size` - the base-2 logarithm of the batch size of the interleaved code.
 #[instrument(skip_all, level = "debug")]
-fn fold_interleaved<F, FS, P>(
+fn fold_interleaved<F, FS, NTT, P>(
+	ntt: &NTT,
 	rs_code: &ReedSolomonCode<FS>,
 	codeword: &[P],
 	challenges: &[F],
@@ -88,6 +84,7 @@ fn fold_interleaved<F, FS, P>(
 where
 	F: BinaryField + ExtensionField<FS>,
 	FS: BinaryField,
+	NTT: AdditiveNTT<FS> + Sync,
 	P: PackedField<Scalar = F>,
 {
 	assert_eq!(len_packed_slice(codeword), 1 << (rs_code.log_len() + log_batch_size));
@@ -111,7 +108,7 @@ where
 			|| vec![F::default(); 2 * fold_chunk_size],
 			|scratch_buffer, (i, chunk)| {
 				fold_interleaved_chunk(
-					rs_code,
+					ntt,
 					log_batch_size,
 					i,
 					chunk,
@@ -279,7 +276,7 @@ pub enum FoldRoundOutput<VCSCommitment> {
 }
 
 /// A stateful prover for the FRI fold phase.
-pub struct FRIFolder<'a, F, FA, P, MerkleProver, VCS>
+pub struct FRIFolder<'a, F, FA, P, NTT, MerkleProver, VCS>
 where
 	FA: BinaryField,
 	F: BinaryField,
@@ -288,6 +285,7 @@ where
 	VCS: MerkleTreeScheme<F>,
 {
 	params: &'a FRIParams<F, FA>,
+	ntt: &'a NTT,
 	merkle_prover: &'a MerkleProver,
 	codeword: &'a [P],
 	codeword_committed: &'a MerkleProver::Committed,
@@ -297,17 +295,19 @@ where
 	unprocessed_challenges: Vec<F>,
 }
 
-impl<'a, F, FA, P, MerkleProver, VCS> FRIFolder<'a, F, FA, P, MerkleProver, VCS>
+impl<'a, F, FA, P, NTT, MerkleProver, VCS> FRIFolder<'a, F, FA, P, NTT, MerkleProver, VCS>
 where
 	F: TowerField + ExtensionField<FA>,
 	FA: BinaryField,
 	P: PackedField<Scalar = F>,
+	NTT: AdditiveNTT<FA> + Sync,
 	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
 	VCS: MerkleTreeScheme<F, Digest: SerializeBytes>,
 {
 	/// Constructs a new folder.
 	pub fn new(
 		params: &'a FRIParams<F, FA>,
+		ntt: &'a NTT,
 		merkle_prover: &'a MerkleProver,
 		committed_codeword: &'a [P],
 		committed: &'a MerkleProver::Committed,
@@ -321,6 +321,7 @@ where
 		let next_commit_round = params.fold_arities().first().copied();
 		Ok(Self {
 			params,
+			ntt,
 			merkle_prover,
 			codeword: committed_codeword,
 			codeword_committed: committed,
@@ -373,6 +374,7 @@ where
 				// Fold a full codeword committed in the previous FRI round into a codeword with
 				// reduced dimension and rate.
 				fold_codeword(
+					self.ntt,
 					self.params.rs_code(),
 					prev_codeword,
 					self.curr_round - self.params.log_batch_size(),
@@ -384,6 +386,7 @@ where
 				// codeword with the same or reduced block length, depending on the sequence of
 				// fold rounds.
 				fold_interleaved(
+					self.ntt,
 					self.params.rs_code(),
 					self.codeword,
 					&self.unprocessed_challenges,

--- a/crates/core/src/protocols/fri/tests.rs
+++ b/crates/core/src/protocols/fri/tests.rs
@@ -13,7 +13,7 @@ use binius_hal::{make_portable_backend, ComputationBackendExt};
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_math::MultilinearExtension;
 use binius_maybe_rayon::prelude::ParallelIterator;
-use binius_ntt::NTTOptions;
+use binius_ntt::{NTTOptions, SingleThreadedNTT};
 use binius_utils::checked_arithmetics::log2_strict_usize;
 use rand::prelude::*;
 
@@ -55,6 +55,7 @@ fn test_commit_prove_verify_success<U, F, FA>(
 
 	let committed_rs_code =
 		ReedSolomonCode::<FA>::new(log_dimension, log_inv_rate, &NTTOptions::default()).unwrap();
+	let ntt = SingleThreadedNTT::new(params.log_len()).unwrap();
 
 	let n_round_commitments = arities.len();
 
@@ -68,7 +69,7 @@ fn test_commit_prove_verify_success<U, F, FA>(
 		commitment: mut codeword_commitment,
 		committed: codeword_committed,
 		codeword,
-	} = fri::commit_interleaved(&committed_rs_code, &params, &merkle_prover, &msg).unwrap();
+	} = fri::commit_interleaved(&committed_rs_code, &params, &ntt, &merkle_prover, &msg).unwrap();
 
 	// Run the prover to generate the proximity proof
 	let mut round_prover =

--- a/crates/core/src/protocols/fri/tests.rs
+++ b/crates/core/src/protocols/fri/tests.rs
@@ -53,7 +53,7 @@ fn test_commit_prove_verify_success<U, F, FA>(
 			.unwrap();
 
 	let committed_rs_code = ReedSolomonCode::<FA>::new(log_dimension, log_inv_rate).unwrap();
-	let ntt = SingleThreadedNTT::new(params.log_len()).unwrap();
+	let ntt = SingleThreadedNTT::new(params.rs_code().log_len()).unwrap();
 
 	let n_round_commitments = arities.len();
 

--- a/crates/core/src/protocols/fri/tests.rs
+++ b/crates/core/src/protocols/fri/tests.rs
@@ -13,7 +13,7 @@ use binius_hal::{make_portable_backend, ComputationBackendExt};
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_math::MultilinearExtension;
 use binius_maybe_rayon::prelude::ParallelIterator;
-use binius_ntt::{NTTOptions, SingleThreadedNTT};
+use binius_ntt::SingleThreadedNTT;
 use binius_utils::checked_arithmetics::log2_strict_usize;
 use rand::prelude::*;
 
@@ -45,16 +45,14 @@ fn test_commit_prove_verify_success<U, F, FA>(
 
 	let merkle_prover = BinaryMerkleTreeProver::<_, Groestl256, _>::new(Groestl256ByteCompression);
 
-	let committed_rs_code =
-		ReedSolomonCode::<FA>::new(log_dimension, log_inv_rate, &NTTOptions::default()).unwrap();
+	let committed_rs_code = ReedSolomonCode::<FA>::new(log_dimension, log_inv_rate).unwrap();
 
 	let n_test_queries = 3;
 	let params =
 		FRIParams::new(committed_rs_code, log_batch_size, arities.to_vec(), n_test_queries)
 			.unwrap();
 
-	let committed_rs_code =
-		ReedSolomonCode::<FA>::new(log_dimension, log_inv_rate, &NTTOptions::default()).unwrap();
+	let committed_rs_code = ReedSolomonCode::<FA>::new(log_dimension, log_inv_rate).unwrap();
 	let ntt = SingleThreadedNTT::new(params.log_len()).unwrap();
 
 	let n_round_commitments = arities.len();
@@ -73,7 +71,7 @@ fn test_commit_prove_verify_success<U, F, FA>(
 
 	// Run the prover to generate the proximity proof
 	let mut round_prover =
-		FRIFolder::new(&params, &merkle_prover, &codeword, &codeword_committed).unwrap();
+		FRIFolder::new(&params, &ntt, &merkle_prover, &codeword, &codeword_committed).unwrap();
 
 	let mut prover_challenger = ProverTranscript::<HasherChallenger<Groestl256>>::new();
 	prover_challenger.message().write(&codeword_commitment);

--- a/crates/core/src/reed_solomon/error.rs
+++ b/crates/core/src/reed_solomon/error.rs
@@ -1,0 +1,13 @@
+// Copyright 2025 Irreducible Inc.
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	#[error("the evaluation domain of the code does not match the subspace of the NTT encoder")]
+	EncoderSubspaceMismatch,
+	#[error("the dimension of the evaluation domain of the code does not match the parameters")]
+	SubspaceDimensionMismatch,
+	#[error("math error: {0}")]
+	Math(#[from] binius_math::Error),
+	#[error("NTT error: {0}")]
+	NTT(#[from] binius_ntt::Error),
+}

--- a/crates/core/src/reed_solomon/mod.rs
+++ b/crates/core/src/reed_solomon/mod.rs
@@ -1,3 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+mod error;
 pub mod reed_solomon;
+
+pub use error::*;
+pub use reed_solomon::*;

--- a/crates/core/src/ring_switch/tests.rs
+++ b/crates/core/src/ring_switch/tests.rs
@@ -299,7 +299,7 @@ fn commit_prove_verify_piop<U, Tower, MTScheme, MTProver>(
 		log_inv_rate,
 	)
 	.unwrap();
-	let ntt = SingleThreadedNTT::new(fri_params.log_len()).unwrap();
+	let ntt = SingleThreadedNTT::new(fri_params.rs_code().log_len()).unwrap();
 
 	let witness_index = generate_multilinears::<U, Tower>(&mut rng, oracles);
 	let committed_multilins = piop::collect_committed_witnesses::<U, FExt<Tower>>(

--- a/crates/core/src/ring_switch/tests.rs
+++ b/crates/core/src/ring_switch/tests.rs
@@ -342,6 +342,7 @@ fn commit_prove_verify_piop<U, Tower, MTScheme, MTProver>(
 	let domain_factory = DefaultEvaluationDomainFactory::<Tower::B8>::default();
 	piop::prove(
 		&fri_params,
+		&ntt,
 		merkle_prover,
 		domain_factory,
 		&commit_meta,

--- a/crates/core/src/ring_switch/tests.rs
+++ b/crates/core/src/ring_switch/tests.rs
@@ -14,6 +14,7 @@ use binius_math::{
 	DefaultEvaluationDomainFactory, MLEEmbeddingAdapter, MultilinearExtension, MultilinearPoly,
 	MultilinearQuery,
 };
+use binius_ntt::SingleThreadedNTT;
 use binius_utils::{DeserializeBytes, SerializeBytes};
 use rand::prelude::*;
 
@@ -298,6 +299,7 @@ fn commit_prove_verify_piop<U, Tower, MTScheme, MTProver>(
 		log_inv_rate,
 	)
 	.unwrap();
+	let ntt = SingleThreadedNTT::new(fri_params.log_len()).unwrap();
 
 	let witness_index = generate_multilinears::<U, Tower>(&mut rng, oracles);
 	let committed_multilins = piop::collect_committed_witnesses::<U, FExt<Tower>>(
@@ -312,7 +314,7 @@ fn commit_prove_verify_piop<U, Tower, MTScheme, MTProver>(
 		commitment,
 		committed,
 		codeword,
-	} = piop::commit(&fri_params, merkle_prover, &committed_multilins).unwrap();
+	} = piop::commit(&fri_params, &ntt, merkle_prover, &committed_multilins).unwrap();
 
 	let eval_claims = setup_test_eval_claims::<U, FExt<Tower>>(&mut rng, oracles, &witness_index);
 

--- a/crates/math/src/binary_subspace.rs
+++ b/crates/math/src/binary_subspace.rs
@@ -9,7 +9,7 @@ use super::error::Error;
 ///
 /// The subspace is defined by a basis of elements from a binary field. The basis elements are
 /// ordered, which implies an ordering on the subspace elements.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BinarySubspace<F: BinaryField> {
 	basis: Vec<F>,
 }

--- a/crates/ntt/src/single_threaded.rs
+++ b/crates/ntt/src/single_threaded.rs
@@ -25,8 +25,7 @@ impl<F: BinaryField> SingleThreadedNTT<F> {
 	/// on-the-fly computed twiddle factors.
 	pub fn new(log_domain_size: usize) -> Result<Self, Error> {
 		let subspace = BinarySubspace::with_dim(log_domain_size)?;
-		let twiddle_access = OnTheFlyTwiddleAccess::generate(&subspace)?;
-		Ok(Self::with_twiddle_access(twiddle_access))
+		Self::with_subspace(&subspace)
 	}
 
 	/// Constructs an NTT over an isomorphic subspace for the given domain field using on-the-fly
@@ -37,7 +36,11 @@ impl<F: BinaryField> SingleThreadedNTT<F> {
 		F: From<FDomain>,
 	{
 		let subspace = BinarySubspace::<FDomain>::with_dim(log_domain_size)?.isomorphic();
-		let twiddle_access = OnTheFlyTwiddleAccess::generate(&subspace)?;
+		Self::with_subspace(&subspace)
+	}
+
+	pub fn with_subspace(subspace: &BinarySubspace<F>) -> Result<Self, Error> {
+		let twiddle_access = OnTheFlyTwiddleAccess::generate(subspace)?;
 		Ok(Self::with_twiddle_access(twiddle_access))
 	}
 


### PR DESCRIPTION
Previously, `ReedSolomonCode` owned an `impl AdditiveNTT` so that it could perform encoding. Several issues became apparent with that coupling:

- As we wrote FRI code, there became a clear need for `ReedSolomonCode`s that are not responsible for encoding, which could be used in the verifier.
- The NTT instance can be expensive to set up if precomputing twiddles, so it should be done outside of proving. See https://github.com/IrreducibleOSS/binius/issues/52. This does not fix the the issue but makes progress towards it.
- A planned feature is batched FRI proximity testing over separately committed interleaved codewords. When these codewords are different sizes, they must be committed over FRI-compatible domains. This decoupling is a step towards that.