### PR TITLE
[evalcheck] Write duplicate claim advice directly to transcript

### DIFF
--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -396,11 +396,11 @@ where
 		if let Some(claim_id) = claim_id {
 			serialize_evalcheck_proof(
 				&mut transcript.message(),
-				&EvalcheckProof::<F>::DuplicateClaim(*claim_id),
+				&EvalcheckProof::DuplicateClaim(*claim_id),
 			);
 			return Ok(());
 		}
-		serialize_evalcheck_proof(&mut transcript.message(), &EvalcheckProof::<F>::Committed);
+		serialize_evalcheck_proof(&mut transcript.message(), &EvalcheckProof::NewClaim);
 
 		self.prove_multilinear_skip_duplicate_check(evalcheck_claim, transcript)
 	}
@@ -478,12 +478,12 @@ where
 					if let Some(claim_index) = self.claim_to_index.get(suboracle_id, &eval_point) {
 						serialize_evalcheck_proof(
 							&mut transcript.message(),
-							&EvalcheckProof::<F>::DuplicateClaim(*claim_index),
+							&EvalcheckProof::DuplicateClaim(*claim_index),
 						);
 					} else {
 						serialize_evalcheck_proof(
 							&mut transcript.message(),
-							&EvalcheckProof::<F>::Committed,
+							&EvalcheckProof::NewClaim,
 						);
 
 						let eval = *self

--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -340,14 +340,17 @@ where
 					.next()
 				{
 					Some((suboracle_id, coeff)) if n_polys == 1 && !coeff.is_zero() => {
-let eval = if let Some(eval) = self.evals_memoization.get(suboracle_id, &eval_point) {
-    *eval
-} else {
-    let eval = (eval - linear_combination.offset())
-        * coeff.invert().expect("not zero");
-    self.evals_memoization.insert(suboracle_id, eval_point.clone(), eval);
-    eval
-};
+						let eval = if let Some(eval) =
+							self.evals_memoization.get(suboracle_id, &eval_point)
+						{
+							*eval
+						} else {
+							let eval = (eval - linear_combination.offset())
+								* coeff.invert().expect("not zero");
+							self.evals_memoization
+								.insert(suboracle_id, eval_point.clone(), eval);
+							eval
+						};
 
 						let subclaim = EvalcheckMultilinearClaim {
 							id: suboracle_id,

--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -340,17 +340,14 @@ where
 					.next()
 				{
 					Some((suboracle_id, coeff)) if n_polys == 1 && !coeff.is_zero() => {
-						let eval = (eval - linear_combination.offset())
-							* coeff.invert().expect("not zero");
-
-						if self
-							.evals_memoization
-							.get(suboracle_id, &eval_point)
-							.is_none()
-						{
-							self.evals_memoization
-								.insert(suboracle_id, eval_point.clone(), eval);
-						}
+let eval = if let Some(eval) = self.evals_memoization.get(suboracle_id, &eval_point) {
+    *eval
+} else {
+    let eval = (eval - linear_combination.offset())
+        * coeff.invert().expect("not zero");
+    self.evals_memoization.insert(suboracle_id, eval_point.clone(), eval);
+    eval
+};
 
 						let subclaim = EvalcheckMultilinearClaim {
 							id: suboracle_id,

--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -12,7 +12,7 @@ use tracing::instrument;
 
 use super::{
 	error::Error,
-	evalcheck::{EvalcheckMultilinearClaim, EvalcheckProof},
+	evalcheck::{EvalcheckHint, EvalcheckMultilinearClaim},
 	serialize_evalcheck_proof,
 	subclaims::{
 		add_composite_sumcheck_to_constraints, calculate_projected_mles, composite_sumcheck_meta,
@@ -125,7 +125,7 @@ where
 	/// Given a prover state containing [`MultilinearOracleSet`] indexing into given
 	/// [`MultilinearExtensionIndex`], we prove an [`EvalcheckMultilinearClaim`] (stating that given composite
 	/// `poly` equals `eval` at `eval_point`) by recursively processing each of the multilinears.
-	/// This way the evalcheck claim gets transformed into an [`EvalcheckProof`]
+	/// This way the evalcheck claim gets transformed into an [`EvalcheckHint`]
 	/// and a new set of claims on:
 	///  * Committed polynomial evaluations
 	///  * New sumcheck constraints that need to be proven in subsequent rounds (those get appended to `new_sumchecks`)
@@ -396,11 +396,11 @@ where
 		if let Some(claim_id) = claim_id {
 			serialize_evalcheck_proof(
 				&mut transcript.message(),
-				&EvalcheckProof::DuplicateClaim(*claim_id),
+				&EvalcheckHint::DuplicateClaim(*claim_id),
 			);
 			return Ok(());
 		}
-		serialize_evalcheck_proof(&mut transcript.message(), &EvalcheckProof::NewClaim);
+		serialize_evalcheck_proof(&mut transcript.message(), &EvalcheckHint::NewClaim);
 
 		self.prove_multilinear_skip_duplicate_check(evalcheck_claim, transcript)
 	}
@@ -478,12 +478,12 @@ where
 					if let Some(claim_index) = self.claim_to_index.get(suboracle_id, &eval_point) {
 						serialize_evalcheck_proof(
 							&mut transcript.message(),
-							&EvalcheckProof::DuplicateClaim(*claim_index),
+							&EvalcheckHint::DuplicateClaim(*claim_index),
 						);
 					} else {
 						serialize_evalcheck_proof(
 							&mut transcript.message(),
-							&EvalcheckProof::NewClaim,
+							&EvalcheckHint::NewClaim,
 						);
 
 						let eval = *self

--- a/crates/core/src/protocols/evalcheck/tests.rs
+++ b/crates/core/src/protocols/evalcheck/tests.rs
@@ -20,12 +20,14 @@ use itertools::Either;
 use rand::{rngs::StdRng, thread_rng, SeedableRng};
 
 use crate::{
+	fiat_shamir::HasherChallenger,
 	oracle::{MultilinearOracleSet, ShiftVariant},
 	polynomial::{ArithCircuitPoly, MultivariatePoly},
 	protocols::evalcheck::{
 		deserialize_evalcheck_proof, serialize_evalcheck_proof, EvalcheckMultilinearClaim,
 		EvalcheckProof, EvalcheckProver, EvalcheckVerifier,
 	},
+	transcript::ProverTranscript,
 	transparent::select_row::SelectRow,
 	witness::MultilinearExtensionIndex,
 };
@@ -109,12 +111,15 @@ where
 		])
 		.unwrap();
 
+	let mut transcript = ProverTranscript::<HasherChallenger<Groestl256>>::new();
 	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
-	let proof = prover_state.prove(claims.clone()).unwrap();
+	let _proof = prover_state.prove(claims.clone()).unwrap();
 	assert_eq!(prover_state.committed_eval_claims().len(), 1);
 
+	let mut transcript = transcript.into_verifier();
 	let mut verifier_state = EvalcheckVerifier::<FExtension>::new(&mut oracles);
-	verifier_state.verify(claims, proof).unwrap();
+
+	verifier_state.verify(claims, &mut transcript).unwrap();
 	assert_eq!(verifier_state.committed_eval_claims().len(), 1);
 }
 
@@ -186,12 +191,14 @@ where
 		])
 		.unwrap();
 
+	let mut transcript = ProverTranscript::<HasherChallenger<Groestl256>>::new();
 	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
-	let proof = prover_state.prove(claims.clone()).unwrap();
+	let _proof = prover_state.prove(claims.clone()).unwrap();
 	assert_eq!(prover_state.committed_eval_claims().len(), 1);
 
+	let mut transcript = transcript.into_verifier();
 	let mut verifier_state = EvalcheckVerifier::<FExtension>::new(&mut oracles);
-	verifier_state.verify(claims, proof).unwrap();
+	verifier_state.verify(claims, &mut transcript).unwrap();
 	assert_eq!(verifier_state.committed_eval_claims().len(), 1);
 }
 
@@ -282,11 +289,14 @@ where
 		.unwrap();
 
 	let backend = make_portable_backend();
-	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
-	let proof = prover_state.prove(vec![claim.clone()]).unwrap();
 
+	let mut transcript = ProverTranscript::<HasherChallenger<Groestl256>>::new();
+	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
+	let _proof = prover_state.prove(vec![claim.clone()]).unwrap();
+
+	let mut transcript = transcript.into_verifier();
 	let mut verifier_state = EvalcheckVerifier::<FExtension>::new(&mut oracles);
-	verifier_state.verify(vec![claim], proof).unwrap();
+	verifier_state.verify(vec![claim], &mut transcript).unwrap();
 }
 
 #[test]
@@ -353,11 +363,14 @@ where
 		.unwrap();
 
 	let backend = make_portable_backend();
-	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
-	let proof = prover_state.prove(vec![claim.clone()]).unwrap();
 
+	let mut transcript = ProverTranscript::<HasherChallenger<Groestl256>>::new();
+	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
+	let _proof = prover_state.prove(vec![claim.clone()]).unwrap();
+
+	let mut transcript = transcript.into_verifier();
 	let mut verifier_state = EvalcheckVerifier::<FExtension>::new(&mut oracles);
-	verifier_state.verify(vec![claim], proof).unwrap();
+	verifier_state.verify(vec![claim], &mut transcript).unwrap();
 }
 
 #[test]
@@ -454,11 +467,14 @@ where
 		.unwrap();
 
 	let backend = make_portable_backend();
-	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
-	let proof = prover_state.prove(vec![claim.clone()]).unwrap();
 
+	let mut transcript = ProverTranscript::<HasherChallenger<Groestl256>>::new();
+	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
+	let _proof = prover_state.prove(vec![claim.clone()]).unwrap();
+
+	let mut transcript = transcript.into_verifier();
 	let mut verifier_state = EvalcheckVerifier::<FExtension>::new(&mut oracles);
-	verifier_state.verify(vec![claim], proof).unwrap();
+	verifier_state.verify(vec![claim], &mut transcript).unwrap();
 }
 
 #[test]
@@ -514,13 +530,16 @@ where
 		.unwrap();
 
 	let backend = make_portable_backend();
+
+	let mut transcript = ProverTranscript::<HasherChallenger<Groestl256>>::new();
 	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
 	let proof = prover_state.prove(vec![claim.clone()]).unwrap();
 
 	assert_matches!(proof[0], EvalcheckProof::Repeating(..));
 
+	let mut transcript = transcript.into_verifier();
 	let mut verifier_state = EvalcheckVerifier::<FExtension>::new(&mut oracles);
-	verifier_state.verify(vec![claim], proof).unwrap();
+	verifier_state.verify(vec![claim], &mut transcript).unwrap();
 }
 
 #[test]
@@ -604,13 +623,14 @@ where
 	};
 
 	let backend = make_portable_backend();
+
+	let mut transcript = ProverTranscript::<HasherChallenger<Groestl256>>::new();
 	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
-	let proof = prover_state.prove(vec![claim.clone()]).unwrap();
+	let _proof = prover_state.prove(vec![claim.clone()]).unwrap();
 
-	assert_matches!(proof[0], EvalcheckProof::ZeroPadded { .. });
-
+	let mut transcript = transcript.into_verifier();
 	let mut verifier_state = EvalcheckVerifier::<FExtension>::new(&mut oracles);
-	verifier_state.verify(vec![claim], proof).unwrap();
+	verifier_state.verify(vec![claim], &mut transcript).unwrap();
 }
 
 #[test]

--- a/crates/core/src/protocols/evalcheck/tests.rs
+++ b/crates/core/src/protocols/evalcheck/tests.rs
@@ -2,7 +2,6 @@
 
 use std::{array, iter::repeat_with, slice};
 
-use assert_matches::assert_matches;
 use binius_field::{
 	packed::{get_packed_slice, len_packed_slice, set_packed_slice},
 	AESTowerField128b, BinaryField128b, BinaryField1b, ByteSliced16x128x1b, ByteSlicedAES16x128b,
@@ -113,7 +112,7 @@ where
 
 	let mut transcript = ProverTranscript::<HasherChallenger<Groestl256>>::new();
 	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
-	let _proof = prover_state.prove(claims.clone()).unwrap();
+	prover_state.prove(claims.clone(), &mut transcript).unwrap();
 	assert_eq!(prover_state.committed_eval_claims().len(), 1);
 
 	let mut transcript = transcript.into_verifier();
@@ -193,7 +192,7 @@ where
 
 	let mut transcript = ProverTranscript::<HasherChallenger<Groestl256>>::new();
 	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
-	let _proof = prover_state.prove(claims.clone()).unwrap();
+	prover_state.prove(claims.clone(), &mut transcript).unwrap();
 	assert_eq!(prover_state.committed_eval_claims().len(), 1);
 
 	let mut transcript = transcript.into_verifier();
@@ -292,7 +291,9 @@ where
 
 	let mut transcript = ProverTranscript::<HasherChallenger<Groestl256>>::new();
 	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
-	let _proof = prover_state.prove(vec![claim.clone()]).unwrap();
+	prover_state
+		.prove(vec![claim.clone()], &mut transcript)
+		.unwrap();
 
 	let mut transcript = transcript.into_verifier();
 	let mut verifier_state = EvalcheckVerifier::<FExtension>::new(&mut oracles);
@@ -366,7 +367,9 @@ where
 
 	let mut transcript = ProverTranscript::<HasherChallenger<Groestl256>>::new();
 	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
-	let _proof = prover_state.prove(vec![claim.clone()]).unwrap();
+	prover_state
+		.prove(vec![claim.clone()], &mut transcript)
+		.unwrap();
 
 	let mut transcript = transcript.into_verifier();
 	let mut verifier_state = EvalcheckVerifier::<FExtension>::new(&mut oracles);
@@ -470,7 +473,9 @@ where
 
 	let mut transcript = ProverTranscript::<HasherChallenger<Groestl256>>::new();
 	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
-	let _proof = prover_state.prove(vec![claim.clone()]).unwrap();
+	prover_state
+		.prove(vec![claim.clone()], &mut transcript)
+		.unwrap();
 
 	let mut transcript = transcript.into_verifier();
 	let mut verifier_state = EvalcheckVerifier::<FExtension>::new(&mut oracles);
@@ -533,9 +538,9 @@ where
 
 	let mut transcript = ProverTranscript::<HasherChallenger<Groestl256>>::new();
 	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
-	let proof = prover_state.prove(vec![claim.clone()]).unwrap();
-
-	assert_matches!(proof[0], EvalcheckProof::Repeating(..));
+	prover_state
+		.prove(vec![claim.clone()], &mut transcript)
+		.unwrap();
 
 	let mut transcript = transcript.into_verifier();
 	let mut verifier_state = EvalcheckVerifier::<FExtension>::new(&mut oracles);
@@ -626,7 +631,9 @@ where
 
 	let mut transcript = ProverTranscript::<HasherChallenger<Groestl256>>::new();
 	let mut prover_state = EvalcheckProver::new(&mut oracles, &mut witness_index, &backend);
-	let _proof = prover_state.prove(vec![claim.clone()]).unwrap();
+	prover_state
+		.prove(vec![claim.clone()], &mut transcript)
+		.unwrap();
 
 	let mut transcript = transcript.into_verifier();
 	let mut verifier_state = EvalcheckVerifier::<FExtension>::new(&mut oracles);

--- a/crates/core/src/protocols/evalcheck/tests.rs
+++ b/crates/core/src/protocols/evalcheck/tests.rs
@@ -23,8 +23,8 @@ use crate::{
 	oracle::{MultilinearOracleSet, ShiftVariant},
 	polynomial::{ArithCircuitPoly, MultivariatePoly},
 	protocols::evalcheck::{
-		deserialize_evalcheck_proof, serialize_evalcheck_proof, EvalcheckMultilinearClaim,
-		EvalcheckProof, EvalcheckProver, EvalcheckVerifier,
+		deserialize_evalcheck_proof, serialize_evalcheck_proof, EvalcheckHint,
+		EvalcheckMultilinearClaim, EvalcheckProver, EvalcheckVerifier,
 	},
 	transcript::ProverTranscript,
 	transparent::select_row::SelectRow,
@@ -654,8 +654,8 @@ fn test_evalcheck_zero_padded() {
 fn test_evalcheck_serialization() {
 	let mut transcript = ProverTranscript::<HasherChallenger<Groestl256>>::new();
 	let mut writer = transcript.message();
-	serialize_evalcheck_proof(&mut writer, &EvalcheckProof::NewClaim);
-	serialize_evalcheck_proof(&mut writer, &EvalcheckProof::DuplicateClaim(6));
+	serialize_evalcheck_proof(&mut writer, &EvalcheckHint::NewClaim);
+	serialize_evalcheck_proof(&mut writer, &EvalcheckHint::DuplicateClaim(6));
 
 	let mut transcript = transcript.into_verifier();
 	let mut reader = transcript.message();
@@ -663,8 +663,8 @@ fn test_evalcheck_serialization() {
 	let out_1 = deserialize_evalcheck_proof(&mut reader).unwrap();
 	let out_2 = deserialize_evalcheck_proof(&mut reader).unwrap();
 
-	assert_eq!(out_1, EvalcheckProof::NewClaim);
-	assert_eq!(out_2, EvalcheckProof::DuplicateClaim(6));
+	assert_eq!(out_1, EvalcheckHint::NewClaim);
+	assert_eq!(out_2, EvalcheckHint::DuplicateClaim(6));
 
 	transcript.finalize().unwrap()
 }

--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -97,7 +97,7 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 		evalcheck_claim: EvalcheckMultilinearClaim<F>,
 		transcript: &mut VerifierTranscript<Challenger_>,
 	) -> Result<(), Error> {
-		let evalcheck_proof = deserialize_evalcheck_proof::<_, F>(&mut transcript.message())?;
+		let evalcheck_proof = deserialize_evalcheck_proof(&mut transcript.message())?;
 
 		// If the proof is a duplicate claim, we need to check if the claim is already in the round
 		// claims, which have been verified.
@@ -106,8 +106,8 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 				if *expected_claim == evalcheck_claim {
 					return Ok(());
 				}
-				return Err(VerificationError::DuplicateClaimMismatch.into());
 			}
+			return Err(VerificationError::DuplicateClaimMismatch.into());
 		}
 
 		self.verify_multilinear_skip_duplicate_check(evalcheck_claim, transcript)
@@ -263,7 +263,7 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 		// If the subproof is a duplicate claim, we need to check if the claim is
 		// already in the round claims which has been verified otherwise, we verify the
 		// subclaim by DFS.
-		let subproof = deserialize_evalcheck_proof::<_, F>(&mut transcript.message())?;
+		let subproof = deserialize_evalcheck_proof(&mut transcript.message())?;
 		match subproof {
 			EvalcheckProof::DuplicateClaim(index) => {
 				if self.round_claims[index].id != oracle_id
@@ -274,7 +274,7 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 
 				Ok(self.round_claims[index].eval)
 			}
-			_ => {
+			EvalcheckProof::NewClaim => {
 				let eval = transcript.message().read_scalar()?;
 				let subclaim = EvalcheckMultilinearClaim {
 					id: oracle_id,

--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -4,22 +4,27 @@ use std::mem;
 
 use binius_field::{util::inner_product_unchecked, TowerField};
 use getset::{Getters, MutGetters};
+use itertools::chain;
 use tracing::instrument;
 
 use super::{
+	deserialize_evalcheck_proof,
 	error::{Error, VerificationError},
 	evalcheck::{EvalcheckMultilinearClaim, EvalcheckProof},
 	subclaims::{
 		add_bivariate_sumcheck_to_constraints, add_composite_sumcheck_to_constraints,
 		composite_sumcheck_meta, packed_sumcheck_meta, shifted_sumcheck_meta,
 	},
+	EvalPoint,
 };
 use crate::{
+	fiat_shamir::Challenger,
 	oracle::{
 		ConstraintSet, ConstraintSetBuilder, Error as OracleError, MultilinearOracleSet,
 		MultilinearPolyVariant, OracleId,
 	},
 	polynomial::MultivariatePoly,
+	transcript::VerifierTranscript,
 	transparent::select_row::SelectRow,
 };
 
@@ -75,28 +80,25 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 	/// For each claim, we verify the proof by recursively verifying the subclaims in a DFS manner deduplicating previously verified claims
 	/// See [`EvalcheckProver::prove`](`super::prove::EvalcheckProver::prove`) docs for more details.
 	#[instrument(skip_all, name = "EvalcheckVerifierState::verify", level = "debug")]
-	pub fn verify(
+	pub fn verify<Challenger_: Challenger>(
 		&mut self,
-		evalcheck_claims: Vec<EvalcheckMultilinearClaim<F>>,
-		evalcheck_proofs: Vec<EvalcheckProof<F>>,
+		evalcheck_claims: impl IntoIterator<Item = EvalcheckMultilinearClaim<F>>,
+		transcript: &mut VerifierTranscript<Challenger_>,
 	) -> Result<(), Error> {
 		self.round_claims.clear();
-
-		for (claim, proof) in evalcheck_claims
-			.into_iter()
-			.zip(evalcheck_proofs.into_iter())
-		{
-			self.verify_multilinear(claim, proof)?;
+		for claim in evalcheck_claims {
+			self.verify_multilinear(claim, transcript)?;
 		}
-
 		Ok(())
 	}
 
-	fn verify_multilinear(
+	fn verify_multilinear<Challenger_: Challenger>(
 		&mut self,
 		evalcheck_claim: EvalcheckMultilinearClaim<F>,
-		evalcheck_proof: EvalcheckProof<F>,
+		transcript: &mut VerifierTranscript<Challenger_>,
 	) -> Result<(), Error> {
+		let evalcheck_proof = deserialize_evalcheck_proof::<_, F>(&mut transcript.message())?;
+
 		// If the proof is a duplicate claim, we need to check if the claim is already in the round claims which has been verified
 		if let EvalcheckProof::DuplicateClaim(index) = evalcheck_proof {
 			if let Some(expected_claim) = self.round_claims.get(index) {
@@ -107,9 +109,17 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 			}
 		}
 
-		// If the proof is not a duplicate claim, we need to add the claim to the round claims
+		// If the proof is not a duplicate claim, we need to add the claim to the round claims.
 		self.round_claims.push(evalcheck_claim.clone());
 
+		self.verify_multilinear_skip_duplicate_check(evalcheck_claim, transcript)
+	}
+
+	fn verify_multilinear_skip_duplicate_check<Challenger_: Challenger>(
+		&mut self,
+		evalcheck_claim: EvalcheckMultilinearClaim<F>,
+		transcript: &mut VerifierTranscript<Challenger_>,
+	) -> Result<(), Error> {
 		let EvalcheckMultilinearClaim {
 			id,
 			eval_point,
@@ -117,81 +127,54 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 		} = evalcheck_claim;
 
 		let multilinear = self.oracles.oracle(id);
-
-		match multilinear.variant.clone() {
+		let multilinear_label = multilinear.label();
+		match multilinear.variant {
 			MultilinearPolyVariant::Transparent(inner) => {
-				if evalcheck_proof != EvalcheckProof::Transparent {
-					return Err(VerificationError::SubproofMismatch.into());
-				}
-
 				let actual_eval = inner.poly().evaluate(&eval_point)?;
 				if actual_eval != eval {
-					return Err(VerificationError::IncorrectEvaluation(
-						self.oracles.oracle(id).label(),
-					)
-					.into());
+					return Err(VerificationError::IncorrectEvaluation(multilinear_label).into());
 				}
 			}
 
 			MultilinearPolyVariant::Committed => {
-				if evalcheck_proof != EvalcheckProof::Committed {
-					return Err(VerificationError::SubproofMismatch.into());
-				}
-
-				let claim = EvalcheckMultilinearClaim {
-					id: multilinear.id(),
+				self.committed_eval_claims.push(EvalcheckMultilinearClaim {
+					id,
 					eval_point,
 					eval,
-				};
-
-				self.committed_eval_claims.push(claim);
+				});
 			}
 
-			MultilinearPolyVariant::Repeating { id, .. } => {
-				let subproof = match evalcheck_proof {
-					EvalcheckProof::Repeating(subproof) => subproof,
-					_ => return Err(VerificationError::SubproofMismatch.into()),
-				};
-				let n_vars = self.oracles.n_vars(id);
-				let subclaim = EvalcheckMultilinearClaim {
-					id,
-					eval_point: eval_point[..n_vars].into(),
-					eval,
-				};
-
-				self.verify_multilinear(subclaim, *subproof)?;
+			MultilinearPolyVariant::Repeating { id, log_count } => {
+				let n_vars = eval_point.len() - log_count;
+				self.verify_multilinear(
+					EvalcheckMultilinearClaim {
+						id,
+						eval_point: eval_point.slice(0..n_vars),
+						eval,
+					},
+					transcript,
+				)?;
 			}
 
 			MultilinearPolyVariant::Projected(projected) => {
-				let subproof = match evalcheck_proof {
-					EvalcheckProof::Projected(subproof) => subproof,
-					_ => return Err(VerificationError::SubproofMismatch.into()),
-				};
-
 				let (id, values) = (projected.id(), projected.values());
 
 				let new_eval_point = {
-					let idx = projected.start_index();
-					let mut new_eval_point = eval_point[0..idx].to_vec();
-					new_eval_point.extend(values.clone());
-					new_eval_point.extend(eval_point[idx..].to_vec());
-					new_eval_point
+					let (lo, hi) = eval_point.split_at(projected.start_index());
+					chain!(lo, values, hi).copied().collect::<Vec<_>>()
 				};
 
-				let new_claim = EvalcheckMultilinearClaim {
-					id,
-					eval_point: new_eval_point.into(),
-					eval,
-				};
-
-				self.verify_multilinear(new_claim, *subproof)?;
+				self.verify_multilinear(
+					EvalcheckMultilinearClaim {
+						id,
+						eval_point: new_eval_point.into(),
+						eval,
+					},
+					transcript,
+				)?;
 			}
 
 			MultilinearPolyVariant::Shifted(shifted) => {
-				if evalcheck_proof != EvalcheckProof::Shifted {
-					return Err(VerificationError::SubproofMismatch.into());
-				}
-
 				let meta = shifted_sumcheck_meta(self.oracles, &shifted, &eval_point)?;
 				add_bivariate_sumcheck_to_constraints(
 					&meta,
@@ -202,10 +185,6 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 			}
 
 			MultilinearPolyVariant::Packed(packed) => {
-				if evalcheck_proof != EvalcheckProof::Packed {
-					return Err(VerificationError::SubproofMismatch.into());
-				}
-
 				let meta = packed_sumcheck_meta(self.oracles, &packed, &eval_point)?;
 				add_bivariate_sumcheck_to_constraints(
 					&meta,
@@ -216,66 +195,30 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 			}
 
 			MultilinearPolyVariant::LinearCombination(linear_combination) => {
-				let subproofs = match evalcheck_proof {
-					EvalcheckProof::LinearCombination { subproofs } => subproofs,
-					_ => return Err(VerificationError::SubproofMismatch.into()),
-				};
-
-				if subproofs.len() != linear_combination.n_polys() {
-					return Err(VerificationError::SubproofMismatch.into());
-				}
-
-				let mut evals = Vec::new();
-
-				for (subproof, sub_oracle_id) in subproofs.iter().zip(linear_combination.polys()) {
-					// If the subproof is a duplicate claim, we need to check if the claim is already in the round claims which has been verified
-					// otherwise, we verify the subclaim by DFS
-					match subproof {
-						(None, EvalcheckProof::DuplicateClaim(index)) => {
-							if self.round_claims[*index].id != sub_oracle_id
-								|| self.round_claims[*index].eval_point != eval_point
-							{
-								return Err(VerificationError::DuplicateClaimMismatch.into());
-							}
-
-							evals.push(self.round_claims[*index].eval);
-						}
-						(Some(eval), _) => {
-							evals.push(*eval);
-						}
-						_ => return Err(VerificationError::MissingLinearCombinationEval.into()),
-					}
-				}
+				let evals = linear_combination
+					.polys()
+					.map(|sub_oracle_id| {
+						self.verify_multilinear_subclaim(
+							sub_oracle_id,
+							eval_point.clone(),
+							transcript,
+						)
+					})
+					.collect::<Result<Vec<_>, _>>()?;
 
 				// Verify the evaluation of the linear combination over the claimed evaluations
 				let actual_eval = linear_combination.offset()
 					+ inner_product_unchecked::<F, F>(evals, linear_combination.coefficients());
 
 				if actual_eval != eval {
-					return Err(VerificationError::IncorrectEvaluation(multilinear.label()).into());
+					return Err(VerificationError::IncorrectEvaluation(multilinear_label).into());
 				}
-
-				subproofs
-					.into_iter()
-					.zip(linear_combination.polys())
-					.try_for_each(|(subclaim, suboracle_id)| match subclaim {
-						(None, EvalcheckProof::DuplicateClaim(_)) => Ok(()),
-						(Some(eval), proof) => {
-							self.verify_multilinear_subclaim(eval, proof, suboracle_id, &eval_point)
-						}
-						_ => Err(VerificationError::MissingLinearCombinationEval.into()),
-					})?;
 			}
 			MultilinearPolyVariant::ZeroPadded(padded) => {
 				let inner = padded.id();
 
 				let start_index = padded.start_index();
 				let extra_n_vars = padded.n_pad_vars();
-
-				let (inner_eval, subproof) = match evalcheck_proof {
-					EvalcheckProof::ZeroPadded(eval, subproof) => (eval, subproof),
-					_ => return Err(VerificationError::SubproofMismatch.into()),
-				};
 
 				let (first_subclaim_eval_point, zs_second_subclaim) =
 					eval_point.split_at(start_index);
@@ -284,27 +227,22 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 				let subclaim_eval_point = [first_subclaim_eval_point, second_subclaim].concat();
 
 				let select_row = SelectRow::new(zs.len(), padded.nonzero_index())?;
-				let expected_eval = inner_eval
-					* select_row
-						.evaluate(zs)
-						.expect("select_row is constructor with zs.len() variables");
+				let select_row_term = select_row
+					.evaluate(zs)
+					.expect("select_row is constructor with zs.len() variables");
 
-				if expected_eval != eval {
-					return Err(VerificationError::IncorrectEvaluation(multilinear.label()).into());
-				}
+				let inner_eval = eval * select_row_term.invert_or_zero();
 
-				self.verify_multilinear_subclaim(
-					inner_eval,
-					*subproof,
-					inner,
-					&subclaim_eval_point,
+				self.verify_multilinear(
+					EvalcheckMultilinearClaim {
+						id: inner,
+						eval_point: subclaim_eval_point.into(),
+						eval: inner_eval,
+					},
+					transcript,
 				)?;
 			}
 			MultilinearPolyVariant::Composite(composition) => {
-				if evalcheck_proof != EvalcheckProof::CompositeMLE {
-					return Err(VerificationError::SubproofMismatch.into());
-				}
-
 				let meta = composite_sumcheck_meta(self.oracles, &eval_point)?;
 				add_composite_sumcheck_to_constraints(
 					&meta,
@@ -318,18 +256,36 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 		Ok(())
 	}
 
-	fn verify_multilinear_subclaim(
+	fn verify_multilinear_subclaim<Challenger_: Challenger>(
 		&mut self,
-		eval: F,
-		subproof: EvalcheckProof<F>,
 		oracle_id: OracleId,
-		eval_point: &[F],
-	) -> Result<(), Error> {
-		let subclaim = EvalcheckMultilinearClaim {
-			id: oracle_id,
-			eval_point: eval_point.into(),
-			eval,
-		};
-		self.verify_multilinear(subclaim, subproof)
+		eval_point: EvalPoint<F>,
+		transcript: &mut VerifierTranscript<Challenger_>,
+	) -> Result<F, Error> {
+		// If the subproof is a duplicate claim, we need to check if the claim is
+		// already in the round claims which has been verified otherwise, we verify the
+		// subclaim by DFS.
+		let subproof = deserialize_evalcheck_proof::<_, F>(&mut transcript.message())?;
+		match subproof {
+			EvalcheckProof::DuplicateClaim(index) => {
+				if self.round_claims[index].id != oracle_id
+					|| self.round_claims[index].eval_point != eval_point
+				{
+					return Err(VerificationError::DuplicateClaimMismatch.into());
+				}
+
+				Ok(self.round_claims[index].eval)
+			}
+			_ => {
+				let eval = transcript.message().read_scalar()?;
+				let subclaim = EvalcheckMultilinearClaim {
+					id: oracle_id,
+					eval_point,
+					eval,
+				};
+				self.verify_multilinear_skip_duplicate_check(subclaim, transcript)?;
+				Ok(eval)
+			}
+		}
 	}
 }


### PR DESCRIPTION
This removes most of the serialization/deserialization & proof struct pattern matching logic from evalcheck. This simplifies the code a lot. Documentation needs updating.