### PR TITLE
Replace backloaded with frontloaded sumchecks

### DIFF
--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -119,7 +119,6 @@ where
 			.iter_mut()
 			.map(|builder| std::mem::take(builder).build_one(self.oracles))
 			.filter(|constraint| !matches!(constraint, Err(OracleError::EmptyConstraintSet)))
-			.rev()
 			.collect()
 	}
 

--- a/crates/core/src/protocols/evalcheck/subclaims.rs
+++ b/crates/core/src/protocols/evalcheck/subclaims.rs
@@ -34,7 +34,10 @@ use crate::{
 	polynomial::MultivariatePoly,
 	protocols::sumcheck::{
 		self,
-		prove::oracles::{constraint_sets_sumcheck_provers_metas, SumcheckProversWithMetas},
+		prove::{
+			front_loaded,
+			oracles::{constraint_sets_sumcheck_provers_metas, SumcheckProversWithMetas},
+		},
 		Error as SumcheckError,
 	},
 	transcript::ProverTranscript,
@@ -533,7 +536,12 @@ where
 		backend,
 	)?;
 
-	let sumcheck_output = sumcheck::batch_prove(provers, transcript)?;
+	let batch_prover = front_loaded::BatchProver::new(provers, transcript)?;
+
+	let mut sumcheck_output = batch_prover.run(transcript)?;
+
+	// Reverse challenges since folding high-to-low
+	sumcheck_output.challenges.reverse();
 
 	let evalcheck_claims =
 		sumcheck::make_eval_claims(EvaluationOrder::HighToLow, metas, sumcheck_output)?;

--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -71,7 +71,6 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 			.iter_mut()
 			.map(|builder| mem::take(builder).build_one(self.oracles))
 			.filter(|constraint| !matches!(constraint, Err(OracleError::EmptyConstraintSet)))
-			.rev()
 			.collect()
 	}
 

--- a/crates/core/src/protocols/sumcheck/oracles.rs
+++ b/crates/core/src/protocols/sumcheck/oracles.rs
@@ -104,11 +104,11 @@ pub fn make_eval_claims<F: TowerField>(
 ) -> Result<Vec<EvalcheckMultilinearClaim<F>>, Error> {
 	let metas = metas.into_iter().collect::<Vec<_>>();
 
-	if !is_sorted_ascending(metas.iter().map(|meta| meta.n_vars).rev()) {
+	if !is_sorted_ascending(metas.iter().map(|meta| meta.n_vars)) {
 		bail!(Error::ClaimsOutOfOrder);
 	}
 
-	let max_n_vars = metas.first().map_or(0, |meta| meta.n_vars);
+	let max_n_vars = metas.last().map_or(0, |meta| meta.n_vars);
 
 	if metas.len() != batch_sumcheck_output.multilinear_evals.len() {
 		bail!(Error::ClaimProofMismatch);
@@ -126,8 +126,8 @@ pub fn make_eval_claims<F: TowerField>(
 
 		for (oracle_id, eval) in iter::zip(meta.oracle_ids, prover_evals) {
 			let eval_points_range = match evaluation_order {
-				EvaluationOrder::LowToHigh => max_n_vars - meta.n_vars..max_n_vars,
-				EvaluationOrder::HighToLow => 0..meta.n_vars,
+				EvaluationOrder::LowToHigh => 0..meta.n_vars,
+				EvaluationOrder::HighToLow => max_n_vars - meta.n_vars..max_n_vars,
 			};
 			let eval_point = batch_sumcheck_output.challenges[eval_points_range].to_vec();
 

--- a/crates/core/src/protocols/sumcheck/prove/front_loaded.rs
+++ b/crates/core/src/protocols/sumcheck/prove/front_loaded.rs
@@ -8,9 +8,9 @@ use bytes::BufMut;
 
 use super::batch_sumcheck::SumcheckProver;
 use crate::{
-	fiat_shamir::CanSample,
-	protocols::sumcheck::{Error, RoundCoeffs},
-	transcript::TranscriptWriter,
+	fiat_shamir::{CanSample, Challenger},
+	protocols::sumcheck::{BatchSumcheckOutput, Error, RoundCoeffs},
+	transcript::{ProverTranscript, TranscriptWriter},
 };
 
 /// Prover for a front-loaded batch sumcheck protocol execution.
@@ -56,6 +56,17 @@ where
 		let batch_coeffs = transcript.sample_vec(provers.len());
 
 		Self::new_prebatched(batch_coeffs, provers)
+	}
+
+	/// Returns total number of batched sumcheck rounds
+	pub fn total_rounds(&self) -> usize
+	where
+		Prover: SumcheckProver<F>,
+	{
+		self.provers
+			.back()
+			.map(|(prover, _)| prover.n_vars())
+			.unwrap_or(0)
 	}
 
 	/// Constructs a new prover for the front-loaded batched sumcheck with
@@ -151,5 +162,30 @@ where
 		}
 
 		Ok(self.multilinear_evals)
+	}
+
+	/// Proves a front-loaded batch sumcheck protocol execution.
+	pub fn run<Challenger_: Challenger>(
+		mut self,
+		transcript: &mut ProverTranscript<Challenger_>,
+	) -> Result<BatchSumcheckOutput<F>, Error> {
+		let round_count = self.total_rounds();
+
+		let mut challenges = Vec::with_capacity(round_count);
+		for _round_no in 0..round_count {
+			self.send_round_proof(&mut transcript.message())?;
+
+			let challenge = transcript.sample();
+			challenges.push(challenge);
+
+			self.receive_challenge(challenge)?;
+		}
+
+		let multilinear_evals = self.finish(&mut transcript.message())?;
+
+		Ok(BatchSumcheckOutput {
+			challenges,
+			multilinear_evals,
+		})
 	}
 }


### PR DESCRIPTION
### Replace Backloaded with Frontloaded Sumchecks

Replaces some backloaded sumchecks with frontloaded suchecks, towards keeping only frontloaded sumchecks. The goal is to simplify and reduce code. I don't know of a scenario when we must use backloaded instead of frontloaded.

There are 6 places where sumcheck is used in Binius:

- gkr gpa
- gkr exp
- zerocheck  
- the univariatizing reduction  
- evalcheck  
- PIOP  

The zerocheck and PIOP cases already use frontloaded sumchecks. This PR switches the univariatizing reduction and evalcheck to using frontloaded as well. I have yet to convert GKR GPA and GKR EXP, which I can do later in this PR or in other PRs.
