### PR TITLE
improve early FRI termination optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,21 +124,18 @@ tracing-profile = "0.10.4"
 transpose = "0.2.2"
 
 [profile.release]
-opt-level = 0
 lto = "fat"
 
 [profile.profiling]
-opt-level = 0
 inherits = "release"
 debug = true
 
 [profile.bench]
-opt-level = 0
 inherits = "release"
 debug = true
 
 [profile.test]
-opt-level = 0
+opt-level = 1
 debug = true
 debug-assertions = true
 overflow-checks = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,18 +124,21 @@ tracing-profile = "0.10.4"
 transpose = "0.2.2"
 
 [profile.release]
+opt-level = 0
 lto = "fat"
 
 [profile.profiling]
+opt-level = 0
 inherits = "release"
 debug = true
 
 [profile.bench]
+opt-level = 0
 inherits = "release"
 debug = true
 
 [profile.test]
-opt-level = 1
+opt-level = 0
 debug = true
 debug-assertions = true
 overflow-checks = true

--- a/crates/core/src/piop/verify.rs
+++ b/crates/core/src/piop/verify.rs
@@ -139,7 +139,7 @@ where
 	// note that `total_vars + log_inv_rate - sum(fold_arities)` is exactly the log-length of the terminal codeword; we want this number to be > cap height.
 	// so fold_arities will repeat `arity` the maximal number of times possible, while maintaining that `total_vars + log_inv_rate - sum(fold_arities) > cap_height` stays true.
 	// this arity-selection strategy can be characterized as: "terminate as LATE as you can while nonetheless maintaining that all oracles have positive-length Merkle paths."
-	// note first that the Merkle path height (post-coset-bundling trick) of the last non-terminal codeword will equal the length of the terminal codeword, which is > cap height by fiat.
+	// note first that the Merkle path height (post-coset-bundling trick) of the last non-terminal codeword will equal the log-length of the terminal codeword, which is > cap height by fiat.
 	// moreover, if we terminated any later than we are above, this would stop being true. imagine what would happen if we took the above terminal codeword and folded more.
 	// in that case, we would Merklize this word, again with the coset-bundling trick; the post-bundling path height would thus be `total_vars + log_inv_rate - sum(fold_arities) - arity`.
 	// but we already agreed (by the maximality of the number of times we subtracted `arity`) that the above thing will be ≤ cap_height. in other words, its paths will be empty.

--- a/crates/core/src/piop/verify.rs
+++ b/crates/core/src/piop/verify.rs
@@ -158,7 +158,7 @@ where
 	// case `log_batch_size = total_vars` and `log_dim = 0`, we're sending the entire message anyway, so the FRI portion is essentially trivial / superfluous, and the security is perfect.
 	// and in any case we could evade it simply by calculating `n_test_queries` and `cap_height` using the provisional `log_dim := total_vars.saturating_sub(arity)`, proceeding as above,
 	// and only then, if we find out post facto that `fold_arities = []`, overwriting `log_batch_size := total_vars` and `log_dim = 0`---and even recalculating `n_test_queries` if we wanted
-	// (though of course it doesn't matter---we could do 0 queries in that case, and we would still get security---and in fact during the actual part portion we will skip querying anyway).
+	// (though of course it doesn't matter---we could do 0 queries in that case, and we would still get security---and in fact during the actual querying part we will skip querying anyway).
 	// in any case, from a purely code-simplicity point of view, the simplest approach is to bite the bullet and let `log_batch_size := min(total_vars, arity)` for good---and keep it there,
 	// even if we post-facto find out that `fold_arities = []`. the cost of this is that the prover has to do a nontrivial (though small!) interleaved encoding, as opposed to a trivial one.
 	let fri_params = FRIParams::new(rs_code, log_batch_size, fold_arities, n_test_queries)?;

--- a/crates/core/src/piop/verify.rs
+++ b/crates/core/src/piop/verify.rs
@@ -149,7 +149,7 @@ where
 	// it can be shown that this strategy beats any strategy which terminates later than it does (in other words, by doing this, we are NOT terminating TOO early!).
 	// this doesn't mean that we should't terminate EVEN earlier (maybe we should). but this approach is conservative and simple; and it's easy to show that you won't lose by doing this.
 
-	// see PR for proof of this fact
+	// see https://github.com/IrreducibleOSS/binius/pull/300 for proof of this fact
 
 	// how should we handle the case `fold_arities = []`, i.e. total_vars + log_inv_rate - cap_height < arity? in that case, we would lose nothing by making the entire thing interleaved,
 	// i.e., setting `log_batch_size := total_vars`, so `terminal_codeword` lives in the interleaving of the repetition code (and so is itself a repetition codeword!). encoding is trivial.

--- a/crates/core/src/piop/verify.rs
+++ b/crates/core/src/piop/verify.rs
@@ -168,15 +168,13 @@ where
 		.unwrap_or(commit_meta.total_vars);
 	// in the case of empty fold arities, we literally lose nothing (in fact we gain) by making the entire thing interleaved.
 	// this has the paradoxical effect that as `total_vars` grows, `log_batch_size` will also grow in lockstep, _until_ total_vars + log_inv_rate - crude_cap_height > arity becomes true,
-	// at which point `fold_arities` will become nonempty and `log_batch_size` will become fixed to 4 from that point onwards.
+	// at which point `fold_arities` will become nonempty and `log_batch_size` will become fixed to `arity` from that point onwards.
 	// so e.g. if `log_inv_rate = 1`, `arity = 4`, `crude_cap_height = 8`, and `total_vars = 11`, then `fold_arities` will be [], `log_batch_size` will be 11, and `log_dim` will be 0;
 	// whereas for all else equal but `total_vars = 12`, then finally we get `fold_arities = [4]` `log_batch_size = 4`, and `log_dim = 8`.
 
 	let log_dim = commit_meta.total_vars - log_batch_size;
 	let rs_code = ReedSolomonCode::new(log_dim, log_inv_rate)?;
-
 	let n_test_queries: usize = fri::calculate_n_test_queries::<F, _>(security_bits, &rs_code)?;
-
 	let fri_params = FRIParams::new(rs_code, log_batch_size, fold_arities, n_test_queries)?;
 	Ok(fri_params)
 }

--- a/crates/core/src/piop/verify.rs
+++ b/crates/core/src/piop/verify.rs
@@ -167,8 +167,8 @@ where
 		.copied()
 		.unwrap_or(commit_meta.total_vars);
 	// in the case of empty fold arities, we literally lose nothing (in fact we gain) by making the entire thing interleaved.
-	// this has the paradoxical effect that as `total_vars` grows, `log_batch_size` will also grow in lockstep, _until_ total_vars + log_inv_rate - crude_cap_height > arity,
-	// at which point `fold_arities` will become nonempty and `log_batch_size` will become fixed to 4 for the rest of time.
+	// this has the paradoxical effect that as `total_vars` grows, `log_batch_size` will also grow in lockstep, _until_ total_vars + log_inv_rate - crude_cap_height > arity becomes true,
+	// at which point `fold_arities` will become nonempty and `log_batch_size` will become fixed to 4 from that point onwards.
 	// so e.g. if `log_inv_rate = 1`, `arity = 4`, `crude_cap_height = 8`, and `total_vars = 11`, then `fold_arities` will be [], `log_batch_size` will be 11, and `log_dim` will be 0;
 	// whereas for all else equal but `total_vars = 12`, then finally we get `fold_arities = [4]` `log_batch_size = 4`, and `log_dim = 8`.
 

--- a/crates/core/src/piop/verify.rs
+++ b/crates/core/src/piop/verify.rs
@@ -155,7 +155,7 @@ where
 	// we need to know whether `total_vars + log_inv_rate - cap_height > arity` or not (we will have positive-indexed oracles if and only if this inequality is true).
 	// and here is the dependency: we need to know what cap height is. in order to break this, i have used a `crude_cap_height` in the above estimation, which ignores code block length.
 	// this might be an underestimate; in general, cap_height ≥ crude_cap_height. so in the worst case, we could have more positive oracles than we should (i.e., we could terminate "too late").
-	// note that this has nothing whatsoever to do with security---the `cap_height` below will be the "true" one. it only has to do with efficiency (early FRI termination).
+	// note that this has nothing whatsoever to do with security---the `n_test_queries` below will be the "true" one. it only has to do with efficiency (early FRI termination).
 	// as a separate note, the case where factoring in `log_dim` bumps up the `n_test_queries` at all, let alone the cap height, is extremely rare.
 	// in any case, here is an example with numbers. let's say that `arity = 4`, `total_vars = 11`, `log_inv_rate` = 1`, and `crude_cap_height = 7`.
 	// in this case `fold_arities` will be the 1-element list [4], `log_batch_size` will be 4, `log_dim` will be 7. now let's assume that `log2_ceil_usize(n_test_queries) = 9`.

--- a/crates/core/src/piop/verify.rs
+++ b/crates/core/src/piop/verify.rs
@@ -152,7 +152,7 @@ where
 	// see PR for proof of this fact
 
 	// how should we handle the case `fold_arities = []`, i.e. total_vars + log_inv_rate - cap_height < arity? in that case, we would lose nothing by making the entire thing interleaved,
-	// i.e., setting `log_batch_size := total_vars`, so `terminal_codeword` is an interleaving of the repetition code---so is itself a repetition code!---the prover just sends the message.
+	// i.e., setting `log_batch_size := total_vars`, so `terminal_codeword` lives in the interleaving of the repetition code (and so is itself a repetition codeword!). encoding is trivial.
 	// but there's a circularity: whether `total_vars + log_inv_rate - cap_height < arity` or not depends on `cap_height`, which depends on `n_test_queries`, which depends on `log_dim`---
 	// soundness depends on block length!---which finally itself depends on whether we're using the repetition code or not. of course this circular dependency is artificial, since in the
 	// case `log_batch_size = total_vars` and `log_dim = 0`, we're sending the entire message anyway, so the FRI portion is essentially trivial / superfluous, and the security is perfect.

--- a/crates/core/src/piop/verify.rs
+++ b/crates/core/src/piop/verify.rs
@@ -139,7 +139,7 @@ where
 	// note that `total_vars + log_inv_rate - sum(fold_arities)` is exactly the log-length of the terminal codeword; we want this number to be > cap height.
 	// so fold_arities will repeat `arity` the maximal number of times possible, while maintaining that `total_vars + log_inv_rate - sum(fold_arities) > cap_height` stays true.
 	// this arity-selection strategy can be characterized as: "terminate as LATE as you can while nonetheless maintaining that all oracles have positive-length Merkle paths."
-	// note first that the Merkle path height (post-coset-bundling trick) of the last non-terminal codeword will equal the length of the terminal codeword, which is sure enough positive.
+	// note first that the Merkle path height (post-coset-bundling trick) of the last non-terminal codeword will equal the length of the terminal codeword, which is > cap height by fiat.
 	// moreover, if we terminated any later than we are above, this would stop being true. imagine what would happen if we took the above terminal codeword and folded more.
 	// in that case, we would Merklize this word, again with the coset-bundling trick; the post-bundling path height would thus be `total_vars + log_inv_rate - sum(fold_arities) - arity`.
 	// but we already agreed (by the maximality of the number of times we subtracted `arity`) that the above thing will be ≤ cap_height. in other words, its paths will be empty.

--- a/crates/core/src/piop/verify.rs
+++ b/crates/core/src/piop/verify.rs
@@ -129,7 +129,7 @@ where
 	let log_dim = commit_meta.total_vars.saturating_sub(arity);
 	let log_batch_size = commit_meta.total_vars.min(arity);
 	let rs_code = ReedSolomonCode::new(log_dim, log_inv_rate)?;
-	let n_test_queries: usize = fri::calculate_n_test_queries::<F, _>(security_bits, &rs_code)?;
+	let n_test_queries = fri::calculate_n_test_queries::<F, _>(security_bits, &rs_code)?;
 
 	let cap_height = log2_ceil_usize(n_test_queries);
 	let fold_arities = std::iter::repeat_n(


### PR DESCRIPTION
significantly improve FRI early termination calculation; this will lead to smaller proof sizes.

here, i am going to show that we can always improve our lives by advancing early termination _at least_ to the point at which the terminal codeword's log length becomes at least as large as the Merkle cap height. Equivalently, we want all Merkle paths to have nonnegative lengths, as opposed to "negative" ones—we don't want to commit to an oracle whose Merkle tree height is so short that the cap becomes "smaller than we decided we wanted". in one word, after this PR, [this min](https://github.com/IrreducibleOSS/binius/blob/ed227dfc69aff8eba37ec6da6edaf85189ec9e95/crates/core/src/merkle_tree/scheme.rs#L50) will have no effect (it will be a no-op).

terminating even earlier might help even more, but we won't hurt ourselves by going at least this far.

let's write $c := \lceil \log_2 \gamma \rceil$ for the Merkle cap height (this depends on the number of queries). it might help to just think `c = 8`. let's write $j = \ell_i + \mathcal{R}$ for the log-length of the `terminal_codeword`. let's assume moreover that $j < c$. we are going to show that by advancing the termination forward by one oracle, we make proof size (strictly!) better, not worse.

if we advance the termination (make it earlier) by one oracle, then three things will happen:
1. the size of the `terminal_codeword` will get worse; it will go from $2^j$ field elements to $2^{j + \vartheta}$ field elements.
2. we will dodge having to send a Merkle cap of the currently-last _non_-terminal codeword. the block length of that codeword is $2^\vartheta \cdot 2^j$; post "coset bundling trick", the Merkle height will be $j$. But we already agreed that $j < c$, so the Merkle cap we are saving will consist of exactly $2^j$ digests.
3. each coset chain during FRI querying will shorten by one (we will no longer have to send a coset for the codeword which is _currently_ the last non-terminal one); the savings will be $\gamma \cdot 2^\vartheta$ field elements
4. note that the total number of Merkle path digests _won't_ change. why? because by 2., we already saw that the currently-last nonterminal codeword's Merkle tree is of height $j$, which is less than the Merkle cap height; so that oracle is contributing nothing to overall Merkle paths sent.

so all we have to do is tally up the net savings, and show that it's positive. the net savings are $\gamma \cdot 2^\vartheta$ field elements, plus $2^j$ digests, _minus_ $(2^\vartheta - 1) \cdot 2^j$ field elements (this is how much _worse_ the terminal codeword gets). actually, I am going to show that we are in the green even if we consider only field elements; that is, if we ignore the digests. this is obviously conservative.

so the net gain, considering only field elements, is $\gamma \cdot 2^\vartheta - (2^\vartheta - 1) \cdot 2^j$; we want this thing to be greater than 0. in other words, we want:

$$2^\vartheta \cdot \gamma \stackrel{?}> (2^\vartheta - 1) \cdot 2^j.$$

note first of all that $2^\vartheta > 2^\vartheta - 1$ obviously. moreover, i claim that $\gamma > 2^j$. why? because we chose $c := \lceil \log_2 \gamma \rceil$, and moreover $j < c$. so $j < \lceil \log_2 \gamma \rceil$. if you stare at this thing, this is equivalent on the nose to $2^j < \gamma$.