### PR TITLE
[m3] log_capacity does not depend on &self

### DIFF
--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -23,7 +23,7 @@ use super::{
 	column::{ColumnDef, ColumnInfo},
 	error::Error,
 	statement::Statement,
-	table::TablePartition,
+	table::{self, TablePartition},
 	types::B128,
 	witness::WitnessIndex,
 	Table, TableBuilder, TableSizeSpec, ZeroConstraint,
@@ -190,7 +190,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 							size: count,
 						});
 					}
-					if count != 1 << table.log_capacity(count) {
+					if count != 1 << table::log_capacity(count) {
 						panic!(
 						    "Tables with required power-of-two size currently cannot have capacity \
 						exceeding their count. This is because the flushes do not have automatic \
@@ -222,7 +222,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 			}
 
 			// Add multilinear oracles for all table columns.
-			let log_capacity = table.log_capacity(count);
+			let log_capacity = table::log_capacity(count);
 			for column_info in table.columns.iter() {
 				let n_vars = log_capacity + column_info.shape.log_values_per_row;
 				let oracle_id = add_oracle_for_column(

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -657,17 +657,6 @@ impl<F: TowerField> Table<F> {
 		self.id
 	}
 
-	/// Returns the binary logarithm of the table capacity required to accommodate the given number
-	/// of rows.
-	///
-	/// The table capacity must be a power of two (in order to be compatible with the multilinear
-	/// proof system, which associates each table index with a vertex of a boolean hypercube).
-	/// This will normally be the next power of two greater than the table size, but could require
-	/// more padding to get a minimum capacity.
-	pub fn log_capacity(&self, table_size: usize) -> usize {
-		log2_ceil_usize(table_size)
-	}
-
 	fn new_column<FSub, const V: usize>(
 		&mut self,
 		name: impl ToString,
@@ -738,6 +727,16 @@ pub(crate) enum TableSizeSpec {
 	PowerOfTwo,
 	/// The table size must be a fixed power of two.
 	Fixed { log_size: usize },
+}
+
+/// Returns the binary logarithm of the table capacity required to accommodate the given number
+/// of rows.
+///
+/// The table capacity must be a power of two (in order to be compatible with the multilinear
+/// proof system, which associates each table index with a vertex of a boolean hypercube).
+/// This is be the next power of two greater than the table size.
+pub fn log_capacity(table_size: usize) -> usize {
+	log2_ceil_usize(table_size)
 }
 
 #[cfg(test)]

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -32,7 +32,7 @@ use itertools::Itertools;
 use super::{
 	column::{Col, ColumnShape},
 	error::Error,
-	table::{Table, TableId},
+	table::{self, Table, TableId},
 	types::{B1, B128, B16, B32, B64, B8},
 	ColumnDef, ColumnId, ColumnIndex, ConstraintSystem, Expr,
 };
@@ -381,7 +381,7 @@ impl<'cs, 'alloc, F: TowerField, P: PackedField<Scalar = F>> TableWitnessIndex<'
 			});
 		}
 
-		let log_capacity = table.log_capacity(size);
+		let log_capacity = table::log_capacity(size);
 		let packed_elem_log_bits = P::LOG_WIDTH + F::TOWER_LEVEL;
 
 		let mut cols = Vec::new();


### PR DESCRIPTION
Small refactor and docs update to avoid confusion.

Why I didn't just inline it? Well then there won't be a platform for the
documentation.