### PR TITLE
Serialize evalcheck proofs using u32s instead of bytes and usize

### DIFF
--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -429,7 +429,7 @@ where
 		if let Some(claim_id) = claim_id {
 			serialize_evalcheck_proof(
 				&mut transcript.message(),
-				&EvalcheckHint::DuplicateClaim(*claim_id),
+				&EvalcheckHint::DuplicateClaim(*claim_id as u32),
 			);
 			return Ok(());
 		}
@@ -519,7 +519,7 @@ where
 					if let Some(claim_index) = self.claim_to_index.get(suboracle_id, &eval_point) {
 						serialize_evalcheck_proof(
 							&mut transcript.message(),
-							&EvalcheckHint::DuplicateClaim(*claim_index),
+							&EvalcheckHint::DuplicateClaim(*claim_index as u32),
 						);
 					} else {
 						serialize_evalcheck_proof(

--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -101,7 +101,7 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 		// If the proof is a duplicate claim, we need to check if the claim is already in the round
 		// claims, which have been verified.
 		if let EvalcheckHint::DuplicateClaim(index) = evalcheck_proof {
-			if let Some(expected_claim) = self.round_claims.get(index) {
+			if let Some(expected_claim) = self.round_claims.get(index as usize) {
 				if *expected_claim == evalcheck_claim {
 					return Ok(());
 				}
@@ -264,6 +264,7 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 		let subproof = deserialize_evalcheck_proof(&mut transcript.message())?;
 		match subproof {
 			EvalcheckHint::DuplicateClaim(index) => {
+				let index = index as usize;
 				if self.round_claims[index].id != oracle_id
 					|| self.round_claims[index].eval_point != eval_point
 				{


### PR DESCRIPTION
The recursive verifier works with words, not bytes or usize.
Currently evalcheck proofs are encoded using bytes and usize. Either we
- switch binius to encoding using words
- post-process binius proofs to convert from bytes and usize to words.

I propose the former, and this is the PR. The latter seems unnecessarily complex.