### PR TITLE
[m3] fix rustdoc for the keccak module

### DIFF
--- a/crates/m3/src/gadgets/hash/keccak/mod.rs
+++ b/crates/m3/src/gadgets/hash/keccak/mod.rs
@@ -44,7 +44,7 @@ const STATE_OUT_TRACK: usize = 7;
 /// You can think about it as 8x wide SIMD performing one permutation per a table row. Below is
 /// the graphical representation of the layout.
 ///
-/// ```
+/// ```plain
 /// | Batch 0  | Batch 1  | Batch 3  |
 /// |----------|----------|----------|
 /// | Round 00 | Round 01 | Round 02 |


### PR DESCRIPTION
Based on top of https://github.com/IrreducibleOSS/binius/pull/283, don't merge until that is in.

Turns out we don't run doc tests.