### PR TITLE
[evalcheck] Handle composite MLEs separately from projected bivariate sumchecks

### DIFF
--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -13,7 +13,7 @@ use super::{
 	evalcheck::{EvalcheckHint, EvalcheckMultilinearClaim},
 	subclaims::{
 		add_bivariate_sumcheck_to_constraints, add_composite_sumcheck_to_constraints,
-		composite_sumcheck_meta, packed_sumcheck_meta, shifted_sumcheck_meta,
+		composite_mlecheck_meta, packed_sumcheck_meta, shifted_sumcheck_meta,
 	},
 	EvalPoint,
 };
@@ -241,9 +241,9 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 				)?;
 			}
 			MultilinearPolyVariant::Composite(composition) => {
-				let meta = composite_sumcheck_meta(self.oracles, &eval_point)?;
+				let meta = composite_mlecheck_meta(self.oracles, &eval_point)?;
 				add_composite_sumcheck_to_constraints(
-					&meta,
+					meta,
 					&mut self.new_sumcheck_constraints,
 					&composition,
 					eval,

--- a/crates/core/src/ring_switch/prove.rs
+++ b/crates/core/src/ring_switch/prove.rs
@@ -148,7 +148,7 @@ where
 		.map(|desc| Arc::as_ref(&desc.suffix))
 		.collect::<Vec<_>>();
 
-	memoized_data.memoize_query_par(&suffixes, backend)?;
+	memoized_data.memoize_query_par(suffixes, backend)?;
 
 	let tensor_elems = system
 		.sumcheck_claim_descs


### PR DESCRIPTION
They are different and should be handled differently. Composite MLE evaluations are not bivariate, and they don't use projection. In the future, we shouldn't handle them as regular sumchecks, we should prove them as MLEchecks, which have a more efficient proving algorithm.