### PR TITLE
[fri] Simplify the FRI folding code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ getset = "0.1.2"
 groestl_crypto = { package = "groestl", version = "0.10.1" }
 hex-literal = "0.4.1"
 inventory = "0.3.19"
-itertools = "0.13.0"
+itertools = "0.14.0"
 lazy_static = "1.5.0"
 paste = "1.0.15"
 proc-macro2 = "1.0.81"

--- a/crates/core/src/protocols/fri/common.rs
+++ b/crates/core/src/protocols/fri/common.rs
@@ -1,15 +1,13 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use std::marker::PhantomData;
+use std::{iter, marker::PhantomData};
 
-use binius_field::{
-	packed::len_packed_slice, util::inner_product_unchecked, BinaryField, ExtensionField,
-	PackedField,
-};
+use binius_field::{util::inner_product_unchecked, BinaryField, ExtensionField, PackedField};
 use binius_math::extrapolate_line_scalar;
 use binius_ntt::AdditiveNTT;
 use binius_utils::bail;
 use getset::{CopyGetters, Getters};
+use itertools::Itertools;
 
 use crate::{
 	merkle_tree::MerkleTreeScheme, protocols::fri::Error,
@@ -53,51 +51,36 @@ where
 #[inline]
 pub fn fold_chunk<F, FS, NTT>(
 	ntt: &NTT,
-	start_round: usize,
+	mut round: usize,
 	chunk_index: usize,
-	values: &[F],
-	folding_challenges: &[F],
-	scratch_buffer: &mut [F],
+	values: &mut [F],
+	challenges: &[F],
 ) -> F
 where
 	F: BinaryField + ExtensionField<FS>,
 	FS: BinaryField,
 	NTT: AdditiveNTT<FS>,
 {
+	let mut log_size = challenges.len();
+
 	// Preconditions
-	debug_assert!(!folding_challenges.is_empty());
-	debug_assert!(start_round + folding_challenges.len() <= ntt.log_domain_size());
-	debug_assert_eq!(values.len(), 1 << folding_challenges.len());
-	debug_assert!(scratch_buffer.len() >= values.len());
+	debug_assert!(round + log_size <= ntt.log_domain_size());
+	debug_assert_eq!(values.len(), 1 << log_size);
 
-	// Fold the chunk with the folding challenges one by one
-	for n_challenges_processed in 0..folding_challenges.len() {
-		let n_remaining_challenges = folding_challenges.len() - n_challenges_processed;
-		let scratch_buffer_len = values.len() >> n_challenges_processed;
-		let new_scratch_buffer_len = scratch_buffer_len >> 1;
-		let round = start_round + n_challenges_processed;
-		let r = folding_challenges[n_challenges_processed];
-		let index_start = chunk_index << (n_remaining_challenges - 1);
-
+	// FRI-fold the values in place.
+	for &r in challenges {
 		// Fold the (2i) and (2i+1)th cells of the scratch buffer in-place into the i-th cell
-		if n_challenges_processed > 0 {
-			(0..new_scratch_buffer_len).for_each(|index_offset| {
-				let values =
-					(scratch_buffer[index_offset << 1], scratch_buffer[(index_offset << 1) + 1]);
-				scratch_buffer[index_offset] =
-					fold_pair(ntt, round, index_start + index_offset, values, r)
-			});
-		} else {
-			// For the first round, we read values directly from the `values` slice.
-			(0..new_scratch_buffer_len).for_each(|index_offset| {
-				let values = (values[index_offset << 1], values[(index_offset << 1) + 1]);
-				scratch_buffer[index_offset] =
-					fold_pair(ntt, round, index_start + index_offset, values, r)
-			});
+		for index_offset in 0..1 << (log_size - 1) {
+			let pair = (values[index_offset << 1], values[(index_offset << 1) + 1]);
+			values[index_offset] =
+				fold_pair(ntt, round, (chunk_index << (log_size - 1)) + index_offset, pair, r)
 		}
+
+		round += 1;
+		log_size -= 1;
 	}
 
-	scratch_buffer[0]
+	values[0]
 }
 
 /// Calculate the fold of an interleaved chunk of values with random folding challenges.
@@ -123,8 +106,10 @@ where
 ///
 /// [DP24]: <https://eprint.iacr.org/2024/504>
 #[inline]
+#[allow(clippy::too_many_arguments)]
 pub fn fold_interleaved_chunk<F, FS, P, NTT>(
 	ntt: &NTT,
+	log_len: usize,
 	log_batch_size: usize,
 	chunk_index: usize,
 	values: &[P],
@@ -139,36 +124,30 @@ where
 	P: PackedField<Scalar = F>,
 {
 	// Preconditions
-	debug_assert!(fold_challenges.len() <= ntt.log_domain_size() + log_batch_size);
-	debug_assert_eq!(len_packed_slice(values), 1 << (log_batch_size + fold_challenges.len()));
+	debug_assert!(fold_challenges.len() <= log_len);
+	debug_assert!(log_len <= ntt.log_domain_size());
+	debug_assert_eq!(
+		values.len(),
+		1 << (fold_challenges.len() + log_batch_size).saturating_sub(P::LOG_WIDTH)
+	);
 	debug_assert_eq!(tensor.len(), 1 << log_batch_size);
-	debug_assert!(scratch_buffer.len() >= 2 * (values.len() >> log_batch_size));
+	debug_assert!(scratch_buffer.len() >= 1 << fold_challenges.len());
 
-	// TODO: handle the case when log_batch_size is not a multiple of P::LOG_WIDTH
-	assert!(log_batch_size >= P::LOG_WIDTH);
+	let scratch_buffer = &mut scratch_buffer[..1 << fold_challenges.len()];
 
-	// There are two types of mixing we do in this loop. Buffer 1 is populated with the
-	// folding of symbols from the interleaved codewords into a single codeword. These
-	// values are mixed as a regular tensor product combination. Buffer 2 is then
-	// populated with `fold_chunk`, which folds a coset of a codeword using the FRI
-	// folding algorithm.
-	let (buffer1, buffer2) = scratch_buffer.split_at_mut(1 << fold_challenges.len());
-
-	for (interleave_chunk, val) in values
-		.chunks(1 << (log_batch_size - P::LOG_WIDTH))
-		.zip(buffer1.iter_mut())
-	{
-		*val = inner_product_unchecked(
-			PackedField::iter_slice(interleave_chunk),
-			tensor.iter().copied(),
-		);
-	}
-
-	if fold_challenges.is_empty() {
-		buffer1[0]
+	let values_iter = P::iter_slice(values);
+	if log_batch_size == 0 {
+		iter::zip(&mut *scratch_buffer, values_iter).for_each(|(dst, val)| *dst = val);
 	} else {
-		fold_chunk(ntt, 0, chunk_index, buffer1, fold_challenges, buffer2)
-	}
+		let values_chunks = values_iter.chunks(1 << log_batch_size);
+		let folded_values = values_chunks
+			.into_iter()
+			.map(|chunk| inner_product_unchecked(chunk, tensor.iter().copied()));
+		iter::zip(&mut *scratch_buffer, folded_values).for_each(|(dst, val)| *dst = val);
+	};
+
+	let round = ntt.log_domain_size() - log_len;
+	fold_chunk(ntt, round, chunk_index, scratch_buffer, fold_challenges)
 }
 
 /// Parameters for an FRI interleaved code proximity protocol.

--- a/crates/core/src/protocols/fri/prove.rs
+++ b/crates/core/src/protocols/fri/prove.rs
@@ -26,14 +26,19 @@ use crate::{
 	transcript::{ProverTranscript, TranscriptWriter},
 };
 
-/// Fold the interleaved codeword into a single codeword.
+/// FRI-fold the interleaved codeword using the given challenges.
 ///
 /// ## Arguments
 ///
-/// * `rs_code` - the Reed–Solomon code the protocol tests proximity to.
+/// * `ntt` - the NTT instance, used to look up the twiddle values.
 /// * `codeword` - an interleaved codeword.
 /// * `challenges` - the folding challenges. The length must be at least `log_batch_size`.
-/// * `log_batch_size` - the base-2 logarithm of the batch size of the interleaved code.
+/// * `log_len` - the binary logarithm of the code length.
+/// * `log_batch_size` - the binary logarithm of the interleaved code batch size.
+///
+/// See [DP24], Def. 3.6 and Lemma 3.9 for more details.
+///
+/// [DP24]: <https://eprint.iacr.org/2024/504>
 #[instrument(skip_all, level = "debug")]
 fn fold_interleaved<F, FS, NTT, P>(
 	ntt: &NTT,

--- a/crates/core/src/protocols/fri/prove.rs
+++ b/crates/core/src/protocols/fri/prove.rs
@@ -4,10 +4,10 @@ use binius_field::{
 	packed::{iter_packed_slice_with_offset, len_packed_slice},
 	BinaryField, ExtensionField, PackedExtension, PackedField, TowerField,
 };
-use binius_hal::{make_portable_backend, ComputationBackend};
+use binius_math::MultilinearQuery;
 use binius_maybe_rayon::prelude::*;
 use binius_ntt::AdditiveNTT;
-use binius_utils::{bail, SerializeBytes};
+use binius_utils::{bail, checked_arithmetics::log2_strict_usize, SerializeBytes};
 use bytemuck::zeroed_vec;
 use bytes::BufMut;
 use itertools::izip;
@@ -21,51 +21,12 @@ use super::{
 use crate::{
 	fiat_shamir::{CanSampleBits, Challenger},
 	merkle_tree::{MerkleTreeProver, MerkleTreeScheme},
-	protocols::fri::common::{fold_chunk, fold_interleaved_chunk},
+	protocols::fri::common::fold_interleaved_chunk,
 	reed_solomon::reed_solomon::ReedSolomonCode,
 	transcript::{ProverTranscript, TranscriptWriter},
 };
 
-#[instrument(skip_all, level = "debug")]
-pub fn fold_codeword<F, FS, NTT>(
-	ntt: &NTT,
-	rs_code: &ReedSolomonCode<FS>,
-	codeword: &[F],
-	// Round is the number of total folding challenges received so far.
-	round: usize,
-	folding_challenges: &[F],
-) -> Vec<F>
-where
-	F: BinaryField + ExtensionField<FS>,
-	FS: BinaryField,
-	NTT: AdditiveNTT<FS> + Sync,
-{
-	// Preconditions
-	assert_eq!(codeword.len() % (1 << folding_challenges.len()), 0);
-	assert!(round >= folding_challenges.len());
-	assert!(round <= rs_code.log_dim());
-
-	if folding_challenges.is_empty() {
-		return codeword.to_vec();
-	}
-
-	let start_round = round - folding_challenges.len();
-	let chunk_size = 1 << folding_challenges.len();
-
-	// For each chunk of size `2^chunk_size` in the codeword, fold it with the folding challenges
-	codeword
-		.par_chunks(chunk_size)
-		.enumerate()
-		.map_init(
-			|| vec![F::default(); chunk_size],
-			|scratch_buffer, (chunk_index, chunk)| {
-				fold_chunk(ntt, start_round, chunk_index, chunk, folding_challenges, scratch_buffer)
-			},
-		)
-		.collect()
-}
-
-/// Fold the interleaved codeword into a single codeword with the same block length.
+/// Fold the interleaved codeword into a single codeword.
 ///
 /// ## Arguments
 ///
@@ -76,9 +37,9 @@ where
 #[instrument(skip_all, level = "debug")]
 fn fold_interleaved<F, FS, NTT, P>(
 	ntt: &NTT,
-	rs_code: &ReedSolomonCode<FS>,
 	codeword: &[P],
 	challenges: &[F],
+	log_len: usize,
 	log_batch_size: usize,
 ) -> Vec<F>
 where
@@ -87,32 +48,28 @@ where
 	NTT: AdditiveNTT<FS> + Sync,
 	P: PackedField<Scalar = F>,
 {
-	assert_eq!(len_packed_slice(codeword), 1 << (rs_code.log_len() + log_batch_size));
-	assert!(P::LOG_WIDTH <= log_batch_size);
+	assert_eq!(codeword.len(), 1 << (log_len + log_batch_size).saturating_sub(P::LOG_WIDTH));
 	assert!(challenges.len() >= log_batch_size);
 
-	let backend = make_portable_backend();
-
 	let (interleave_challenges, fold_challenges) = challenges.split_at(log_batch_size);
-	let tensor = backend
-		.tensor_product_full_query(interleave_challenges)
-		.expect("number of challenges is less than 32");
+	let tensor = MultilinearQuery::expand(interleave_challenges);
 
 	// For each chunk of size `2^chunk_size` in the codeword, fold it with the folding challenges
 	let fold_chunk_size = 1 << fold_challenges.len();
-	let chunk_size = 1 << (fold_challenges.len() + log_batch_size - P::LOG_WIDTH);
+	let chunk_size = 1 << challenges.len().saturating_sub(P::LOG_WIDTH);
 	codeword
 		.par_chunks(chunk_size)
 		.enumerate()
 		.map_init(
-			|| vec![F::default(); 2 * fold_chunk_size],
+			|| vec![F::default(); fold_chunk_size],
 			|scratch_buffer, (i, chunk)| {
 				fold_interleaved_chunk(
 					ntt,
+					log_len,
 					log_batch_size,
 					i,
 					chunk,
-					&tensor,
+					tensor.expansion(),
 					fold_challenges,
 					scratch_buffer,
 				)
@@ -373,12 +330,12 @@ where
 			Some((prev_codeword, _)) => {
 				// Fold a full codeword committed in the previous FRI round into a codeword with
 				// reduced dimension and rate.
-				fold_codeword(
+				fold_interleaved(
 					self.ntt,
-					self.params.rs_code(),
 					prev_codeword,
-					self.curr_round - self.params.log_batch_size(),
 					&self.unprocessed_challenges,
+					log2_strict_usize(prev_codeword.len()),
+					0,
 				)
 			}
 			None => {
@@ -387,9 +344,9 @@ where
 				// fold rounds.
 				fold_interleaved(
 					self.ntt,
-					self.params.rs_code(),
 					self.codeword,
 					&self.unprocessed_challenges,
+					self.params.rs_code().log_len(),
 					self.params.log_batch_size(),
 				)
 			}

--- a/crates/core/src/protocols/fri/verify.rs
+++ b/crates/core/src/protocols/fri/verify.rs
@@ -172,14 +172,8 @@ where
 				.chunks(1 << n_final_challenges)
 				.enumerate()
 				.map(|(i, coset_values)| {
-					fold_chunk(
-						ntt,
-						n_prior_challenges,
-						i,
-						coset_values,
-						final_challenges,
-						&mut scratch_buffer,
-					)
+					scratch_buffer.copy_from_slice(coset_values);
+					fold_chunk(ntt, n_prior_challenges, i, &mut scratch_buffer, final_challenges)
 				})
 				.collect::<Vec<_>>()
 		} else {
@@ -187,13 +181,14 @@ where
 			// codeword.
 
 			let fold_arity = self.params.rs_code().log_dim() + self.params.log_batch_size();
-			let mut scratch_buffer = vec![F::default(); 2 * (1 << fold_arity)];
+			let mut scratch_buffer = vec![F::default(); 1 << self.params.rs_code().log_dim()];
 			terminate_codeword
 				.chunks(1 << fold_arity)
 				.enumerate()
 				.map(|(i, chunk)| {
 					fold_interleaved_chunk(
 						ntt,
+						self.params.rs_code().log_len(),
 						self.params.log_batch_size(),
 						i,
 						chunk,
@@ -290,6 +285,7 @@ where
 		)?;
 		let mut next_value = fold_interleaved_chunk(
 			ntt,
+			self.params.rs_code().log_len(),
 			self.params.log_batch_size(),
 			index,
 			&values,
@@ -306,7 +302,7 @@ where
 
 			log_n_cosets -= arity;
 
-			let values = verify_coset_opening(
+			let mut values = verify_coset_opening(
 				self.vcs,
 				coset_index,
 				arity,
@@ -328,9 +324,8 @@ where
 				ntt,
 				fold_round,
 				coset_index,
-				&values,
+				&mut values,
 				&self.fold_challenges[fold_round..fold_round + arity],
-				scratch_buffer,
 			);
 			index = coset_index;
 			fold_round += arity;

--- a/crates/core/src/protocols/fri/verify.rs
+++ b/crates/core/src/protocols/fri/verify.rs
@@ -173,7 +173,13 @@ where
 				.enumerate()
 				.map(|(i, coset_values)| {
 					scratch_buffer.copy_from_slice(coset_values);
-					fold_chunk(ntt, n_prior_challenges, i, &mut scratch_buffer, final_challenges)
+					fold_chunk(
+						ntt,
+						n_final_challenges + self.params.rs_code().log_inv_rate(),
+						i,
+						&mut scratch_buffer,
+						final_challenges,
+					)
 				})
 				.collect::<Vec<_>>()
 		} else {
@@ -322,7 +328,7 @@ where
 
 			next_value = fold_chunk(
 				ntt,
-				fold_round,
+				self.params.rs_code().log_len() - fold_round,
 				coset_index,
 				&mut values,
 				&self.fold_challenges[fold_round..fold_round + arity],


### PR DESCRIPTION
This simplifies the FRI folding code in a few ways. The improvements are:

- Remove the requirement that fold_challenges be non-empty
- Remove the `fold_codeword` prover function and use the more general `fold_interleaved` in all cases
- Pass `log_len` instead of `round` parameter so that the code will work with NTT instances with larger domains