### PR TITLE
[ntt] Add skip_rounds parameter to AdditiveNTT

### DIFF
--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -17,7 +17,7 @@ use binius_math::{
 	IsomorphicEvaluationDomainFactory, MLEDirectAdapter, MultilinearExtension, MultilinearPoly,
 };
 use binius_maybe_rayon::prelude::*;
-use binius_ntt::{DynamicDispatchNTT, NTTOptions, ThreadingSettings};
+use binius_ntt::SingleThreadedNTT;
 use binius_utils::bail;
 use digest::{core_api::BlockSizeUser, Digest, FixedOutputReset, Output};
 use itertools::chain;
@@ -130,13 +130,9 @@ where
 		security_bits,
 		log_inv_rate,
 	)?;
-	let ntt = DynamicDispatchNTT::new(
-		fri_params.rs_code().log_len(),
-		&NTTOptions {
-			thread_settings: ThreadingSettings::MultithreadedDefault,
-			precompute_twiddles: true,
-		},
-	)?;
+	let ntt = SingleThreadedNTT::new(fri_params.rs_code().log_len())?
+		.precompute_twiddles()
+		.multithreaded();
 
 	let commit_span =
 		tracing::info_span!("[phase] Commit", phase = "commit", perfetto_category = "phase.main")

--- a/crates/core/src/protocols/sumcheck/prove/univariate.rs
+++ b/crates/core/src/protocols/sumcheck/prove/univariate.rs
@@ -587,7 +587,7 @@ fn extrapolate_round_evals<F: TowerField>(
 			log_y: next_log_n,
 			..Default::default()
 		};
-		ntt.forward_transform(round_evals, shape, 0)?;
+		ntt.forward_transform(round_evals, shape, 0, 0)?;
 
 		// Sanity check: first 1 << skip_rounds evals are still zeros.
 		debug_assert!(round_evals[..1 << skip_rounds]
@@ -621,7 +621,7 @@ where
 	};
 
 	// Inverse NTT: convert evals to novel basis representation
-	ntt.inverse_transform(evals, shape, 0)?;
+	ntt.inverse_transform(evals, shape, 0, 0)?;
 
 	// Forward NTT: evaluate novel basis representation at consecutive cosets
 	for (coset, extrapolated_chunk) in
@@ -629,7 +629,7 @@ where
 	{
 		// REVIEW: can avoid that copy (and extrapolated_evals scratchpad) when composition_max_degree == 2
 		extrapolated_chunk.copy_from_slice(evals);
-		ntt.forward_transform(extrapolated_chunk, shape, coset)?;
+		ntt.forward_transform(extrapolated_chunk, shape, coset, 0)?;
 	}
 
 	Ok(())

--- a/crates/core/src/reed_solomon/error.rs
+++ b/crates/core/src/reed_solomon/error.rs
@@ -2,6 +2,8 @@
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+	#[error("incorrect buffer length: expected {expected}, got {actual}")]
+	IncorrectBufferLength { expected: usize, actual: usize },
 	#[error("the evaluation domain of the code does not match the subspace of the NTT encoder")]
 	EncoderSubspaceMismatch,
 	#[error("the dimension of the evaluation domain of the code does not match the parameters")]

--- a/crates/core/src/reed_solomon/reed_solomon.rs
+++ b/crates/core/src/reed_solomon/reed_solomon.rs
@@ -6,8 +6,7 @@
 
 use binius_field::{BinaryField, ExtensionField, PackedExtension, PackedField};
 use binius_math::BinarySubspace;
-use binius_maybe_rayon::prelude::*;
-use binius_ntt::{AdditiveNTT, Error as NTTError, NTTShape};
+use binius_ntt::{AdditiveNTT, NTTShape};
 use binius_utils::bail;
 use getset::{CopyGetters, Getters};
 
@@ -103,6 +102,15 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 		if ntt.subspace(ntt.log_domain_size() - self.log_len()) != self.subspace {
 			bail!(Error::EncoderSubspaceMismatch);
 		}
+		let expected_buffer_len =
+			1 << (self.log_len() + log_batch_size).saturating_sub(P::LOG_WIDTH);
+		if code.len() != expected_buffer_len {
+			bail!(Error::IncorrectBufferLength {
+				expected: expected_buffer_len,
+				actual: code.len(),
+			});
+		}
+
 		let _scope = tracing::trace_span!(
 			"Reed–Solomon encode",
 			log_len = self.log_len(),
@@ -110,29 +118,33 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 			symbol_bits = F::N_BITS,
 		)
 		.entered();
-		if (code.len() << log_batch_size) < self.len() {
-			bail!(Error::NTT(NTTError::BufferTooSmall {
-				log_code_len: self.len(),
-			}));
-		}
-		if self.dim() % P::WIDTH != 0 {
-			bail!(Error::NTT(NTTError::PackingWidthMustDivideDimension));
+
+		// Repeat the message to fill the entire buffer.
+
+		// First, if the message is less than the packing width, we need to repeat it to fill one
+		// packed element.
+		if self.dim() + log_batch_size < P::LOG_WIDTH {
+			let repeated_values = code[0]
+				.into_iter()
+				.take(1 << (self.log_dim() + log_batch_size))
+				.cycle();
+			code[0] = P::from_scalars(repeated_values);
 		}
 
-		let msgs_len = (self.dim() / P::WIDTH) << log_batch_size;
-		for i in 1..(1 << self.log_inv_rate) {
-			code.copy_within(0..msgs_len, i * msgs_len);
+		// Repeat the packed message to fill the entire buffer.
+		let mut chunks =
+			code.chunks_mut(1 << (self.log_dim() + log_batch_size).saturating_sub(P::LOG_WIDTH));
+		let first_chunk = chunks.next().expect("code is not empty; checked above");
+		for chunk in chunks {
+			chunk.copy_from_slice(first_chunk);
 		}
 
 		let shape = NTTShape {
 			log_x: log_batch_size,
-			log_y: self.log_dim(),
+			log_y: self.log_len(),
 			..Default::default()
 		};
-		(0..(1 << self.log_inv_rate))
-			.into_par_iter()
-			.zip(code.par_chunks_exact_mut(msgs_len))
-			.try_for_each(|(i, data)| ntt.forward_transform(data, shape, i, 0))?;
+		ntt.forward_transform(code, shape, 0, self.log_inv_rate)?;
 		Ok(())
 	}
 

--- a/crates/core/src/reed_solomon/reed_solomon.rs
+++ b/crates/core/src/reed_solomon/reed_solomon.rs
@@ -132,7 +132,7 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 		(0..(1 << self.log_inv_rate))
 			.into_par_iter()
 			.zip(code.par_chunks_exact_mut(msgs_len))
-			.try_for_each(|(i, data)| ntt.forward_transform(data, shape, i))?;
+			.try_for_each(|(i, data)| ntt.forward_transform(data, shape, i, 0))?;
 		Ok(())
 	}
 

--- a/crates/ntt/benches/additive_ntt.rs
+++ b/crates/ntt/benches/additive_ntt.rs
@@ -136,7 +136,7 @@ fn bench_forward_transform(c: &mut Criterion) {
 				..Default::default()
 			};
 			group.bench_function(BenchmarkId::new(name, param), |b| {
-				b.iter(|| ntt.forward_transform(data, shape, 0));
+				b.iter(|| ntt.forward_transform(data, shape, 0, 0));
 			});
 		}
 	}
@@ -166,7 +166,7 @@ fn bench_inverse_transform(c: &mut Criterion) {
 				..Default::default()
 			};
 			group.bench_function(BenchmarkId::new(name, param), |b| {
-				b.iter(|| ntt.inverse_transform(data, shape, 0));
+				b.iter(|| ntt.inverse_transform(data, shape, 0, 0));
 			});
 		}
 	}

--- a/crates/ntt/benches/large_transform.rs
+++ b/crates/ntt/benches/large_transform.rs
@@ -35,7 +35,7 @@ fn bench_large_transform<F: TowerField, PE: PackedExtension<F>>(c: &mut Criterio
 				.unwrap()
 				.precompute_twiddles();
 			group.bench_function(BenchmarkId::new("single-thread/precompute", &params), |b| {
-				b.iter(|| ntt.forward_transform_ext(&mut data, shape, 0));
+				b.iter(|| ntt.forward_transform_ext(&mut data, shape, 0, 0));
 			});
 
 			let ntt = SingleThreadedNTT::<F>::new(log_dim)
@@ -43,7 +43,7 @@ fn bench_large_transform<F: TowerField, PE: PackedExtension<F>>(c: &mut Criterio
 				.precompute_twiddles()
 				.multithreaded();
 			group.bench_function(BenchmarkId::new("multithread/precompute", &params), |b| {
-				b.iter(|| ntt.forward_transform_ext(&mut data, shape, 0));
+				b.iter(|| ntt.forward_transform_ext(&mut data, shape, 0, 0));
 			});
 		}
 	}

--- a/crates/ntt/src/dynamic_dispatch.rs
+++ b/crates/ntt/src/dynamic_dispatch.rs
@@ -116,12 +116,17 @@ impl<F: BinaryField> AdditiveNTT<F> for DynamicDispatchNTT<F> {
 		data: &mut [P],
 		shape: NTTShape,
 		coset: u32,
+		skip_rounds: usize,
 	) -> Result<(), Error> {
 		match self {
-			Self::SingleThreaded(ntt) => ntt.forward_transform(data, shape, coset),
-			Self::SingleThreadedPrecompute(ntt) => ntt.forward_transform(data, shape, coset),
-			Self::MultiThreaded(ntt) => ntt.forward_transform(data, shape, coset),
-			Self::MultiThreadedPrecompute(ntt) => ntt.forward_transform(data, shape, coset),
+			Self::SingleThreaded(ntt) => ntt.forward_transform(data, shape, coset, skip_rounds),
+			Self::SingleThreadedPrecompute(ntt) => {
+				ntt.forward_transform(data, shape, coset, skip_rounds)
+			}
+			Self::MultiThreaded(ntt) => ntt.forward_transform(data, shape, coset, skip_rounds),
+			Self::MultiThreadedPrecompute(ntt) => {
+				ntt.forward_transform(data, shape, coset, skip_rounds)
+			}
 		}
 	}
 
@@ -130,12 +135,17 @@ impl<F: BinaryField> AdditiveNTT<F> for DynamicDispatchNTT<F> {
 		data: &mut [P],
 		shape: NTTShape,
 		coset: u32,
+		skip_rounds: usize,
 	) -> Result<(), Error> {
 		match self {
-			Self::SingleThreaded(ntt) => ntt.inverse_transform(data, shape, coset),
-			Self::SingleThreadedPrecompute(ntt) => ntt.inverse_transform(data, shape, coset),
-			Self::MultiThreaded(ntt) => ntt.inverse_transform(data, shape, coset),
-			Self::MultiThreadedPrecompute(ntt) => ntt.inverse_transform(data, shape, coset),
+			Self::SingleThreaded(ntt) => ntt.inverse_transform(data, shape, coset, skip_rounds),
+			Self::SingleThreadedPrecompute(ntt) => {
+				ntt.inverse_transform(data, shape, coset, skip_rounds)
+			}
+			Self::MultiThreaded(ntt) => ntt.inverse_transform(data, shape, coset, skip_rounds),
+			Self::MultiThreadedPrecompute(ntt) => {
+				ntt.inverse_transform(data, shape, coset, skip_rounds)
+			}
 		}
 	}
 }

--- a/crates/ntt/src/error.rs
+++ b/crates/ntt/src/error.rs
@@ -10,8 +10,6 @@ pub enum Error {
 	DomainTooSmall { log_required_domain_size: usize },
 	#[error("evaluation subspace must include the 1 element")]
 	DomainMustIncludeOne,
-	#[error("the packing width must divide the code dimension")]
-	PackingWidthMustDivideDimension,
 	#[error("the input length must be a power of two")]
 	PowerOfTwoLengthRequired,
 	#[error("the field extension degree must be a power of two")]

--- a/crates/ntt/src/error.rs
+++ b/crates/ntt/src/error.rs
@@ -20,6 +20,8 @@ pub enum Error {
 	StrideGreaterThanPackedWidth,
 	#[error("the batch size is greater than the number of elements")]
 	BatchTooLarge,
+	#[error("the skip_rounds parameter exceeds the total number of NTT rounds")]
+	SkipRoundsTooLarge,
 	#[error("odd interpolation length mismatch, expected to be exactly {expected_len}")]
 	OddInterpolateIncorrectLength { expected_len: usize },
 	#[error("math error: {0}")]

--- a/crates/ntt/src/odd_interpolate.rs
+++ b/crates/ntt/src/odd_interpolate.rs
@@ -75,7 +75,7 @@ impl<F: BinaryField> OddInterpolate<F> {
 			..Default::default()
 		};
 		for (i, chunk) in data.chunks_exact_mut(1 << ell).enumerate() {
-			ntt.inverse_transform(chunk, shape, i as u32)?;
+			ntt.inverse_transform(chunk, shape, i as u32, 0)?;
 		}
 
 		// Given M and a vector v, do the "strided product" M v. In more detail: we assume matrix is $d\times d$,
@@ -176,7 +176,7 @@ mod tests {
 					log_y: next_log_n,
 					..Default::default()
 				};
-				ntt.forward_transform(&mut ntt_evals, shape, 0).unwrap();
+				ntt.forward_transform(&mut ntt_evals, shape, 0, 0).unwrap();
 
 				let odd_interpolate = OddInterpolate::new(d, ell, &ntt.s_evals).unwrap();
 				odd_interpolate

--- a/crates/ntt/src/tests/ntt_tests.rs
+++ b/crates/ntt/src/tests/ntt_tests.rs
@@ -26,6 +26,7 @@ fn check_roundtrip_with_reference<F, P>(
 	data: &[P],
 	shape: NTTShape,
 	cosets: Range<u32>,
+	skip_rounds: usize,
 ) where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
@@ -49,18 +50,18 @@ fn check_roundtrip_with_reference<F, P>(
 	let mut data_copy_ref = orig_data.clone();
 
 	for coset in cosets {
-		ntt.forward_transform(&mut data_copy_impl, shape, coset, 0)
+		ntt.forward_transform(&mut data_copy_impl, shape, coset, skip_rounds)
 			.unwrap();
 		reference_ntt
-			.forward_transform(&mut data_copy_ref, shape, coset, 0)
+			.forward_transform(&mut data_copy_ref, shape, coset, skip_rounds)
 			.unwrap();
 
 		assert_eq!(&data_copy_impl, &data_copy_ref);
 
-		ntt.inverse_transform(&mut data_copy_impl, shape, coset, 0)
+		ntt.inverse_transform(&mut data_copy_impl, shape, coset, skip_rounds)
 			.unwrap();
 		reference_ntt
-			.inverse_transform(&mut data_copy_ref, shape, coset, 0)
+			.inverse_transform(&mut data_copy_ref, shape, coset, skip_rounds)
 			.unwrap();
 
 		assert_eq!(&orig_data, &data_copy_impl);
@@ -115,55 +116,62 @@ fn check_roundtrip_all_ntts<P>(
 		for log_n_b in log_n_b_range {
 			for log_n in 0..=log_n_b {
 				let log_batch = log_n_b - log_n;
-
 				let shape = NTTShape {
 					log_x: log_stride_batch,
 					log_y: log_n,
 					log_z: log_batch,
 				};
 
-				check_roundtrip_with_reference(
-					&simple_ntt,
-					&single_threaded_ntt,
-					&data,
-					shape,
-					cosets.clone(),
-				);
-				check_roundtrip_with_reference(
-					&simple_ntt,
-					&single_threaded_precompute_ntt,
-					&data,
-					shape,
-					cosets.clone(),
-				);
-				check_roundtrip_with_reference(
-					&simple_ntt,
-					&multithreaded_ntt_2,
-					&data,
-					shape,
-					cosets.clone(),
-				);
-				check_roundtrip_with_reference(
-					&simple_ntt,
-					&multithreaded_ntt_4,
-					&data,
-					shape,
-					cosets.clone(),
-				);
-				check_roundtrip_with_reference(
-					&simple_ntt,
-					&multithreaded_precompute_ntt_2,
-					&data,
-					shape,
-					cosets.clone(),
-				);
-				check_roundtrip_with_reference(
-					&simple_ntt,
-					&dynamic_dispatch_ntt,
-					&data,
-					shape,
-					cosets.clone(),
-				);
+				for skip_rounds in [0, log_n / 3, log_n / 2] {
+					check_roundtrip_with_reference(
+						&simple_ntt,
+						&single_threaded_ntt,
+						&data,
+						shape,
+						cosets.clone(),
+						skip_rounds,
+					);
+					check_roundtrip_with_reference(
+						&simple_ntt,
+						&single_threaded_precompute_ntt,
+						&data,
+						shape,
+						cosets.clone(),
+						skip_rounds,
+					);
+					check_roundtrip_with_reference(
+						&simple_ntt,
+						&multithreaded_ntt_2,
+						&data,
+						shape,
+						cosets.clone(),
+						skip_rounds,
+					);
+					check_roundtrip_with_reference(
+						&simple_ntt,
+						&multithreaded_ntt_4,
+						&data,
+						shape,
+						cosets.clone(),
+						skip_rounds,
+					);
+					check_roundtrip_with_reference(
+						&simple_ntt,
+						&multithreaded_precompute_ntt_2,
+						&data,
+						shape,
+						cosets.clone(),
+						skip_rounds,
+					);
+					check_roundtrip_with_reference(
+						&simple_ntt,
+						&dynamic_dispatch_ntt,
+						&data,
+						shape,
+						cosets.clone(),
+						skip_rounds,
+					);
+				}
 			}
 		}
 	}

--- a/crates/ntt/src/tests/ntt_tests.rs
+++ b/crates/ntt/src/tests/ntt_tests.rs
@@ -49,18 +49,18 @@ fn check_roundtrip_with_reference<F, P>(
 	let mut data_copy_ref = orig_data.clone();
 
 	for coset in cosets {
-		ntt.forward_transform(&mut data_copy_impl, shape, coset)
+		ntt.forward_transform(&mut data_copy_impl, shape, coset, 0)
 			.unwrap();
 		reference_ntt
-			.forward_transform(&mut data_copy_ref, shape, coset)
+			.forward_transform(&mut data_copy_ref, shape, coset, 0)
 			.unwrap();
 
 		assert_eq!(&data_copy_impl, &data_copy_ref);
 
-		ntt.inverse_transform(&mut data_copy_impl, shape, coset)
+		ntt.inverse_transform(&mut data_copy_impl, shape, coset, 0)
 			.unwrap();
 		reference_ntt
-			.inverse_transform(&mut data_copy_ref, shape, coset)
+			.inverse_transform(&mut data_copy_ref, shape, coset, 0)
 			.unwrap();
 
 		assert_eq!(&orig_data, &data_copy_impl);
@@ -234,16 +234,16 @@ fn check_packed_extension_roundtrip_with_reference<F, PE>(
 			..Default::default()
 		};
 
-		ntt.forward_transform_ext(data, shape, coset).unwrap();
+		ntt.forward_transform_ext(data, shape, coset, 0).unwrap();
 		reference_ntt
-			.forward_transform_ext(&mut data_copy_2, shape, coset)
+			.forward_transform_ext(&mut data_copy_2, shape, coset, 0)
 			.unwrap();
 
 		assert_eq!(data, &data_copy_2);
 
-		ntt.inverse_transform_ext(data, shape, coset).unwrap();
+		ntt.inverse_transform_ext(data, shape, coset, 0).unwrap();
 		reference_ntt
-			.inverse_transform_ext(&mut data_copy_2, shape, coset)
+			.inverse_transform_ext(&mut data_copy_2, shape, coset, 0)
 			.unwrap();
 
 		assert_eq!(data, &data_copy);
@@ -381,13 +381,13 @@ fn check_ntt_with_transform<P1, P2>(
 		};
 
 		ntt_binary
-			.forward_transform(&mut result_bin, shape, coset)
+			.forward_transform(&mut result_bin, shape, coset, 0)
 			.unwrap();
 		ntt_aes_1
-			.forward_transform(&mut result_aes, shape, coset)
+			.forward_transform(&mut result_aes, shape, coset, 0)
 			.unwrap();
 		ntt_aes_2
-			.forward_transform(&mut result_aes_cob, shape, coset)
+			.forward_transform(&mut result_aes_cob, shape, coset, 0)
 			.unwrap();
 
 		let result_bin_to_aes: Vec<_> = result_bin.iter().map(|x| P2::Scalar::from(*x)).collect();
@@ -396,13 +396,13 @@ fn check_ntt_with_transform<P1, P2>(
 		assert_ne!(result_bin_to_aes, result_aes);
 
 		ntt_binary
-			.inverse_transform(&mut result_bin, shape, coset)
+			.inverse_transform(&mut result_bin, shape, coset, 0)
 			.unwrap();
 		ntt_aes_1
-			.inverse_transform(&mut result_aes, shape, coset)
+			.inverse_transform(&mut result_aes, shape, coset, 0)
 			.unwrap();
 		ntt_aes_2
-			.inverse_transform(&mut result_aes_cob, shape, coset)
+			.inverse_transform(&mut result_aes_cob, shape, coset, 0)
 			.unwrap();
 
 		let result_bin_to_aes: Vec<_> = result_bin.iter().map(|x| P2::Scalar::from(*x)).collect();

--- a/crates/ntt/src/tests/reference.rs
+++ b/crates/ntt/src/tests/reference.rs
@@ -64,6 +64,7 @@ fn forward_transform_simple<F, FF>(
 	data: &mut impl RandomAccessSequenceMut<FF>,
 	coset: u32,
 	log_n: usize,
+	skip_rounds: usize,
 ) -> Result<(), Error>
 where
 	F: BinaryField,
@@ -76,7 +77,7 @@ where
 		});
 	}
 
-	for i in (0..log_n).rev() {
+	for i in (skip_rounds..log_n).rev() {
 		let s_evals_i = &s_evals[i];
 		for j in 0..1 << (log_n - 1 - i) {
 			let twiddle = s_evals_i.get((coset as usize) << (log_n - 1 - i) | j);
@@ -109,6 +110,7 @@ fn inverse_transform_simple<F, FF>(
 	data: &mut impl RandomAccessSequenceMut<FF>,
 	coset: u32,
 	log_n: usize,
+	skip_rounds: usize,
 ) -> Result<(), Error>
 where
 	F: BinaryField,
@@ -122,7 +124,7 @@ where
 	}
 
 	#[allow(clippy::needless_range_loop)]
-	for i in 0..log_n {
+	for i in skip_rounds..log_n {
 		let s_evals_i = &s_evals[i];
 		for j in 0..1 << (log_n - 1 - i) {
 			let twiddle = s_evals_i.get((coset as usize) << (log_n - 1 - i) | j);
@@ -170,6 +172,7 @@ impl<F: BinaryField, TA: TwiddleAccess<F>> AdditiveNTT<F> for SimpleAdditiveNTT<
 		data: &mut [P],
 		shape: NTTShape,
 		coset: u32,
+		skip_rounds: usize,
 	) -> Result<(), Error> {
 		let NTTShape {
 			log_x,
@@ -190,6 +193,7 @@ impl<F: BinaryField, TA: TwiddleAccess<F>> AdditiveNTT<F> for SimpleAdditiveNTT<
 					&mut batch,
 					coset,
 					log_y,
+					skip_rounds,
 				)?;
 			}
 		}
@@ -202,6 +206,7 @@ impl<F: BinaryField, TA: TwiddleAccess<F>> AdditiveNTT<F> for SimpleAdditiveNTT<
 		data: &mut [P],
 		shape: NTTShape,
 		coset: u32,
+		skip_rounds: usize,
 	) -> Result<(), Error> {
 		let NTTShape {
 			log_x,
@@ -222,6 +227,7 @@ impl<F: BinaryField, TA: TwiddleAccess<F>> AdditiveNTT<F> for SimpleAdditiveNTT<
 					&mut batch,
 					coset,
 					log_y,
+					skip_rounds,
 				)?;
 			}
 		}

--- a/crates/ntt/src/tests/reference.rs
+++ b/crates/ntt/src/tests/reference.rs
@@ -77,7 +77,7 @@ where
 		});
 	}
 
-	for i in (skip_rounds..log_n).rev() {
+	for i in (0..(log_n - skip_rounds)).rev() {
 		let s_evals_i = &s_evals[i];
 		for j in 0..1 << (log_n - 1 - i) {
 			let twiddle = s_evals_i.get((coset as usize) << (log_n - 1 - i) | j);
@@ -124,7 +124,7 @@ where
 	}
 
 	#[allow(clippy::needless_range_loop)]
-	for i in skip_rounds..log_n {
+	for i in 0..(log_n - skip_rounds) {
 		let s_evals_i = &s_evals[i];
 		for j in 0..1 << (log_n - 1 - i) {
 			let twiddle = s_evals_i.get((coset as usize) << (log_n - 1 - i) | j);


### PR DESCRIPTION
This generalizes the AdditiveNTT operation to be able to perform a truncated NTT, which skips rounds at the beginning of a forward transform and the end of an inverse transform. This is useful for Reed-Solomon encoding, where we want to run a large NTT but know apriori that the first few rounds have the effect of simply copying data.

This resolves a limitation of `ReedSolomonCode::encode`, which imposes a packing length restriction on the encoded message and also complicates the multithreading around the NTT with an additional Rayon loop. Now the multithreading is delegated to the AdditiveNTT implementation, which can size the matrix more appropriately.