### PR TITLE
Fix zero pad check and improve error message

### DIFF
--- a/crates/math/src/error.rs
+++ b/crates/math/src/error.rs
@@ -31,6 +31,8 @@ pub enum Error {
 	IncorrectQuerySize { expected: usize },
 	#[error("the sum of the query and the start index must be at most {expected}")]
 	IncorrectStartIndex { expected: usize },
+	#[error("the zero padding start index must be at most {expected}")]
+	IncorrectStartIndexZeroPad { expected: usize },
 	#[error("the index of the nonzero block should be at most {expected}")]
 	IncorrectNonZeroIndex { expected: usize },
 	#[error("the nonzero scalar prefix should be at most {expected}")]

--- a/crates/math/src/multilinear_extension.rs
+++ b/crates/math/src/multilinear_extension.rs
@@ -341,8 +341,8 @@ where
 		PE::Scalar: ExtensionField<P::Scalar>,
 	{
 		let init_n_vars = self.mu;
-		if start_index >= init_n_vars {
-			bail!(Error::IncorrectStartIndex { expected: self.mu })
+		if start_index > init_n_vars {
+			bail!(Error::IncorrectStartIndexZeroPad { expected: self.mu })
 		}
 		let new_n_vars = init_n_vars + n_pad_vars;
 		if nonzero_index >= 1 << n_pad_vars {


### PR DESCRIPTION
There is a small bug in the zero padding check in multilinear_extension.rs. This PR aims at fixing this issue and improving the associated error message.