### PR TITLE
[core] FRI fold include num_challenges in dimensions trace

### DIFF
--- a/crates/core/src/protocols/fri/logging.rs
+++ b/crates/core/src/protocols/fri/logging.rs
@@ -66,13 +66,15 @@ impl_debug_with_json!(MerkleTreeDimensionData);
 pub(super) struct FRIFoldData {
 	log_len: usize,
 	log_batch_size: usize,
+	num_challenges: usize,
 }
 
 impl FRIFoldData {
-	pub(super) fn new(log_len: usize, log_batch_size: usize) -> Self {
+	pub(super) fn new(log_len: usize, log_batch_size: usize, num_challenges: usize) -> Self {
 		Self {
 			log_len,
 			log_batch_size,
+			num_challenges,
 		}
 	}
 

--- a/crates/core/src/protocols/fri/prove.rs
+++ b/crates/core/src/protocols/fri/prove.rs
@@ -337,8 +337,16 @@ where
 		}
 
 		let dimensions_data = match self.round_committed.last() {
-			Some((codeword, _)) => FRIFoldData::new(log2_strict_usize(codeword.len()), 0),
-			None => FRIFoldData::new(self.params.rs_code().log_len(), self.params.log_batch_size()),
+			Some((codeword, _)) => FRIFoldData::new(
+				log2_strict_usize(codeword.len()),
+				0,
+				self.unprocessed_challenges.len(),
+			),
+			None => FRIFoldData::new(
+				self.params.rs_code().log_len(),
+				self.params.log_batch_size(),
+				self.unprocessed_challenges.len(),
+			),
 		};
 
 		let fri_fold_span = tracing::debug_span!(


### PR DESCRIPTION
The hardware-accelerated fri_fold implementation's architecture depends on the relationship between the typical number of challenges and data length. Track the number of challenges per commitment round.

Sample output:
```
cargo run --example keccak
...
   │  └── [step] FRI Fold Rounds [ 1.08s | 2.82% ] { phase = piop_compiler, round = 3, perfetto_category = phase.sub, dimensions_data = {"round":3,"log_batch_size":4,"codeword_len":524288} }
   │     ├>incremental_proof_size: 32
   │     ├── [task] FRI Fold [ 864.31ms | 2.27% ] { phase = piop_compiler, perfetto_category = task.main, dimensions_data = {"log_len":15,"log_batch_size":4,"num_challenges":4} }
   │     │  └── fold_interleaved [ 864.28ms | 2.27% ]
   │     └── [...] [ 212.51ms | 0.56% ]
```

SYS-210