### PR TITLE
[m3] emulate Channel relax Default constraint

### DIFF
--- a/crates/m3/src/emulate.rs
+++ b/crates/m3/src/emulate.rs
@@ -3,9 +3,17 @@
 use std::{collections::HashMap, hash::Hash};
 
 /// A channel used to validate a high-level M3 trace.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Channel<T> {
 	net_multiplicities: HashMap<T, isize>,
+}
+
+impl<T> Default for Channel<T> {
+	fn default() -> Self {
+		Self {
+			net_multiplicities: HashMap::default(),
+		}
+	}
 }
 
 impl<T: Hash + Eq> Channel<T> {


### PR DESCRIPTION
Channel prior to this PR is overconstrained. It requires T to implement Default all the while the Channel does not actually contain any T by default.