### PR TITLE
[core] newtype OracleId

### DIFF
--- a/crates/circuits/src/arithmetic/mul.rs
+++ b/crates/circuits/src/arithmetic/mul.rs
@@ -174,7 +174,7 @@ pub fn u32_mul<const LOG_MAX_MULTIPLICITY: usize>(
 	let name = name.to_string();
 
 	let [xin_low, xin_high] = array::from_fn(|i| {
-		let bits: [(usize, F); 16] =
+		let bits: [(OracleId, F); 16] =
 			array::from_fn(|j| (xin_bits[16 * i + j], <F as TowerField>::basis(0, j).unwrap()));
 
 		builder
@@ -266,7 +266,7 @@ pub fn u32_mul<const LOG_MAX_MULTIPLICITY: usize>(
 		builder.add_committed_multiple("cout_bits", log_rows, BinaryField1b::TOWER_LEVEL);
 
 	let cout: [OracleId; 4] = array::from_fn(|i| {
-		let bits: [(usize, F); 16] =
+		let bits: [(OracleId, F); 16] =
 			array::from_fn(|j| (cout_bits[16 * i + j], <F as TowerField>::basis(0, j).unwrap()));
 
 		builder

--- a/crates/circuits/src/builder/constraint_system.rs
+++ b/crates/circuits/src/builder/constraint_system.rs
@@ -353,7 +353,7 @@ impl<'arena> ConstraintSystemBuilder<'arena> {
 		id: OracleId,
 		values: Vec<F>,
 		start_index: usize,
-	) -> Result<usize, OracleError> {
+	) -> Result<OracleId, OracleError> {
 		self.oracles
 			.borrow_mut()
 			.add_named(self.scoped_name(name))
@@ -366,7 +366,7 @@ impl<'arena> ConstraintSystemBuilder<'arena> {
 		name: impl ToString,
 		id: OracleId,
 		values: Vec<F>,
-	) -> Result<usize, OracleError> {
+	) -> Result<OracleId, OracleError> {
 		self.oracles
 			.borrow_mut()
 			.add_named(self.scoped_name(name))

--- a/crates/circuits/src/lasso/big_integer_ops/byte_sliced_double_conditional_increment.rs
+++ b/crates/circuits/src/lasso/big_integer_ops/byte_sliced_double_conditional_increment.rs
@@ -21,7 +21,7 @@ pub fn byte_sliced_double_conditional_increment<Level: TowerLevel<Data<OracleId>
 	first_carry_in: OracleId,
 	second_carry_in: OracleId,
 	log_size: usize,
-	zero_oracle_carry: usize,
+	zero_oracle_carry: OracleId,
 	lookup_batch_dci: &mut LookupBatch,
 ) -> Result<(OracleId, Level::Data<OracleId>), anyhow::Error> {
 	if Level::WIDTH == 1 {

--- a/crates/circuits/src/lasso/big_integer_ops/byte_sliced_modular_mul.rs
+++ b/crates/circuits/src/lasso/big_integer_ops/byte_sliced_modular_mul.rs
@@ -38,7 +38,7 @@ pub fn byte_sliced_modular_mul<LevelIn: TowerLevel, LevelOut: TowerLevel<Base = 
 
 	// The double conditional increment wont be used if we're at the base of the tower
 	let lookup_t_dci = if LevelIn::WIDTH == 1 {
-		usize::MAX
+		OracleId::invalid()
 	} else {
 		dci_lookup(builder, "dci table")?
 	};
@@ -100,7 +100,7 @@ pub fn byte_sliced_modular_mul<LevelIn: TowerLevel, LevelOut: TowerLevel<Base = 
 
 		let mut remainder: Vec<_> = (0..LevelIn::WIDTH)
 			.map(|this_byte_idx| {
-				let this_byte_oracle: usize = remainder[this_byte_idx];
+				let this_byte_oracle = remainder[this_byte_idx];
 				witness.new_column::<B8>(this_byte_oracle)
 			})
 			.collect();

--- a/crates/circuits/src/lasso/big_integer_ops/byte_sliced_test_utils.rs
+++ b/crates/circuits/src/lasso/big_integer_ops/byte_sliced_test_utils.rs
@@ -197,8 +197,8 @@ where
 
 pub fn test_bytesliced_modular_mul<const WIDTH: usize, TL>()
 where
-	TL: TowerLevel<Data<usize>: Debug>,
-	TL::Base: TowerLevel<Data<usize> = [OracleId; WIDTH]>,
+	TL: TowerLevel<Data<OracleId>: Debug>,
+	TL::Base: TowerLevel<Data<OracleId> = [OracleId; WIDTH]>,
 {
 	test_circuit(|builder| {
 		let log_size = 12;

--- a/crates/circuits/src/lasso/sha256.rs
+++ b/crates/circuits/src/lasso/sha256.rs
@@ -187,7 +187,7 @@ pub fn sha256(
 
 	let mut several_maj = SeveralBitwise::new(builder, |a, b, c| (a & b) ^ (a & c) ^ (b & c))?;
 
-	let mut w = [OracleId::MAX; 64];
+	let mut w = [OracleId::invalid(); 64];
 
 	w[0..16].copy_from_slice(&input);
 

--- a/crates/circuits/src/lib.rs
+++ b/crates/circuits/src/lib.rs
@@ -31,7 +31,7 @@ mod tests {
 			channel::{validate_witness, Boundary, FlushDirection, OracleOrConst},
 		},
 		fiat_shamir::HasherChallenger,
-		oracle::ShiftVariant,
+		oracle::{OracleId, ShiftVariant},
 		polynomial::ArithCircuitPoly,
 	};
 	use binius_field::{
@@ -338,7 +338,7 @@ mod tests {
 			})
 			.collect::<Vec<_>>();
 
-		let mut add_witness_col_b128 = |oracle_id: usize, values: &[B128]| {
+		let mut add_witness_col_b128 = |oracle_id: OracleId, values: &[B128]| {
 			builder
 				.witness()
 				.unwrap()

--- a/crates/circuits/src/sha256.rs
+++ b/crates/circuits/src/sha256.rs
@@ -102,7 +102,7 @@ pub fn sha256(
 		Err(anyhow::Error::msg("log_size too small"))?
 	}
 
-	let mut w = [OracleId::MAX; 64];
+	let mut w = [OracleId::invalid(); 64];
 
 	w[0..16].copy_from_slice(&input);
 

--- a/crates/core/src/constraint_system/channel.rs
+++ b/crates/core/src/constraint_system/channel.rs
@@ -63,7 +63,7 @@ pub type ChannelId = usize;
 
 #[derive(Debug, Clone, Copy, SerializeBytes, DeserializeBytes, PartialEq, Eq)]
 pub enum OracleOrConst<F: Field> {
-	Oracle(usize),
+	Oracle(OracleId),
 	Const { base: F, tower_level: usize },
 }
 #[derive(Debug, Clone, SerializeBytes, DeserializeBytes)]

--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -487,7 +487,7 @@ where
 	// The function is on the critical path, parallelize.
 	let indices_to_update: Vec<(OracleId, MultilinearWitness<'a, _>)> = flush_oracle_ids
 		.par_iter()
-		.map(|&flush_oracle| match oracles.oracle(flush_oracle).variant {
+		.map(|&flush_oracle| match &oracles[flush_oracle].variant {
 			MultilinearPolyVariant::Composite(composite) => {
 				let inner_polys = composite.inner();
 

--- a/crates/core/src/constraint_system/validate.rs
+++ b/crates/core/src/constraint_system/validate.rs
@@ -72,7 +72,7 @@ where
 
 	// Check consistency of virtual oracle witnesses (eg. that shift polynomials are actually
 	// shifts).
-	for oracle in constraint_system.oracles.iter() {
+	for oracle in constraint_system.oracles.polys() {
 		validate_virtual_oracle_witness(oracle, &constraint_system.oracles, witness)?;
 	}
 
@@ -80,7 +80,7 @@ where
 }
 
 pub fn validate_virtual_oracle_witness<F, P>(
-	oracle: MultilinearPolyOracle<F>,
+	oracle: &MultilinearPolyOracle<F>,
 	oracles: &MultilinearOracleSet<F>,
 	witness: &MultilinearExtensionIndex<P>,
 ) -> Result<(), Error>
@@ -100,7 +100,7 @@ where
 		})
 	}
 
-	match oracle.variant {
+	match &oracle.variant {
 		MultilinearPolyVariant::Committed => {
 			// Committed oracles don't need to be checked as they are allowed to contain any data
 			// here
@@ -131,8 +131,8 @@ where
 			}
 		}
 		MultilinearPolyVariant::Repeating { id, .. } => {
-			let unrepeated_poly = witness.get_multilin_poly(id)?;
-			let unrepeated_n_vars = oracles.n_vars(id);
+			let unrepeated_poly = witness.get_multilin_poly(*id)?;
+			let unrepeated_n_vars = oracles.n_vars(*id);
 			for i in 0..1 << n_vars {
 				let got = poly.evaluate_on_hypercube(i)?;
 				let expected =
@@ -305,7 +305,7 @@ pub mod nonzerocheck {
 					if multilinear.evaluate_on_hypercube(hypercube_index)? == F::ZERO {
 						bail!(Error::NonzerocheckNaiveValidationFailure {
 							hypercube_index,
-							oracle: oracles.oracle(*id).label()
+							oracle: oracles[*id].label()
 						})
 					}
 					Ok(())

--- a/crates/core/src/oracle/mod.rs
+++ b/crates/core/src/oracle/mod.rs
@@ -10,8 +10,10 @@ mod composite;
 mod constraint;
 mod error;
 mod multilinear;
+mod oracle_id;
 
 pub use composite::*;
 pub use constraint::*;
 pub use error::Error;
 pub use multilinear::*;
+pub use oracle_id::*;

--- a/crates/core/src/oracle/oracle_id.rs
+++ b/crates/core/src/oracle/oracle_id.rs
@@ -1,0 +1,71 @@
+// Copyright 2025 Irreducible Inc.
+
+use std::fmt;
+
+use binius_utils::{DeserializeBytes, SerializationError, SerializationMode, SerializeBytes};
+
+/// Identifier for a multilinear oracle in a [`super::MultilinearOracleSet`].
+///
+/// This is essentially an index.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OracleId(usize);
+
+impl OracleId {
+	/// Create an Oracle ID from the index this oracle stored in the
+	/// [`super::MultilinearOracleSet`].
+	///
+	/// Largely an escape hatch and discouraged to use.
+	pub fn from_index(index: usize) -> Self {
+		Self(index)
+	}
+
+	/// Returns the index in the associated [`super::MultilinearOracleSet`].
+	///
+	/// Largely an escape hatch and discouraged to use.
+	pub fn index(&self) -> usize {
+		self.0
+	}
+
+	/// Returns an invalid OracleId.
+	pub const fn invalid() -> Self {
+		Self(usize::MAX)
+	}
+}
+
+impl SerializeBytes for OracleId {
+	fn serialize(
+		&self,
+		write_buf: impl bytes::BufMut,
+		mode: SerializationMode,
+	) -> Result<(), SerializationError> {
+		let index: u32 = self.0 as u32;
+		u32::serialize(&index, write_buf, mode)
+	}
+}
+impl DeserializeBytes for OracleId {
+	fn deserialize(
+		read_buf: impl bytes::Buf,
+		mode: SerializationMode,
+	) -> Result<Self, SerializationError>
+	where
+		Self: Sized,
+	{
+		let index = u32::deserialize(read_buf, mode)?;
+		Ok(Self(index as usize))
+	}
+}
+
+impl fmt::Display for OracleId {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		// Delegate to debug.
+		write!(f, "{self:?}")
+	}
+}
+
+// Technically, there must be no notion of a "default" oracle ID. However, there is some code that
+// requires that, so until it's fixed this is going to mean INVALID.
+impl Default for OracleId {
+	fn default() -> Self {
+		Self::invalid()
+	}
+}

--- a/crates/core/src/piop/commit.rs
+++ b/crates/core/src/piop/commit.rs
@@ -41,13 +41,13 @@ pub fn make_oracle_commit_meta<F: TowerField>(
 	// First pass: count the number of multilinears and index within buckets
 	let mut first_pass_index = SparseIndex::with_capacity(oracles.size());
 	let mut n_multilins_by_vars = ResizeableIndex::<usize>::new();
-	for oracle in oracles.iter() {
+	for oracle in oracles.polys() {
 		if matches!(oracle.variant, MultilinearPolyVariant::Committed) {
-			let n_packed_vars = n_packed_vars_for_committed_oracle(&oracle);
+			let n_packed_vars = n_packed_vars_for_committed_oracle(oracle);
 			let n_multilins_for_vars = n_multilins_by_vars.get_mut(n_packed_vars);
 
 			first_pass_index.set(
-				oracle.id(),
+				oracle.id().index(),
 				CommitIDFirstPass {
 					n_packed_vars,
 					idx_in_bucket: *n_multilins_for_vars,
@@ -96,8 +96,8 @@ where
 	F: TowerField,
 {
 	let mut witnesses = vec![None; commit_meta.total_multilins()];
-	for oracle_id in 0..oracles.size() {
-		if let Some(commit_idx) = oracle_to_commit_index.get(oracle_id) {
+	for oracle_id in oracles.ids() {
+		if let Some(commit_idx) = oracle_to_commit_index.get(oracle_id.index()) {
 			witnesses[*commit_idx] = Some(witness_index.get_multilin_poly(oracle_id)?);
 		}
 	}
@@ -135,18 +135,18 @@ mod tests {
 
 		let (commit_meta, index) = make_oracle_commit_meta(&oracles).unwrap();
 		assert_eq!(commit_meta.n_multilins_by_vars(), &[0, 2, 0, 4, 0, 4, 0, 2]);
-		assert_eq!(index.get(batch_0_0_ids[0]).copied(), Some(0));
-		assert_eq!(index.get(batch_0_0_ids[1]).copied(), Some(1));
-		assert_eq!(index.get(batch_0_1_ids[0]).copied(), Some(2));
-		assert_eq!(index.get(batch_0_1_ids[1]).copied(), Some(3));
-		assert_eq!(index.get(batch_0_2_ids[0]).copied(), Some(6));
-		assert_eq!(index.get(batch_0_2_ids[1]).copied(), Some(7));
-		assert_eq!(index.get(batch_2_0_ids[0]).copied(), Some(4));
-		assert_eq!(index.get(batch_2_0_ids[1]).copied(), Some(5));
-		assert_eq!(index.get(batch_2_1_ids[0]).copied(), Some(8));
-		assert_eq!(index.get(batch_2_1_ids[1]).copied(), Some(9));
-		assert_eq!(index.get(batch_2_2_ids[0]).copied(), Some(10));
-		assert_eq!(index.get(batch_2_2_ids[1]).copied(), Some(11));
-		assert_eq!(index.get(repeat).copied(), None);
+		assert_eq!(index.get(batch_0_0_ids[0].index()).copied(), Some(0));
+		assert_eq!(index.get(batch_0_0_ids[1].index()).copied(), Some(1));
+		assert_eq!(index.get(batch_0_1_ids[0].index()).copied(), Some(2));
+		assert_eq!(index.get(batch_0_1_ids[1].index()).copied(), Some(3));
+		assert_eq!(index.get(batch_0_2_ids[0].index()).copied(), Some(6));
+		assert_eq!(index.get(batch_0_2_ids[1].index()).copied(), Some(7));
+		assert_eq!(index.get(batch_2_0_ids[0].index()).copied(), Some(4));
+		assert_eq!(index.get(batch_2_0_ids[1].index()).copied(), Some(5));
+		assert_eq!(index.get(batch_2_1_ids[0].index()).copied(), Some(8));
+		assert_eq!(index.get(batch_2_1_ids[1].index()).copied(), Some(9));
+		assert_eq!(index.get(batch_2_2_ids[0].index()).copied(), Some(10));
+		assert_eq!(index.get(batch_2_2_ids[1].index()).copied(), Some(11));
+		assert_eq!(index.get(repeat.index()).copied(), None);
 	}
 }

--- a/crates/core/src/protocols/evalcheck/evalcheck.rs
+++ b/crates/core/src/protocols/evalcheck/evalcheck.rs
@@ -111,7 +111,7 @@ impl<T: Clone, F: Field> EvalPointOracleIdMap<T, F> {
 	/// Returns `None` if no value is found.
 	pub fn get(&self, id: OracleId, eval_point: &[F]) -> Option<&T> {
 		self.data
-			.get(id)?
+			.get(id.index())?
 			.iter()
 			.find(|(ep, _)| **ep == *eval_point)
 			.map(|(_, val)| val)
@@ -121,11 +121,11 @@ impl<T: Clone, F: Field> EvalPointOracleIdMap<T, F> {
 	///
 	/// We do not replace existing values.
 	pub fn insert(&mut self, id: OracleId, eval_point: EvalPoint<F>, val: T) {
-		if id >= self.data.len() {
-			self.data.resize(id + 1, Vec::new());
+		if id.index() >= self.data.len() {
+			self.data.resize(id.index() + 1, Vec::new());
 		}
 
-		self.data[id].push((eval_point, val))
+		self.data[id.index()].push((eval_point, val))
 	}
 
 	/// Flatten the data structure into a vector of values.

--- a/crates/core/src/ring_switch/common.rs
+++ b/crates/core/src/ring_switch/common.rs
@@ -109,7 +109,7 @@ impl<'a, F: TowerField> EvalClaimSystem<'a, F> {
 					return Err(Error::EvalcheckClaimForDerivedPoly { id: eval_claim.id });
 				}
 				let committed_idx = oracle_to_commit_index
-					.get(oracle.id())
+					.get(oracle.id().index())
 					.copied()
 					.ok_or_else(|| Error::OracleToCommitIndexMissingEntry { id: eval_claim.id })?;
 				let suffix_desc_idx = eval_claim_to_suffix_desc_index[i];

--- a/crates/core/src/ring_switch/tests.rs
+++ b/crates/core/src/ring_switch/tests.rs
@@ -68,7 +68,7 @@ where
 {
 	let mut witness_index = MultilinearExtensionIndex::new();
 
-	for oracle in oracles.iter() {
+	for oracle in oracles.polys() {
 		if matches!(oracle.variant, MultilinearPolyVariant::Committed) {
 			let n_vars = oracle.n_vars();
 			let witness = match oracle.binary_tower_level() {
@@ -141,7 +141,7 @@ where
 	F: TowerField,
 {
 	let max_n_vars = oracles
-		.iter()
+		.polys()
 		.filter(|oracle| matches!(oracle.variant, MultilinearPolyVariant::Committed))
 		.map(|oracle| oracle.n_vars())
 		.max()
@@ -151,7 +151,7 @@ where
 		.collect::<Vec<_>>();
 
 	let mut eval_claims = Vec::new();
-	for oracle in oracles.iter() {
+	for oracle in oracles.polys() {
 		if !matches!(oracle.variant, MultilinearPolyVariant::Committed) {
 			continue;
 		}

--- a/crates/core/src/witness.rs
+++ b/crates/core/src/witness.rs
@@ -58,7 +58,7 @@ where
 	pub fn get_index_entry(&self, id: OracleId) -> Result<IndexEntry<'a, P>, Error> {
 		let entry = self
 			.entries
-			.get(id)
+			.get(id.index())
 			.ok_or(Error::MissingWitness { id })?
 			.as_ref()
 			.ok_or(Error::MissingWitness { id })?;
@@ -71,7 +71,7 @@ where
 
 	/// Whether has data for the given oracle id.
 	pub fn has(&self, id: OracleId) -> bool {
-		self.entries.get(id).is_some_and(Option::is_some)
+		self.entries.get(id.index()).is_some_and(Option::is_some)
 	}
 
 	pub fn update_multilin_poly(
@@ -91,11 +91,12 @@ where
 		witnesses: impl IntoIterator<Item = (OracleId, MultilinearWitness<'a, P>, usize)>,
 	) -> Result<(), Error> {
 		for (id, multilin_poly, nonzero_scalars_prefix) in witnesses {
-			if id >= self.entries.len() {
-				self.entries.resize_with(id + 1, || None);
+			let id_index = id.index();
+			if id_index >= self.entries.len() {
+				self.entries.resize_with(id_index + 1, || None);
 			}
 			// TODO: validate nonzero_scalars_prefix
-			self.entries[id] = Some(IndexEntry {
+			self.entries[id_index] = Some(IndexEntry {
 				multilin_poly,
 				nonzero_scalars_prefix,
 			});

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -475,7 +475,7 @@ fn add_oracle_for_column<F: TowerField>(
 fn translate_constraint_set<F: TowerField>(
 	n_vars: usize,
 	zero_constraints: &[ZeroConstraint<F>],
-	partition_oracle_ids: Vec<usize>,
+	partition_oracle_ids: Vec<OracleId>,
 ) -> ConstraintSet<F> {
 	// We need to figure out which oracle ids from the entire set of the partition oracles is
 	// actually referenced in every zero constraint expressions.

--- a/crates/utils/src/graph.rs
+++ b/crates/utils/src/graph.rs
@@ -19,13 +19,18 @@ use std::cmp::Ordering;
 ///     vec![0, 0, 0, 0, 4, 5, 5, 5, 5, 0]
 /// );
 /// ```
-pub fn connected_components(data: &[&[usize]]) -> Vec<usize> {
+pub fn connected_components<T: AsRef<[impl AsRef<[usize]>]>>(data: T) -> Vec<usize> {
+	let data = data.as_ref();
 	if data.is_empty() {
 		return vec![];
 	}
 
 	// Determine the maximum node ID
-	let max_id = *data.iter().flat_map(|ids| ids.iter()).max().unwrap_or(&0);
+	let max_id = *data
+		.iter()
+		.flat_map(|ids| ids.as_ref().iter())
+		.max()
+		.unwrap_or(&0);
 
 	let n = max_id + 1;
 	let mut uf = UnionFind::new(n);
@@ -35,9 +40,10 @@ pub fn connected_components(data: &[&[usize]]) -> Vec<usize> {
 	// we can simply connect each node in the subset to the minimum node in that subset.
 	// This still ensures they all become part of one connected component.
 	for ids in data {
+		let ids = ids.as_ref();
 		if ids.len() > 1 {
 			let &base = ids.iter().min().unwrap();
-			for &node in *ids {
+			for &node in ids {
 				if node != base {
 					uf.union(base, node);
 				}


### PR DESCRIPTION
OracleId becomes a newtype. This is a non-functional change.

As you see, this PR introduces some friction when using OracleId as an index by
forcing using `OracleId::from_index` and `OracleId::index`. This is intentional.
Users who call either of those functions should think of a better way of
structuring the code to avoid this. Some of the usages are hopefully going away
with follow-up refactorings.

As a bonus: turns out there were quite a bit of clones of MultilinearPolyOracle
struct. Each one is, if instantiated with e.g. F=BinaryField32b is 160 bytes.
Not too much but definitely annoying, especially considering why it was
happening. In one instance the whole clone of the structure would be done
just to get the name/label.

The tests seem to pass locally and petravm also green.