### PR TITLE
Reduce CompositeMLE evaluations to MLEchecks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
           - runner: "c7a-2xlarge"
             name: "amd-portable"
             cmd: 'RUSTFLAGS="-C target-cpu=generic" ./scripts/run_tests_and_examples.sh'
-          - runner: "c7a-2xlarge"
+          - runner: "c7a-4xlarge"
             name: "amd-stable"
             cmd: 'RUSTFLAGS="-C target-cpu=native" CARGO_STABLE=true ./scripts/run_tests_and_examples.sh'
           - runner: "c7a-2xlarge"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
           - runner: "c7a-2xlarge"
             name: "amd-portable"
             cmd: 'RUSTFLAGS="-C target-cpu=generic" ./scripts/run_tests_and_examples.sh'
-          - runner: "c7a-4xlarge"
+          - runner: "c7a-2xlarge"
             name: "amd-stable"
             cmd: 'RUSTFLAGS="-C target-cpu=native" CARGO_STABLE=true ./scripts/run_tests_and_examples.sh'
           - runner: "c7a-2xlarge"

--- a/crates/core/src/protocols/evalcheck/error.rs
+++ b/crates/core/src/protocols/evalcheck/error.rs
@@ -41,6 +41,8 @@ pub enum VerificationError {
 	IncorrectCompositePolyEvaluation(String),
 	#[error("subproof type or shape does not match the claim")]
 	SubproofMismatch,
+	#[error("Advised MLECheck ConstraintSet positios must has the same eval_point")]
+	MLECheckConstraintSetPositionMismatch,
 	#[error("LinearCombination must contain an eval")]
 	MissingLinearCombinationEval,
 	#[error("The referenced duplicate claim is different from expected")]

--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -518,7 +518,7 @@ where
 					.position(|(ep, _)| *ep == eval_point)
 					.unwrap_or(self.new_mlechecks_constraints.len());
 
-				transcript.message().write(&(position as u32));
+				transcript.decommitment().write(&(position as u32));
 
 				add_composite_sumcheck_to_constraints(
 					position,

--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -515,9 +515,10 @@ where
 				let position = self
 					.new_mlechecks_constraints
 					.iter()
-					.position(|(ep, _)| *ep == eval_point);
+					.position(|(ep, _)| *ep == eval_point)
+					.unwrap_or(self.new_mlechecks_constraints.len());
 
-				transcript.message().write(&position);
+				transcript.message().write(&(position as u32));
 
 				add_composite_sumcheck_to_constraints(
 					position,

--- a/crates/core/src/protocols/evalcheck/subclaims.rs
+++ b/crates/core/src/protocols/evalcheck/subclaims.rs
@@ -152,8 +152,8 @@ pub fn add_composite_sumcheck_to_constraints<F: TowerField>(
 ) {
 	let oracle_ids = comp.inner().clone();
 
-	if let Some(constraint_builder) = constraint_builders.get_mut(position) {
-		constraint_builder.1.add_sumcheck(
+	if let Some((_, constraint_builder)) = constraint_builders.get_mut(position) {
+		constraint_builder.add_sumcheck(
 			oracle_ids,
 			<_ as CompositionPoly<F>>::expression(comp.c()),
 			eval,

--- a/crates/core/src/protocols/evalcheck/subclaims.rs
+++ b/crates/core/src/protocols/evalcheck/subclaims.rs
@@ -144,7 +144,7 @@ pub fn add_bivariate_sumcheck_to_constraints<F: TowerField>(
 }
 
 pub fn add_composite_sumcheck_to_constraints<F: TowerField>(
-	position: Option<usize>,
+	position: usize,
 	eval_point: &EvalPoint<F>,
 	constraint_builders: &mut Vec<(EvalPoint<F>, ConstraintSetBuilder<F>)>,
 	comp: &CompositeMLE<F>,
@@ -152,8 +152,8 @@ pub fn add_composite_sumcheck_to_constraints<F: TowerField>(
 ) {
 	let oracle_ids = comp.inner().clone();
 
-	if let Some(position) = position {
-		constraint_builders[position].1.add_sumcheck(
+	if let Some(constraint_builder) = constraint_builders.get_mut(position) {
+		constraint_builder.1.add_sumcheck(
 			oracle_ids,
 			<_ as CompositionPoly<F>>::expression(comp.c()),
 			eval,
@@ -162,7 +162,7 @@ pub fn add_composite_sumcheck_to_constraints<F: TowerField>(
 		let mut new_builder = ConstraintSetBuilder::new();
 		new_builder.add_sumcheck(oracle_ids, <_ as CompositionPoly<F>>::expression(comp.c()), eval);
 		constraint_builders.push((eval_point.clone(), new_builder));
-	};
+	}
 }
 
 /// Creates bivariate witness and adds them to the witness index, and add bivariate sumcheck

--- a/crates/core/src/protocols/evalcheck/subclaims.rs
+++ b/crates/core/src/protocols/evalcheck/subclaims.rs
@@ -9,22 +9,19 @@
 //!  * one multilin (the multiplier) is transparent (`shift_ind`, `eq_ind`, or tower basis)
 //!  * other multilin is a projection of one of the evalcheck claim multilins to its first variables
 
-use std::{
-	collections::{HashMap, HashSet},
-	iter,
-};
+use std::collections::HashSet;
 
 use binius_field::{ExtensionField, Field, PackedExtension, PackedField, TowerField};
 use binius_hal::{ComputationBackend, ComputationBackendExt};
 use binius_math::{
-	ArithCircuit, ArithExpr, CompositionPoly, EvaluationDomainFactory, EvaluationOrder,
-	MLEDirectAdapter, MultilinearExtension, MultilinearQuery,
+	ArithExpr, CompositionPoly, EvaluationDomainFactory, EvaluationOrder, MLEDirectAdapter,
+	MultilinearExtension, MultilinearQuery,
 };
 use binius_maybe_rayon::prelude::*;
 use binius_utils::bail;
 use tracing::instrument;
 
-use super::{error::Error, evalcheck::EvalcheckMultilinearClaim, EvalPointOracleIdMap};
+use super::{error::Error, evalcheck::EvalcheckMultilinearClaim, EvalPoint, EvalPointOracleIdMap};
 use crate::{
 	fiat_shamir::Challenger,
 	oracle::{
@@ -36,14 +33,15 @@ use crate::{
 		self,
 		prove::{
 			front_loaded,
-			oracles::{constraint_sets_sumcheck_provers_metas, SumcheckProversWithMetas},
+			oracles::{
+				constraint_sets_mlecheck_prover_meta, constraint_sets_sumcheck_provers_metas,
+				MLECheckProverWithMeta, SumcheckProversWithMetas,
+			},
 		},
 		Error as SumcheckError,
 	},
 	transcript::ProverTranscript,
-	transparent::{
-		eq_ind::EqIndPartialEval, shift_ind::ShiftIndPartialEval, tower_basis::TowerBasis,
-	},
+	transparent::{shift_ind::ShiftIndPartialEval, tower_basis::TowerBasis},
 	witness::{MultilinearExtensionIndex, MultilinearWitness},
 };
 
@@ -132,14 +130,6 @@ pub fn packed_sumcheck_meta<F: TowerField>(
 	})
 }
 
-pub fn composite_mlecheck_meta<F: TowerField>(
-	oracles: &mut MultilinearOracleSet<F>,
-	eval_point: &[F],
-) -> Result<CompositeMLECheckMeta, Error> {
-	let eq_ind_id = oracles.add_transparent(EqIndPartialEval::new(eval_point.to_vec()))?;
-	Ok(CompositeMLECheckMeta { eq_ind_id })
-}
-
 pub fn add_bivariate_sumcheck_to_constraints<F: TowerField>(
 	meta: &ProjectedBivariateMeta,
 	constraint_builders: &mut Vec<ConstraintSetBuilder<F>>,
@@ -154,21 +144,25 @@ pub fn add_bivariate_sumcheck_to_constraints<F: TowerField>(
 }
 
 pub fn add_composite_sumcheck_to_constraints<F: TowerField>(
-	meta: CompositeMLECheckMeta,
-	constraint_builders: &mut Vec<ConstraintSetBuilder<F>>,
+	position: Option<usize>,
+	eval_point: &EvalPoint<F>,
+	constraint_builders: &mut Vec<(EvalPoint<F>, ConstraintSetBuilder<F>)>,
 	comp: &CompositeMLE<F>,
 	eval: F,
 ) {
-	let n_vars = comp.n_vars();
-	let mut oracle_ids = comp.inner().clone();
-	oracle_ids.push(meta.eq_ind_id); // eq
+	let oracle_ids = comp.inner().clone();
 
-	// Var(comp.n_polys()) corresponds to the eq MLE
-	let expr = <_ as CompositionPoly<F>>::expression(comp.c()) * ArithCircuit::var(comp.n_polys());
-	if n_vars >= constraint_builders.len() {
-		constraint_builders.resize_with(n_vars + 1, || ConstraintSetBuilder::new());
-	}
-	constraint_builders[n_vars].add_sumcheck(oracle_ids, expr, eval);
+	if let Some(position) = position {
+		constraint_builders[position].1.add_sumcheck(
+			oracle_ids,
+			<_ as CompositionPoly<F>>::expression(comp.c()),
+			eval,
+		);
+	} else {
+		let mut new_builder = ConstraintSetBuilder::new();
+		new_builder.add_sumcheck(oracle_ids, <_ as CompositionPoly<F>>::expression(comp.c()), eval);
+		constraint_builders.push((eval_point.clone(), new_builder));
+	};
 }
 
 /// Creates bivariate witness and adds them to the witness index, and add bivariate sumcheck
@@ -205,11 +199,6 @@ where
 
 	add_bivariate_sumcheck_to_constraints(meta, constraint_builders, packed.log_degree(), eval);
 	Ok(())
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct CompositeMLECheckMeta {
-	pub eq_ind_id: OracleId,
 }
 
 /// Metadata about a sumcheck over a bivariate product of two multilinears.
@@ -350,53 +339,6 @@ where
 		.collect::<Result<Vec<Option<_>>, Error>>()
 }
 
-/// Each composite oracle induces a new eq oracle, for which we need to fill the witness
-pub fn fill_eq_witness_for_composites<F, P, Backend>(
-	metas: &[CompositeMLECheckMeta],
-	memoized_queries: &mut MemoizedData<P, Backend>,
-	composite_mle_claims: &[EvalcheckMultilinearClaim<F>],
-	witness_index: &mut MultilinearExtensionIndex<P>,
-	backend: &Backend,
-) -> Result<(), Error>
-where
-	P: PackedField<Scalar = F>,
-	F: TowerField,
-	Backend: ComputationBackend,
-{
-	let dedup_eval_points = composite_mle_claims
-		.iter()
-		.map(|claim| claim.eval_point.as_ref())
-		.collect::<HashSet<_>>();
-
-	memoized_queries.memoize_query_par(dedup_eval_points.iter().copied(), backend)?;
-
-	let eq_indicators = dedup_eval_points
-		.into_iter()
-		.map(|eval_point| {
-			let mle = MLEDirectAdapter::from(MultilinearExtension::new(
-				eval_point.len(),
-				memoized_queries
-					.full_query_readonly(eval_point)
-					.expect("computed above")
-					.expansion()
-					.to_vec(),
-			)?)
-			.upcast_arc_dyn();
-			Ok((eval_point, mle))
-		})
-		.collect::<Result<HashMap<_, _>, Error>>()?;
-
-	for (claim, meta) in iter::zip(composite_mle_claims, metas) {
-		let eq_ind = eq_indicators
-			.get(claim.eval_point.as_ref())
-			.expect("was added above");
-
-		witness_index.update_multilin_poly(vec![(meta.eq_ind_id, eq_ind.clone())])?;
-	}
-
-	Ok(())
-}
-
 /// Struct for memoizing tensor expansions of evaluation points and partial evaluations of
 /// multilinears
 #[allow(clippy::type_complexity)]
@@ -418,7 +360,7 @@ impl<'a, P: PackedField, Backend: ComputationBackend> MemoizedData<'a, P, Backen
 		&mut self,
 		eval_point: &[P::Scalar],
 		backend: &Backend,
-	) -> Result<&MultilinearQuery<P, Backend::Vec<P>>, Error> {
+	) -> Result<&MultilinearQuery<P, Backend::Vec<P>>, binius_hal::Error> {
 		if let Some(index) = self
 			.query
 			.iter()
@@ -552,8 +494,49 @@ where
 	Ok(evalcheck_claims)
 }
 
-#[derive(Clone)]
-pub enum SumcheckClaims<F: Field> {
-	Projected(EvalcheckMultilinearClaim<F>),
-	Composite(EvalcheckMultilinearClaim<F>),
+#[allow(clippy::too_many_arguments)]
+pub fn prove_mlecheck_with_switchover<'a, F, P, DomainField, Transcript, Backend>(
+	witness: &MultilinearExtensionIndex<P>,
+	constraint_set: ConstraintSet<F>,
+	eq_ind_challenges: EvalPoint<F>,
+	memoized_data: &mut MemoizedData<'a, P, Backend>,
+	transcript: &mut ProverTranscript<Transcript>,
+	switchover_fn: impl Fn(usize) -> usize + 'static,
+	domain_factory: impl EvaluationDomainFactory<DomainField>,
+	backend: &Backend,
+) -> Result<SumcheckProofEvalcheckClaims<F>, SumcheckError>
+where
+	P: PackedField<Scalar = F>
+		+ PackedExtension<F, PackedSubfield = P>
+		+ PackedExtension<DomainField>,
+	F: TowerField + ExtensionField<DomainField>,
+	DomainField: Field,
+	Transcript: Challenger,
+	Backend: ComputationBackend,
+{
+	let MLECheckProverWithMeta { prover, meta } = constraint_sets_mlecheck_prover_meta(
+		EvaluationOrder::HighToLow,
+		constraint_set,
+		eq_ind_challenges,
+		memoized_data,
+		witness,
+		domain_factory,
+		&switchover_fn,
+		backend,
+	)?;
+
+	let batch_prover = front_loaded::BatchProver::new(vec![prover], transcript)?;
+
+	let mut sumcheck_output = batch_prover.run(transcript)?;
+
+	// Reverse challenges since folding high-to-low
+	sumcheck_output.challenges.reverse();
+
+	// extract eq_ind_eval
+	sumcheck_output.multilinear_evals[0].pop();
+
+	let evalcheck_claims =
+		sumcheck::make_eval_claims(EvaluationOrder::HighToLow, vec![meta], sumcheck_output)?;
+
+	Ok(evalcheck_claims)
 }

--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -266,7 +266,7 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 				)?;
 			}
 			MultilinearPolyVariant::Composite(composite) => {
-				let position = transcript.message().read::<u32>()? as usize;
+				let position = transcript.decommitment().read::<u32>()? as usize;
 
 				if let Some((constraints_eval_point, _)) =
 					self.new_mlechecks_constraints.get(position)

--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -266,11 +266,11 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 				)?;
 			}
 			MultilinearPolyVariant::Composite(composite) => {
-				let position = transcript.message().read()?;
+				let position = transcript.message().read::<u32>()? as usize;
 
-				if let Some(position) = position {
-					let (constraints_eval_point, _) = &self.new_mlechecks_constraints[position];
-
+				if let Some((constraints_eval_point, _)) =
+					self.new_mlechecks_constraints.get(position)
+				{
 					if *constraints_eval_point != eval_point {
 						return Err(VerificationError::MLECheckConstraintSetPositionMismatch.into());
 					}

--- a/crates/core/src/protocols/greedy_evalcheck/error.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/error.rs
@@ -22,4 +22,6 @@ pub enum Error {
 	Sumcheck(#[from] sumcheck::Error),
 	#[error("transcript error: {0}")]
 	TranscriptError(#[from] crate::transcript::Error),
+	#[error("oracle error: {0}")]
+	Oracle(#[from] crate::oracle::Error),
 }

--- a/crates/core/src/protocols/greedy_evalcheck/prove.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/prove.rs
@@ -9,8 +9,10 @@ use crate::{
 	fiat_shamir::Challenger,
 	oracle::MultilinearOracleSet,
 	protocols::evalcheck::{
-		subclaims::{prove_bivariate_sumchecks_with_switchover, MemoizedData},
-		EvalcheckMultilinearClaim, EvalcheckProver,
+		subclaims::{
+			prove_bivariate_sumchecks_with_switchover, prove_mlecheck_with_switchover, MemoizedData,
+		},
+		ConstraintSetEqIndPoint, EvalcheckMultilinearClaim, EvalcheckProver,
 	},
 	transcript::ProverTranscript,
 	witness::MultilinearExtensionIndex,
@@ -62,30 +64,80 @@ where
 			perfetto_category = "phase.sub"
 		)
 		.entered();
-		let new_sumchecks = evalcheck_prover.take_new_sumchecks_constraints().unwrap();
-		if new_sumchecks.is_empty() {
-			break;
+
+		let new_bivariate_sumchecks =
+			evalcheck_prover.take_new_bivariate_sumchecks_constraints()?;
+
+		let new_mlechecks = evalcheck_prover.take_new_mlechecks_constraints()?;
+
+		let mut new_evalcheck_claims =
+			Vec::with_capacity(new_bivariate_sumchecks.len() + new_mlechecks.len());
+
+		if !new_bivariate_sumchecks.is_empty() {
+			// Reduce the new sumcheck claims for virtual polynomial openings to new evalcheck
+			// claims.
+			let dimensions_data =
+				RegularSumcheckDimensionsData::new(new_bivariate_sumchecks.iter());
+			let evalcheck_round_mle_fold_high_span = tracing::debug_span!(
+				"[task] (Evalcheck) Regular Sumcheck (Small)",
+				phase = "evalcheck",
+				perfetto_category = "task.main",
+				dimensions_data = ?dimensions_data,
+			)
+			.entered();
+			let evalcheck_claims =
+				prove_bivariate_sumchecks_with_switchover::<_, _, DomainField, _, _>(
+					evalcheck_prover.witness_index,
+					new_bivariate_sumchecks,
+					transcript,
+					switchover_fn.clone(),
+					domain_factory.clone(),
+					backend,
+				)?;
+
+			new_evalcheck_claims.extend(evalcheck_claims);
+			drop(evalcheck_round_mle_fold_high_span);
 		}
 
-		// Reduce the new sumcheck claims for virtual polynomial openings to new evalcheck claims.
-		let dimensions_data = RegularSumcheckDimensionsData::new(new_sumchecks.iter());
-		let evalcheck_round_mle_fold_high_span = tracing::debug_span!(
-			"[task] (Evalcheck) Regular Sumcheck (Small)",
-			phase = "evalcheck",
-			perfetto_category = "task.main",
-			?dimensions_data,
-		)
-		.entered();
-		let new_evalcheck_claims =
-			prove_bivariate_sumchecks_with_switchover::<_, _, DomainField, _, _>(
-				evalcheck_prover.witness_index,
-				new_sumchecks,
-				transcript,
-				switchover_fn.clone(),
-				domain_factory.clone(),
-				backend,
-			)?;
-		drop(evalcheck_round_mle_fold_high_span);
+		if !new_mlechecks.is_empty() {
+			// Reduce the new mle claims for virtual polynomial openings to new evalcheck claims.
+			let dimensions_data = RegularSumcheckDimensionsData::new(
+				new_mlechecks
+					.iter()
+					.map(|new_mlecheck| &new_mlecheck.constraint_set),
+			);
+			let evalcheck_round_mle_fold_high_span = tracing::debug_span!(
+				"[task] (Evalcheck) MLE check",
+				phase = "evalcheck",
+				perfetto_category = "task.main",
+				dimensions_data = ?dimensions_data,
+			)
+			.entered();
+
+			for ConstraintSetEqIndPoint {
+				eq_ind_challenges,
+				constraint_set,
+			} in new_mlechecks
+			{
+				let evalcheck_claims = prove_mlecheck_with_switchover::<_, _, DomainField, _, _>(
+					evalcheck_prover.witness_index,
+					constraint_set,
+					eq_ind_challenges,
+					&mut evalcheck_prover.memoized_data,
+					transcript,
+					switchover_fn.clone(),
+					domain_factory.clone(),
+					backend,
+				)?;
+				new_evalcheck_claims.extend(evalcheck_claims);
+			}
+
+			drop(evalcheck_round_mle_fold_high_span);
+		}
+
+		if new_evalcheck_claims.is_empty() {
+			break;
+		}
 
 		evalcheck_prover.prove(new_evalcheck_claims, transcript)?;
 	}

--- a/crates/core/src/protocols/greedy_evalcheck/verify.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/verify.rs
@@ -3,14 +3,19 @@
 use binius_field::TowerField;
 use binius_math::EvaluationOrder;
 use binius_utils::bail;
+use itertools::izip;
 
 use super::error::Error;
 use crate::{
 	fiat_shamir::Challenger,
 	oracle::MultilinearOracleSet,
 	protocols::{
-		evalcheck::{EvalcheckMultilinearClaim, EvalcheckVerifier},
-		sumcheck::{self, constraint_set_sumcheck_claims, front_loaded, SumcheckClaimsWithMeta},
+		evalcheck::{ConstraintSetsEqIndPoints, EvalcheckMultilinearClaim, EvalcheckVerifier},
+		sumcheck::{
+			self, constraint_set_mlecheck_claims, constraint_set_sumcheck_claims,
+			eq_ind::{self, reduce_to_regular_sumchecks, ClaimsSortingOrder},
+			front_loaded, MLEcheckClaimsWithMeta, SumcheckClaimsWithMeta,
+		},
 	},
 	transcript::VerifierTranscript,
 };
@@ -30,28 +35,79 @@ where
 	evalcheck_verifier.verify(claims, transcript)?;
 
 	loop {
-		let SumcheckClaimsWithMeta { claims, metas } = constraint_set_sumcheck_claims(
-			evalcheck_verifier.take_new_sumcheck_constraints().unwrap(),
-		)?;
+		let mut new_evalcheck_claims = Vec::new();
 
-		if claims.is_empty() {
-			break;
+		let SumcheckClaimsWithMeta {
+			claims: new_bivariate_sumchecks_claims,
+			metas,
+		} = constraint_set_sumcheck_claims(evalcheck_verifier.take_new_sumcheck_constraints()?)?;
+
+		if !new_bivariate_sumchecks_claims.is_empty() {
+			// Reduce the new sumcheck claims for virtual polynomial openings to new evalcheck
+			// claims.
+			let batch_sumcheck_verifier =
+				front_loaded::BatchVerifier::new(&new_bivariate_sumchecks_claims, transcript)?;
+			let mut sumcheck_output = batch_sumcheck_verifier.run(transcript)?;
+
+			// Reverse challenges since foldling high-to-low
+			sumcheck_output.challenges.reverse();
+
+			let evalcheck_claims =
+				sumcheck::make_eval_claims(EvaluationOrder::HighToLow, metas, sumcheck_output)?;
+			new_evalcheck_claims.extend(evalcheck_claims)
 		}
 
-		// Reduce the new sumcheck claims for virtual polynomial openings to new evalcheck claims.
-		let batch_sumcheck_verifier = front_loaded::BatchVerifier::new(&claims, transcript)?;
-		let mut sumcheck_output = batch_sumcheck_verifier.run(transcript)?;
+		let ConstraintSetsEqIndPoints {
+			eq_ind_challenges,
+			constraint_sets,
+		} = evalcheck_verifier.take_new_mlechecks_constraints()?;
 
-		// Reverse challenges since foldling high-to-low
-		sumcheck_output.challenges.reverse();
+		let MLEcheckClaimsWithMeta {
+			claims: mlecheck_claims,
+			metas,
+		} = constraint_set_mlecheck_claims(constraint_sets)?;
 
-		let new_evalcheck_claims =
-			sumcheck::make_eval_claims(EvaluationOrder::HighToLow, metas, sumcheck_output)?;
+		if !mlecheck_claims.is_empty() {
+			// Reduce the new mlecheck claims for virtual polynomial openings to new evalcheck
+			// claims.
+			for (eq_ind_challenges, mlecheck_claim, meta) in
+				izip!(eq_ind_challenges, mlecheck_claims, metas)
+			{
+				let mlecheck_claim = vec![mlecheck_claim];
+
+				let batch_sumcheck_verifier = front_loaded::BatchVerifier::new(
+					&reduce_to_regular_sumchecks(&mlecheck_claim)?,
+					transcript,
+				)?;
+				let mut sumcheck_output = batch_sumcheck_verifier.run(transcript)?;
+
+				// Reverse challenges since foldling high-to-low
+				sumcheck_output.challenges.reverse();
+
+				let eq_ind_output = eq_ind::verify_sumcheck_outputs(
+					ClaimsSortingOrder::AscendingVars,
+					&mlecheck_claim,
+					&eq_ind_challenges,
+					sumcheck_output,
+				)?;
+
+				let evalcheck_claims = sumcheck::make_eval_claims(
+					EvaluationOrder::HighToLow,
+					vec![meta],
+					eq_ind_output,
+				)?;
+				new_evalcheck_claims.extend(evalcheck_claims)
+			}
+		}
+
+		if new_evalcheck_claims.is_empty() {
+			break;
+		}
 
 		evalcheck_verifier.verify(new_evalcheck_claims, transcript)?;
 	}
 
-	let new_sumchecks = evalcheck_verifier.take_new_sumcheck_constraints().unwrap();
+	let new_sumchecks = evalcheck_verifier.take_new_sumcheck_constraints()?;
 	if !new_sumchecks.is_empty() {
 		bail!(Error::MissingVirtualOpeningProof);
 	}

--- a/crates/core/src/protocols/greedy_evalcheck/verify.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/verify.rs
@@ -49,7 +49,7 @@ where
 				front_loaded::BatchVerifier::new(&new_bivariate_sumchecks_claims, transcript)?;
 			let mut sumcheck_output = batch_sumcheck_verifier.run(transcript)?;
 
-			// Reverse challenges since foldling high-to-low
+			// Reverse challenges since folding high-to-low
 			sumcheck_output.challenges.reverse();
 
 			let evalcheck_claims =

--- a/crates/core/src/protocols/sumcheck/oracles.rs
+++ b/crates/core/src/protocols/sumcheck/oracles.rs
@@ -148,7 +148,6 @@ pub fn make_eval_claims<F: TowerField>(
 	let mut evalcheck_claims = Vec::new();
 	for (meta, prover_evals) in iter::zip(metas, batch_sumcheck_output.multilinear_evals) {
 		if meta.oracle_ids.len() != prover_evals.len() {
-			println!("!!!!!!!!!!!!!!!!! {} {}", meta.oracle_ids.len(), prover_evals.len());
 			bail!(Error::ClaimProofMismatch);
 		}
 

--- a/crates/core/src/protocols/sumcheck/prove/oracles.rs
+++ b/crates/core/src/protocols/sumcheck/prove/oracles.rs
@@ -52,7 +52,7 @@ pub type OracleMLECheckProver<'a, FDomain, P, Backend> = EqIndSumcheckProver<
 	Backend,
 >;
 
-// Construct zerocheck prover from the constraint set. Fails when constraint set contains regular
+/// Construct zerocheck prover from the constraint set. Fails when constraint set contains regular
 /// sumchecks.
 pub fn constraint_set_zerocheck_prover<'a, P, F, FBase, FDomain, DomainFactory, Backend>(
 	constraints: Vec<Constraint<P::Scalar>>,
@@ -108,21 +108,21 @@ where
 
 /// Construct regular sumcheck prover from the constraint set. Fails when constraint set contains
 /// zerochecks.
-pub fn constraint_set_sumcheck_prover<'a, FW, PW, FDomain, Backend>(
+pub fn constraint_set_sumcheck_prover<'a, F, P, FDomain, Backend>(
 	evaluation_order: EvaluationOrder,
-	constraint_set: ConstraintSet<FW>,
-	witness: &MultilinearExtensionIndex<'a, PW>,
+	constraint_set: ConstraintSet<F>,
+	witness: &MultilinearExtensionIndex<'a, P>,
 	evaluation_domain_factory: impl EvaluationDomainFactory<FDomain>,
 	switchover_fn: impl Fn(usize) -> usize + Clone,
 	backend: &'a Backend,
-) -> Result<OracleSumcheckProver<'a, FDomain, PW, Backend>, Error>
+) -> Result<OracleSumcheckProver<'a, FDomain, P, Backend>, Error>
 where
-	PW: PackedField<Scalar = FW> + PackedExtension<FDomain>,
-	FW: TowerField + ExtensionField<FDomain>,
+	P: PackedField<Scalar = F> + PackedExtension<FDomain>,
+	F: TowerField + ExtensionField<FDomain>,
 	FDomain: Field,
 	Backend: ComputationBackend,
 {
-	let (constraints, multilinears) = split_constraint_set::<FW, PW>(constraint_set, witness)?;
+	let (constraints, multilinears) = split_constraint_set::<F, P>(constraint_set, witness)?;
 
 	let mut sums = Vec::new();
 
@@ -153,26 +153,26 @@ where
 	Ok(prover)
 }
 
-/// Construct regular sumcheck prover from the constraint set. Fails when constraint set contains
+/// Construct mlecheck prover from the constraint set. Fails when constraint set contains
 /// zerochecks.
 #[allow(clippy::too_many_arguments)]
-pub fn constraint_set_mlecheck_prover<'a, 'b, FW, PW, FDomain, Backend>(
+pub fn constraint_set_mlecheck_prover<'a, 'b, F, P, FDomain, Backend>(
 	evaluation_order: EvaluationOrder,
-	constraint_set: ConstraintSet<FW>,
-	eq_ind_challenges: &[FW],
-	memoized_data: &mut MemoizedData<'b, PW, Backend>,
-	witness: &MultilinearExtensionIndex<'a, PW>,
+	constraint_set: ConstraintSet<F>,
+	eq_ind_challenges: &[F],
+	memoized_data: &mut MemoizedData<'b, P, Backend>,
+	witness: &MultilinearExtensionIndex<'a, P>,
 	evaluation_domain_factory: impl EvaluationDomainFactory<FDomain>,
 	switchover_fn: impl Fn(usize) -> usize + Clone,
 	backend: &'a Backend,
-) -> Result<OracleMLECheckProver<'a, FDomain, PW, Backend>, Error>
+) -> Result<OracleMLECheckProver<'a, FDomain, P, Backend>, Error>
 where
-	PW: PackedField<Scalar = FW> + PackedExtension<FDomain>,
-	FW: TowerField + ExtensionField<FDomain>,
+	P: PackedField<Scalar = F> + PackedExtension<FDomain>,
+	F: TowerField + ExtensionField<FDomain>,
 	FDomain: Field,
 	Backend: ComputationBackend,
 {
-	let (constraints, multilinears) = split_constraint_set::<FW, PW>(constraint_set, witness)?;
+	let (constraints, multilinears) = split_constraint_set::<F, P>(constraint_set, witness)?;
 
 	let mut sums = Vec::new();
 
@@ -210,17 +210,17 @@ where
 	Ok(prover)
 }
 
-type ConstraintsAndMultilinears<'a, F, PW> = (Vec<Constraint<F>>, Vec<MultilinearWitness<'a, PW>>);
+type ConstraintsAndMultilinears<'a, F, P> = (Vec<Constraint<F>>, Vec<MultilinearWitness<'a, P>>);
 
 #[allow(clippy::type_complexity)]
-pub fn split_constraint_set<'a, F, PW>(
+pub fn split_constraint_set<'a, F, P>(
 	constraint_set: ConstraintSet<F>,
-	witness: &MultilinearExtensionIndex<'a, PW>,
-) -> Result<ConstraintsAndMultilinears<'a, F, PW>, Error>
+	witness: &MultilinearExtensionIndex<'a, P>,
+) -> Result<ConstraintsAndMultilinears<'a, F, P>, Error>
 where
 	F: Field,
-	PW: PackedField,
-	PW::Scalar: ExtensionField<F>,
+	P: PackedField,
+	P::Scalar: ExtensionField<F>,
 {
 	let ConstraintSet {
 		oracle_ids,
@@ -243,28 +243,28 @@ where
 	Ok((constraints, multilinears))
 }
 
-pub struct SumcheckProversWithMetas<'a, PW, FDomain, Backend>
+pub struct SumcheckProversWithMetas<'a, P, FDomain, Backend>
 where
-	PW: PackedField,
+	P: PackedField,
 	FDomain: Field,
 	Backend: ComputationBackend,
 {
-	pub provers: Vec<OracleSumcheckProver<'a, FDomain, PW, Backend>>,
+	pub provers: Vec<OracleSumcheckProver<'a, FDomain, P, Backend>>,
 	pub metas: Vec<OracleClaimMeta>,
 }
 
 /// Constructs sumcheck provers and metas from the vector of [`ConstraintSet`]
-pub fn constraint_sets_sumcheck_provers_metas<'a, PW, FDomain, Backend>(
+pub fn constraint_sets_sumcheck_provers_metas<'a, P, FDomain, Backend>(
 	evaluation_order: EvaluationOrder,
-	constraint_sets: Vec<ConstraintSet<PW::Scalar>>,
-	witness: &MultilinearExtensionIndex<'a, PW>,
+	constraint_sets: Vec<ConstraintSet<P::Scalar>>,
+	witness: &MultilinearExtensionIndex<'a, P>,
 	evaluation_domain_factory: impl EvaluationDomainFactory<FDomain>,
 	switchover_fn: impl Fn(usize) -> usize,
 	backend: &'a Backend,
-) -> Result<SumcheckProversWithMetas<'a, PW, FDomain, Backend>, Error>
+) -> Result<SumcheckProversWithMetas<'a, P, FDomain, Backend>, Error>
 where
-	PW: PackedExtension<FDomain>,
-	PW::Scalar: TowerField + ExtensionField<FDomain>,
+	P: PackedExtension<FDomain>,
+	P::Scalar: TowerField + ExtensionField<FDomain>,
 	FDomain: Field,
 	Backend: ComputationBackend,
 {
@@ -287,31 +287,31 @@ where
 	Ok(SumcheckProversWithMetas { provers, metas })
 }
 
-pub struct MLECheckProverWithMeta<'a, PW, FDomain, Backend>
+pub struct MLECheckProverWithMeta<'a, P, FDomain, Backend>
 where
-	PW: PackedField,
+	P: PackedField,
 	FDomain: Field,
 	Backend: ComputationBackend,
 {
-	pub prover: OracleMLECheckProver<'a, FDomain, PW, Backend>,
+	pub prover: OracleMLECheckProver<'a, FDomain, P, Backend>,
 	pub meta: OracleClaimMeta,
 }
 
 /// Constructs sumcheck provers and metas from the vector of [`ConstraintSet`]
 #[allow(clippy::too_many_arguments)]
-pub fn constraint_sets_mlecheck_prover_meta<'a, 'b, PW, FDomain, Backend>(
+pub fn constraint_sets_mlecheck_prover_meta<'a, 'b, P, FDomain, Backend>(
 	evaluation_order: EvaluationOrder,
-	constraint_set: ConstraintSet<PW::Scalar>,
-	eq_ind_challenges: EvalPoint<PW::Scalar>,
-	memoized_data: &mut MemoizedData<'b, PW, Backend>,
-	witness: &MultilinearExtensionIndex<'a, PW>,
+	constraint_set: ConstraintSet<P::Scalar>,
+	eq_ind_challenges: EvalPoint<P::Scalar>,
+	memoized_data: &mut MemoizedData<'b, P, Backend>,
+	witness: &MultilinearExtensionIndex<'a, P>,
 	evaluation_domain_factory: impl EvaluationDomainFactory<FDomain>,
 	switchover_fn: impl Fn(usize) -> usize,
 	backend: &'a Backend,
-) -> Result<MLECheckProverWithMeta<'a, PW, FDomain, Backend>, Error>
+) -> Result<MLECheckProverWithMeta<'a, P, FDomain, Backend>, Error>
 where
-	PW: PackedExtension<FDomain>,
-	PW::Scalar: TowerField + ExtensionField<FDomain>,
+	P: PackedExtension<FDomain>,
+	P::Scalar: TowerField + ExtensionField<FDomain>,
 	FDomain: Field,
 	Backend: ComputationBackend,
 {


### PR DESCRIPTION
This PR collects CompositeMLE constraints separately by eval_point and builds an EqIndSumcheckProver instead of a RegularSumcheckProver.
This allows us to avoid repeated evaluations of eq_ind and is generally more efficient.

Also, to avoid searching for the position by eval_point, the prover provides it as an advice to the verifier.