### PR TITLE
[Fix] Match the order of processing bivariate sumcheck claims in evalcheck

### DIFF
--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -1,13 +1,13 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use std::{collections::HashSet, iter};
+use std::collections::HashSet;
 
 use binius_field::{PackedField, TowerField};
 use binius_hal::ComputationBackend;
 use binius_math::MultilinearExtension;
 use binius_maybe_rayon::prelude::*;
 use getset::{Getters, MutGetters};
-use itertools::{chain, izip};
+use itertools::chain;
 use tracing::instrument;
 
 use super::{
@@ -16,7 +16,7 @@ use super::{
 	serialize_evalcheck_proof,
 	subclaims::{
 		add_composite_sumcheck_to_constraints, calculate_projected_mles, composite_mlecheck_meta,
-		fill_eq_witness_for_composites, MemoizedData, ProjectedBivariateMeta,
+		fill_eq_witness_for_composites, BivariateClaims, MemoizedData, ProjectedBivariateMeta,
 	},
 	EvalPoint, EvalPointOracleIdMap,
 };
@@ -60,9 +60,7 @@ where
 	// Internally used to collect subclaims without evaluations for future query and memoization
 	claims_without_evals: Vec<(MultilinearPolyOracle<F>, EvalPoint<F>)>,
 	// The list of claims that reduces to a bivariate sumcheck in a round.
-	projected_bivariate_claims: Vec<EvalcheckMultilinearClaim<F>>,
-	// The list of claims that reduces to a composite MLEcheck in a round.
-	composite_mle_claims: Vec<EvalcheckMultilinearClaim<F>>,
+	bivariate_claims: Vec<BivariateClaims<P::Scalar>>,
 
 	// The new sumcheck constraints arising in this round
 	new_sumchecks_constraints: Vec<ConstraintSetBuilder<F>>,
@@ -101,8 +99,7 @@ where
 			new_sumchecks_constraints: Vec::new(),
 			claims_queue: Vec::new(),
 			claims_without_evals: Vec::new(),
-			projected_bivariate_claims: Vec::new(),
-			composite_mle_claims: Vec::new(),
+			bivariate_claims: Vec::new(),
 			memoized_data: MemoizedData::new(),
 			backend,
 
@@ -237,13 +234,26 @@ where
 			perfetto_category = "task.main"
 		)
 		.entered();
-		let projected_bivariate_metas = self
-			.projected_bivariate_claims
-			.iter()
-			.map(|claim| Self::projected_bivariate_meta(self.oracles, claim))
-			.collect::<Result<Vec<_>, Error>>()?;
 
-		let projected_bivariate_claims = std::mem::take(&mut self.projected_bivariate_claims);
+		let mut projected_bivariate_metas = Vec::new();
+		let mut composite_mle_metas = Vec::new();
+		let mut projected_bivariate_claims = Vec::new();
+		let mut composite_mle_claims = Vec::new();
+
+		for claim in &self.bivariate_claims {
+			match claim {
+				BivariateClaims::Projected(claim) => {
+					let meta = Self::projected_bivariate_meta(self.oracles, claim)?;
+					projected_bivariate_metas.push(meta);
+					projected_bivariate_claims.push(claim.clone())
+				}
+				BivariateClaims::Composite(claim) => {
+					let meta = composite_mlecheck_meta(self.oracles, &claim.eval_point)?;
+					composite_mle_metas.push(meta);
+					composite_mle_claims.push(claim.clone())
+				}
+			}
+		}
 
 		let projected_mles = calculate_projected_mles(
 			&projected_bivariate_metas,
@@ -254,13 +264,6 @@ where
 		)?;
 		drop(evalcheck_mle_fold_high_span);
 
-		// Fill witnesss data for Composite MLEs
-		let composite_mle_claims = std::mem::take(&mut self.composite_mle_claims);
-		let composite_mle_metas = composite_mle_claims
-			.iter()
-			.map(|claim| composite_mlecheck_meta(self.oracles, &claim.eval_point))
-			.collect::<Result<Vec<_>, Error>>()?;
-
 		fill_eq_witness_for_composites(
 			&composite_mle_metas,
 			&mut self.memoized_data,
@@ -269,14 +272,23 @@ where
 			self.backend,
 		)?;
 
-		for (claim, meta, projected) in
-			izip!(&projected_bivariate_claims, &projected_bivariate_metas, projected_mles)
-		{
-			self.process_bivariate_sumcheck(claim, meta, projected)?;
-		}
+		let mut projected_index = 0;
+		let mut composite_index = 0;
 
-		for (claim, meta) in iter::zip(composite_mle_claims, composite_mle_metas) {
-			self.process_composite_mlecheck(claim, meta)?;
+		for claim in std::mem::take(&mut self.bivariate_claims) {
+			match claim {
+				BivariateClaims::Projected(claim) => {
+					let meta = &projected_bivariate_metas[projected_index];
+					let projected = projected_mles[projected_index].clone();
+					self.process_bivariate_sumcheck(&claim, meta, projected)?;
+					projected_index += 1;
+				}
+				BivariateClaims::Composite(claim) => {
+					let meta = composite_mle_metas[composite_index];
+					self.process_composite_mlecheck(&claim, meta)?;
+					composite_index += 1;
+				}
+			}
 		}
 
 		self.memoized_data.memoize_partial_evals(
@@ -477,19 +489,24 @@ where
 				)?;
 			}
 			MultilinearPolyVariant::Shifted { .. } | MultilinearPolyVariant::Packed { .. } => {
-				self.projected_bivariate_claims
-					.push(EvalcheckMultilinearClaim {
-						id,
-						eval_point,
-						eval,
-					});
-			}
-			MultilinearPolyVariant::Composite { .. } => {
-				self.composite_mle_claims.push(EvalcheckMultilinearClaim {
+				let claim = EvalcheckMultilinearClaim {
 					id,
 					eval_point,
 					eval,
-				});
+				};
+
+				self.bivariate_claims
+					.push(BivariateClaims::Projected(claim));
+			}
+			MultilinearPolyVariant::Composite { .. } => {
+				let claim = EvalcheckMultilinearClaim {
+					id,
+					eval_point,
+					eval,
+				};
+
+				self.bivariate_claims
+					.push(BivariateClaims::Composite(claim));
 			}
 			MultilinearPolyVariant::LinearCombination(linear_combination) => {
 				for suboracle_id in linear_combination.polys() {
@@ -605,7 +622,7 @@ where
 
 	fn process_composite_mlecheck(
 		&mut self,
-		evalcheck_claim: EvalcheckMultilinearClaim<F>,
+		evalcheck_claim: &EvalcheckMultilinearClaim<F>,
 		meta: CompositeMLECheckMeta,
 	) -> Result<(), Error> {
 		let EvalcheckMultilinearClaim {
@@ -614,14 +631,14 @@ where
 			eval,
 		} = evalcheck_claim;
 
-		match self.oracles.oracle(id).variant {
+		match self.oracles.oracle(*id).variant {
 			MultilinearPolyVariant::Composite(composite) => {
 				// witness for eq MLE has been previously filled in `fill_eq_witness_for_composites`
 				add_composite_sumcheck_to_constraints(
 					meta,
 					&mut self.new_sumchecks_constraints,
 					&composite,
-					eval,
+					*eval,
 				);
 				Ok(())
 			}

--- a/crates/core/src/protocols/evalcheck/subclaims.rs
+++ b/crates/core/src/protocols/evalcheck/subclaims.rs
@@ -540,3 +540,9 @@ where
 
 	Ok(evalcheck_claims)
 }
+
+#[derive(Clone)]
+pub enum BivariateClaims<F: Field> {
+	Projected(EvalcheckMultilinearClaim<F>),
+	Composite(EvalcheckMultilinearClaim<F>),
+}

--- a/crates/core/src/protocols/evalcheck/subclaims.rs
+++ b/crates/core/src/protocols/evalcheck/subclaims.rs
@@ -542,7 +542,7 @@ where
 }
 
 #[derive(Clone)]
-pub enum BivariateClaims<F: Field> {
+pub enum SumcheckClaims<F: Field> {
 	Projected(EvalcheckMultilinearClaim<F>),
 	Composite(EvalcheckMultilinearClaim<F>),
 }

--- a/crates/core/src/protocols/greedy_evalcheck/mod.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/mod.rs
@@ -13,6 +13,8 @@
 
 mod error;
 mod prove;
+#[cfg(test)]
+mod tests;
 mod verify;
 
 pub use error::*;

--- a/crates/core/src/protocols/greedy_evalcheck/prove.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/prove.rs
@@ -1,8 +1,6 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use binius_field::{
-	ExtensionField, Field, PackedExtension, PackedField, PackedFieldIndexable, TowerField,
-};
+use binius_field::{ExtensionField, Field, PackedExtension, PackedField, TowerField};
 use binius_hal::ComputationBackend;
 use binius_math::EvaluationDomainFactory;
 
@@ -35,7 +33,7 @@ pub fn prove<'a, F, P, DomainField, Challenger_, Backend>(
 ) -> Result<GreedyEvalcheckProveOutput<'a, F, P, Backend>, Error>
 where
 	F: TowerField + ExtensionField<DomainField>,
-	P: PackedFieldIndexable<Scalar = F>
+	P: PackedField<Scalar = F>
 		+ PackedExtension<F, PackedSubfield = P>
 		+ PackedExtension<DomainField>,
 	DomainField: TowerField,

--- a/crates/core/src/protocols/greedy_evalcheck/tests.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/tests.rs
@@ -1,0 +1,179 @@
+// Copyright 2024-2025 Irreducible Inc.
+use std::iter::repeat_with;
+
+use binius_field::{
+	packed::{get_packed_slice, len_packed_slice, pack_slice, set_packed_slice},
+	BinaryField128b, BinaryField1b, BinaryField32b, ExtensionField, Field, PackedBinaryField128x1b,
+	PackedBinaryField1x128b, PackedExtension, PackedField, RepackedExtension, TowerField,
+};
+use binius_hal::{make_portable_backend, ComputationBackendExt};
+use binius_hash::groestl::Groestl256;
+use binius_macros::arith_expr;
+use binius_math::{DefaultEvaluationDomainFactory, MultilinearExtension};
+use bytemuck::Pod;
+use either::Either;
+use rand::{rngs::StdRng, SeedableRng};
+
+use crate::{
+	fiat_shamir::HasherChallenger,
+	oracle::{MultilinearOracleSet, ShiftVariant},
+	polynomial::MultivariatePoly,
+	protocols::{
+		evalcheck::EvalcheckMultilinearClaim,
+		greedy_evalcheck::{prove, verify},
+		sumcheck::standard_switchover_heuristic,
+	},
+	transcript::ProverTranscript,
+	transparent::select_row::SelectRow,
+	witness::MultilinearExtensionIndex,
+};
+
+type FExtension = BinaryField128b;
+type PExtension = PackedBinaryField1x128b;
+type FDomain = BinaryField32b;
+
+pub fn shift_one<P: PackedField>(evals: &mut [P], bits: usize, variant: ShiftVariant) {
+	let len = len_packed_slice(evals);
+	assert_eq!(len % (1 << bits), 0);
+
+	for block_idx in 0..len >> bits {
+		let range = (block_idx << bits)..((block_idx + 1) << bits);
+		let (range, mut last) = match variant {
+			ShiftVariant::LogicalLeft => (Either::Left(range), P::Scalar::ZERO),
+			ShiftVariant::LogicalRight => (Either::Right(range.rev()), P::Scalar::ZERO),
+			ShiftVariant::CircularLeft => {
+				let last = get_packed_slice(evals, range.end - 1);
+				(Either::Left(range), last)
+			}
+		};
+
+		for i in range {
+			let next = get_packed_slice(evals, i);
+			set_packed_slice(evals, i, last);
+			last = next;
+		}
+	}
+}
+
+fn run_test_evalcheck_composite_projected<P, FExtension, PExtension>(n_vars: usize)
+where
+	P: PackedField<Scalar = BinaryField1b> + Pod,
+	P::Scalar: TowerField,
+	FExtension: TowerField + ExtensionField<BinaryField1b> + ExtensionField<FDomain>,
+	PExtension: PackedField<Scalar = FExtension>
+		+ PackedExtension<FDomain>
+		+ RepackedExtension<P>
+		+ RepackedExtension<PExtension>
+		+ Pod,
+{
+	let mut rng = StdRng::seed_from_u64(0);
+
+	let select_row1 = SelectRow::new(n_vars, 0).unwrap();
+	let select_row2 = SelectRow::new(n_vars, 5).unwrap();
+	let select_row3 = SelectRow::new(n_vars, 10).unwrap();
+
+	let mut oracles = MultilinearOracleSet::new();
+
+	let select_row1_oracle_id = oracles.add_transparent(select_row1.clone()).unwrap();
+	let select_row2_oracle_id = oracles.add_transparent(select_row2.clone()).unwrap();
+	let select_row3_oracle_id = oracles.add_transparent(select_row3.clone()).unwrap();
+
+	let comp = arith_expr!(FExtension[x, y, z] = x*y + x*z +  z);
+
+	let composite_id = oracles
+		.add_composite_mle(
+			n_vars,
+			[
+				select_row1_oracle_id,
+				select_row2_oracle_id,
+				select_row3_oracle_id,
+			],
+			comp,
+		)
+		.unwrap();
+
+	let eval_point = repeat_with(|| <FExtension as Field>::random(&mut rng))
+		.take(n_vars)
+		.collect::<Vec<_>>();
+
+	let eval = select_row3.evaluate(&eval_point).unwrap();
+
+	let composite_claim = EvalcheckMultilinearClaim {
+		id: composite_id,
+		eval_point: eval_point.clone().into(),
+		eval,
+	};
+
+	let select_row1_witness = select_row1.multilinear_extension::<P>().unwrap();
+	let select_row2_witness = select_row2.multilinear_extension::<P>().unwrap();
+	let select_row3_witness = select_row3.multilinear_extension::<P>().unwrap();
+
+	let composite_scalars = (0..1 << n_vars)
+		.map(|i| {
+			select_row1_witness.evaluate_on_hypercube(i).unwrap()
+				* select_row2_witness.evaluate_on_hypercube(i).unwrap()
+				+ select_row2_witness.evaluate_on_hypercube(i).unwrap()
+					* select_row3_witness.evaluate_on_hypercube(i).unwrap()
+				+ select_row3_witness.evaluate_on_hypercube(i).unwrap()
+		})
+		.collect::<Vec<P::Scalar>>();
+
+	let composite_values: Vec<P> = pack_slice(&composite_scalars);
+
+	let composite_witness = MultilinearExtension::from_values(composite_values).unwrap();
+
+	let mut shifted_evals = composite_witness.evals().to_vec();
+	shift_one(&mut shifted_evals, n_vars, ShiftVariant::CircularLeft);
+	let shifted_witness = MultilinearExtension::from_values(shifted_evals).unwrap();
+
+	let shifted_id = oracles
+		.add_shifted(composite_id, 1, n_vars, ShiftVariant::CircularLeft)
+		.unwrap();
+
+	let backend = make_portable_backend();
+
+	let query = backend
+		.multilinear_query::<FExtension>(&eval_point)
+		.unwrap();
+
+	let eval = shifted_witness.evaluate(query.to_ref()).unwrap();
+
+	let mut witness_index = MultilinearExtensionIndex::<PExtension>::new();
+	witness_index
+		.update_multilin_poly(vec![
+			(select_row1_oracle_id, select_row1_witness.specialize_arc_dyn()),
+			(select_row2_oracle_id, select_row2_witness.specialize_arc_dyn()),
+			(select_row3_oracle_id, select_row3_witness.specialize_arc_dyn()),
+			(composite_id, composite_witness.specialize_arc_dyn()),
+			(shifted_id, shifted_witness.specialize_arc_dyn()),
+		])
+		.unwrap();
+
+	let shifted_claim = EvalcheckMultilinearClaim {
+		id: shifted_id,
+		eval_point: eval_point.into(),
+		eval,
+	};
+
+	let domain_factory = DefaultEvaluationDomainFactory::<FDomain>::default();
+
+	let mut transcript = ProverTranscript::<HasherChallenger<Groestl256>>::new();
+	let _ = prove::<_, _, FDomain, _, _>(
+		&mut oracles,
+		&mut witness_index,
+		[composite_claim.clone(), shifted_claim.clone()],
+		standard_switchover_heuristic(-2),
+		&mut transcript,
+		&domain_factory,
+		&backend,
+	)
+	.unwrap();
+
+	let mut transcript = transcript.into_verifier();
+	verify(&mut oracles, [composite_claim, shifted_claim], &mut transcript).unwrap();
+}
+
+#[test]
+fn test_evalcheck_composite_projected() {
+	run_test_evalcheck_composite_projected::<PackedBinaryField128x1b, FExtension, PExtension>(8);
+}


### PR DESCRIPTION
The verifier processes claims successively, while the prover processes all projected claims first, followed by all composite.
As a result, if a projected and a composite claim have the same n_vars, the order of sumcheck_claims will differ between the verifier and prover.

The fix is a bit ad hoc, but #291 will provide a cleaner long-term solution

