### PR TITLE
Add FRI folding tower level logging

### DIFF
--- a/crates/core/src/piop/prove.rs
+++ b/crates/core/src/piop/prove.rs
@@ -345,7 +345,7 @@ where
 			phase = "piop_compiler",
 			round = round,
 			perfetto_category = "phase.sub",
-			dimensions_data = ?dimensions_data,
+			?dimensions_data,
 		)
 		.entered();
 		match fri_prover.execute_fold_round(challenge)? {

--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -254,7 +254,7 @@ where
 			"[task] (Evalcheck) MLE Fold High",
 			phase = "evalcheck",
 			perfetto_category = "task.main",
-			dimensions_data = ?dimensions_data,
+			?dimensions_data,
 		)
 		.entered();
 

--- a/crates/core/src/protocols/fri/logging.rs
+++ b/crates/core/src/protocols/fri/logging.rs
@@ -72,7 +72,11 @@ pub(super) struct FRIFoldData {
 }
 
 impl FRIFoldData {
-	pub(super) fn new<F: BinaryField, FA: BinaryField>(log_len: usize, log_batch_size: usize, num_challenges: usize) -> Self {
+	pub(super) fn new<F: BinaryField, FA: BinaryField>(
+		log_len: usize,
+		log_batch_size: usize,
+		num_challenges: usize,
+	) -> Self {
 		Self {
 			log_len,
 			log_batch_size,

--- a/crates/core/src/protocols/fri/logging.rs
+++ b/crates/core/src/protocols/fri/logging.rs
@@ -67,14 +67,18 @@ pub(super) struct FRIFoldData {
 	log_len: usize,
 	log_batch_size: usize,
 	num_challenges: usize,
+	codeword_tower_height: usize,
+	ntt_tower_height: usize,
 }
 
 impl FRIFoldData {
-	pub(super) fn new(log_len: usize, log_batch_size: usize, num_challenges: usize) -> Self {
+	pub(super) fn new<F: BinaryField, FA: BinaryField>(log_len: usize, log_batch_size: usize, num_challenges: usize) -> Self {
 		Self {
 			log_len,
 			log_batch_size,
 			num_challenges,
+			codeword_tower_height: <F as ExtensionField<BinaryField1b>>::LOG_DEGREE,
+			ntt_tower_height: <FA as ExtensionField<BinaryField1b>>::LOG_DEGREE,
 		}
 	}
 

--- a/crates/core/src/protocols/fri/prove.rs
+++ b/crates/core/src/protocols/fri/prove.rs
@@ -193,14 +193,24 @@ where
 	let mut encoded = zeroed_vec(1 << (log_elems - P::LOG_WIDTH + rs_code.log_inv_rate()));
 
 	let dimensions_data = SortAndMergeDimensionData::new::<F>(log_elems);
-	tracing::debug_span!("[task] Sort & Merge", phase = "commit", perfetto_category = "task.main", ?dimensions_data)
-		.in_scope(|| {
-			message_writer(&mut encoded[..1 << (log_elems - P::LOG_WIDTH)]);
-		});
+	tracing::debug_span!(
+		"[task] Sort & Merge",
+		phase = "commit",
+		perfetto_category = "task.main",
+		?dimensions_data
+	)
+	.in_scope(|| {
+		message_writer(&mut encoded[..1 << (log_elems - P::LOG_WIDTH)]);
+	});
 
 	let dimensions_data = RSEncodeDimensionData::new::<F>(log_elems, log_batch_size);
-	tracing::debug_span!("[task] RS Encode", phase = "commit", perfetto_category = "task.main", ?dimensions_data)
-		.in_scope(|| rs_code.encode_ext_batch_inplace(ntt, &mut encoded, log_batch_size))?;
+	tracing::debug_span!(
+		"[task] RS Encode",
+		phase = "commit",
+		perfetto_category = "task.main",
+		?dimensions_data
+	)
+	.in_scope(|| rs_code.encode_ext_batch_inplace(ntt, &mut encoded, log_batch_size))?;
 
 	// Take the first arity as coset_log_len, or use the value such that the number of leaves equals 1 << log_inv_rate if arities is empty
 	let coset_log_len = params.fold_arities().first().copied().unwrap_or(log_elems);

--- a/crates/core/src/protocols/fri/prove.rs
+++ b/crates/core/src/protocols/fri/prove.rs
@@ -193,13 +193,13 @@ where
 	let mut encoded = zeroed_vec(1 << (log_elems - P::LOG_WIDTH + rs_code.log_inv_rate()));
 
 	let dimensions_data = SortAndMergeDimensionData::new::<F>(log_elems);
-	tracing::debug_span!("[task] Sort & Merge", phase = "commit", perfetto_category = "task.main", dimensions_data = ?dimensions_data)
+	tracing::debug_span!("[task] Sort & Merge", phase = "commit", perfetto_category = "task.main", ?dimensions_data)
 		.in_scope(|| {
 			message_writer(&mut encoded[..1 << (log_elems - P::LOG_WIDTH)]);
 		});
 
 	let dimensions_data = RSEncodeDimensionData::new::<F>(log_elems, log_batch_size);
-	tracing::debug_span!("[task] RS Encode", phase = "commit", perfetto_category = "task.main", dimensions_data = ?dimensions_data)
+	tracing::debug_span!("[task] RS Encode", phase = "commit", perfetto_category = "task.main", ?dimensions_data)
 		.in_scope(|| rs_code.encode_ext_batch_inplace(ntt, &mut encoded, log_batch_size))?;
 
 	// Take the first arity as coset_log_len, or use the value such that the number of leaves equals 1 << log_inv_rate if arities is empty
@@ -337,12 +337,12 @@ where
 		}
 
 		let dimensions_data = match self.round_committed.last() {
-			Some((codeword, _)) => FRIFoldData::new(
+			Some((codeword, _)) => FRIFoldData::new::<F, FA>(
 				log2_strict_usize(codeword.len()),
 				0,
 				self.unprocessed_challenges.len(),
 			),
-			None => FRIFoldData::new(
+			None => FRIFoldData::new::<F, FA>(
 				self.params.rs_code().log_len(),
 				self.params.log_batch_size(),
 				self.unprocessed_challenges.len(),
@@ -353,7 +353,7 @@ where
 			"[task] FRI Fold",
 			phase = "piop_compiler",
 			perfetto_category = "task.main",
-			dimensions_data = ?dimensions_data
+			?dimensions_data
 		)
 		.entered();
 		// Fold the last codeword with the accumulated folding challenges.

--- a/crates/core/src/protocols/greedy_evalcheck/prove.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/prove.rs
@@ -73,7 +73,7 @@ where
 			"[task] (Evalcheck) Regular Sumcheck (Small)",
 			phase = "evalcheck",
 			perfetto_category = "task.main",
-			dimensions_data = ?dimensions_data,
+			?dimensions_data,
 		)
 		.entered();
 		let new_evalcheck_claims =

--- a/crates/core/src/protocols/sumcheck/prove/batch_zerocheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/batch_zerocheck.rs
@@ -241,7 +241,7 @@ where
 		"[task] Initial MLE Fold Low",
 		phase = "zerocheck",
 		perfetto_category = "task.main",
-		dimensions_data = ?dimensions_data,
+		?dimensions_data,
 	)
 	.entered();
 	for prover in provers {

--- a/crates/core/src/protocols/sumcheck/prove/front_loaded.rs
+++ b/crates/core/src/protocols/sumcheck/prove/front_loaded.rs
@@ -144,7 +144,7 @@ where
 				"[task] (PIOP Compiler) Fold",
 				phase = "piop_compiler",
 				round = self.round,
-				dimensions_data = ?dimensions_data,
+				?dimensions_data,
 			)
 			.entered();
 			prover.fold(challenge)?;

--- a/crates/core/src/protocols/sumcheck/prove/univariate.rs
+++ b/crates/core/src/protocols/sumcheck/prove/univariate.rs
@@ -292,7 +292,7 @@ where
 		"[task] Expand Query",
 		phase = "zerocheck",
 		perfetto_category = "task.main",
-		dimensions_data = ?dimensions_data,
+		?dimensions_data,
 	)
 	.entered();
 	let partial_eq_ind_evals: <Backend as ComputationBackend>::Vec<P> =
@@ -316,7 +316,7 @@ where
 		"[task] Univariate Skip Calculate coeffs",
 		phase = "zerocheck",
 		perfetto_category = "task.main",
-		dimensions_data = ?dimensions_data,
+		?dimensions_data,
 	)
 	.entered();
 

--- a/crates/core/src/ring_switch/prove.rs
+++ b/crates/core/src/ring_switch/prove.rs
@@ -68,7 +68,7 @@ where
 		"[task] (Ring Switch) MLE Fold High",
 		phase = "ring_switch",
 		perfetto_category = "task.main",
-		dimensions_data = ?dimensions_data,
+		?dimensions_data,
 	)
 	.entered();
 
@@ -106,7 +106,7 @@ where
 		"[task] Calculate Ring Switch Eq Ind",
 		phase = "ring_switch",
 		perfetto_category = "task.main",
-		dimensions_data = ?dimensions_data,
+		?dimensions_data,
 	)
 	.entered();
 


### PR DESCRIPTION
Log the tower levels of the codeword and NTT coefficients.

Also apply the proposal by @nikurt to pass the parameters to the span macro in a more elegant way.  