### PR TITLE
[m3] Exposed input and output columns for Keccak-f[1600] gadget.

### DIFF
--- a/crates/m3/src/gadgets/hash/keccak/mod.rs
+++ b/crates/m3/src/gadgets/hash/keccak/mod.rs
@@ -254,7 +254,7 @@ impl Keccakf {
 	pub fn populate_state_in<'a, P>(
 		&self,
 		index: &mut TableWitnessSegment<P>,
-		state_ins: impl IntoIterator<Item = &'a [u64; 25]>,
+		state_ins: impl IntoIterator<Item = &'a StateMatrix<u64>>,
 	) -> Result<()>
 	where
 		P: PackedFieldIndexable<Scalar = B128> + PackedExtension<B1> + PackedExtension<B8>,
@@ -461,7 +461,7 @@ impl RoundBatch {
 		&self,
 		index: &mut TableWitnessSegment<P>,
 		track: usize,
-		state_ins: impl IntoIterator<Item = &'a [u64; 25]>,
+		state_ins: impl IntoIterator<Item = &'a StateMatrix<u64>>,
 	) -> Result<()>
 	where
 		P: PackedFieldIndexable<Scalar = B128> + PackedExtension<B1> + PackedExtension<B8>,
@@ -472,7 +472,7 @@ impl RoundBatch {
 				for y in 0..5 {
 					let mut state_in_data: std::cell::RefMut<'_, [u64]> =
 						index.get_mut_as(self.state_in[(x, y)])?;
-					state_in_data[TRACKS_PER_BATCH * k + track] = state_in[x + y * 5];
+					state_in_data[TRACKS_PER_BATCH * k + track] = state_in[(x, y)];
 				}
 			}
 		}
@@ -657,7 +657,7 @@ mod tests {
 
 		let state_ins = TEST_VECTOR
 			.iter()
-			.map(|&[state_in, _]| state_in)
+			.map(|&[state_in, _]| StateMatrix::from_values(state_in))
 			.collect::<Vec<_>>();
 
 		keccakf.populate_state_in(&mut segment, &state_ins).unwrap();

--- a/crates/m3/src/gadgets/hash/keccak/mod.rs
+++ b/crates/m3/src/gadgets/hash/keccak/mod.rs
@@ -106,7 +106,8 @@ impl Keccakf {
 			table.add_packed(format!("state_in_packed[{x},{y}]"), state[(x, y)])
 		});
 
-		// Constructing the batches of rounds. The final value of `state` will be the permutation output.
+		// Constructing the batches of rounds. The final value of `state` will be the permutation
+		// output.
 		let batches = array::from_fn(|batch_no| {
 			let batch = RoundBatch::new(
 				&mut table.with_namespace(format!("batch[{batch_no}]")),

--- a/crates/m3/src/gadgets/hash/keccak/mod.rs
+++ b/crates/m3/src/gadgets/hash/keccak/mod.rs
@@ -21,7 +21,7 @@ mod test_vector;
 mod trace;
 
 // This implementation tries to be as close to the
-// [Keccak Specification Summary][keccak_spec_summary] and as such i///////.// //t is highly recommended to
+// [Keccak Specification Summary][keccak_spec_summary] and as such it is highly recommended to
 // get familiar with it. A lot of terminology is carried over from that spec.
 //
 // [keccak_spec_summary]: https://keccak.team/keccak_specs_summary.html
@@ -101,12 +101,12 @@ impl Keccakf {
 
 		let mut state = state_in;
 
-		//Declaring packed state_in columns for exposing in the struct.
+		// Declaring packed state_in columns for exposing in the struct.
 		let state_in_packed: StateMatrix<Col<B64, 8>> = StateMatrix::from_fn(|(x, y)| {
 			table.add_packed(format!("state_in_packed[{x},{y}]"), state[(x, y)])
 		});
 
-		//Constructing the batches of rounds. The final value of `state` will be the permutation output.
+		// Constructing the batches of rounds. The final value of `state` will be the permutation output.
 		let batches = array::from_fn(|batch_no| {
 			let batch = RoundBatch::new(
 				&mut table.with_namespace(format!("batch[{batch_no}]")),
@@ -117,7 +117,7 @@ impl Keccakf {
 			batch
 		});
 
-		//Declaring packed state_out columns to be exposed in the struct.
+		// Declaring packed state_out columns to be exposed in the struct.
 		let state_out_packed: StateMatrix<Col<B64, 8>> = StateMatrix::from_fn(|(x, y)| {
 			table.add_packed(format!("state_out_packed[{x},{y}]"), state[(x, y)])
 		});
@@ -202,7 +202,6 @@ impl Keccakf {
 						index.get_as(self.batches[0].state_in[(x, y)])?;
 					let batch_2_state_out: std::cell::Ref<'_, [u64]> =
 						index.get_as(self.batches[2].state_out[(x, y)])?;
-
 					for track in 0..TRACKS_PER_BATCH - 1 {
 						next_state_in[TRACKS_PER_BATCH * k + track] =
 							batch_0_state_in[TRACKS_PER_BATCH * k + track + 1];
@@ -210,16 +209,15 @@ impl Keccakf {
 							next_state_in[TRACKS_PER_BATCH * k + track],
 							batch_2_state_out[TRACKS_PER_BATCH * k + track]
 						);
-
-						//Populating the packed and selected input and output columns.
-						let mut input: std::cell::RefMut<'_, [u64]> =
-							index.get_mut_as(self.input[x + y * 5])?;
-						let mut output: std::cell::RefMut<'_, [u64]> =
-							index.get_mut_as(self.output[x + y * 5])?;
-
-						input[k] = pts[k].per_batch(0)[0].state_in[(x, y)];
-						output[k] = pts[k].per_batch(2)[TRACKS_PER_BATCH - 1].state_out[(x, y)];
 					}
+					// Populating the packed and selected input and output columns.
+					let mut input: std::cell::RefMut<'_, [u64]> =
+						index.get_mut_as(self.input[x + y * 5])?;
+					let mut output: std::cell::RefMut<'_, [u64]> =
+						index.get_mut_as(self.output[x + y * 5])?;
+
+					input[k] = pts[k].per_batch(0)[0].state_in[(x, y)];
+					output[k] = pts[k].per_batch(2)[TRACKS_PER_BATCH - 1].state_out[(x, y)];
 				}
 			}
 		}
@@ -647,8 +645,6 @@ mod tests {
 		let mut cs = ConstraintSystem::new();
 		let mut table = cs.add_table("test");
 
-		// let state_in: StateMatrix<PackedLane8> =
-		// 	StateMatrix::from_fn(|(x, y)| table.add_committed(format!("in[{x},{y}]")));
 		let keccakf = Keccakf::new(&mut table);
 
 		let allocator = Bump::new();

--- a/crates/m3/src/gadgets/hash/keccak/mod.rs
+++ b/crates/m3/src/gadgets/hash/keccak/mod.rs
@@ -81,8 +81,8 @@ pub struct Keccakf {
 	/// This is used for the state-in to state-out linking rule.
 	next_state_in: StateMatrix<PackedLane8>,
 
-	pub input: [Col<B64>; 25],
-	pub output: [Col<B64>; 25],
+	pub input: StateMatrix<Col<B64>>,
+	pub output: StateMatrix<Col<B64>>,
 	/// Link selector.
 	///
 	/// This is all ones for the first 7 tracks and all zeroes for the last one.
@@ -122,15 +122,11 @@ impl Keccakf {
 			table.add_packed(format!("state_out_packed[{x},{y}]"), state[(x, y)])
 		});
 
-		let input = array::from_fn::<_, 25, _>(|i| {
-			let x = i % 5;
-			let y = i / 5;
+		let input = StateMatrix::from_fn(|(x, y)| {
 			table.add_selected(format!("input[{x},{y}]"), state_in_packed[(x, y)], 0)
 		});
 
-		let output = array::from_fn::<_, 25, _>(|i| {
-			let x = i % 5;
-			let y = i / 5;
+		let output = StateMatrix::from_fn(|(x, y)| {
 			table.add_selected(format!("output[{x},{y}]"), state_out_packed[(x, y)], 7)
 		});
 
@@ -212,9 +208,9 @@ impl Keccakf {
 					}
 					// Populating the packed and selected input and output columns.
 					let mut input: std::cell::RefMut<'_, [u64]> =
-						index.get_mut_as(self.input[x + y * 5])?;
+						index.get_mut_as(self.input[(x, y)])?;
 					let mut output: std::cell::RefMut<'_, [u64]> =
-						index.get_mut_as(self.output[x + y * 5])?;
+						index.get_mut_as(self.output[(x, y)])?;
 
 					input[k] = pts[k].per_batch(0)[0].state_in[(x, y)];
 					output[k] = pts[k].per_batch(2)[TRACKS_PER_BATCH - 1].state_out[(x, y)];

--- a/crates/m3/src/gadgets/hash/keccak/mod.rs
+++ b/crates/m3/src/gadgets/hash/keccak/mod.rs
@@ -102,7 +102,7 @@ impl Keccakf {
 		let mut state = state_in;
 
 		//Declaring packed state_in columns for exposing in the struct.
-		let state_in_packed: StateMatrix<Col<B64, 8>> = StateMatrix::from_fn(|(x,y)| {
+		let state_in_packed: StateMatrix<Col<B64, 8>> = StateMatrix::from_fn(|(x, y)| {
 			table.add_packed(format!("state_in_packed[{x},{y}]"), state[(x, y)])
 		});
 
@@ -118,20 +118,20 @@ impl Keccakf {
 		});
 
 		//Declaring packed state_out columns to be exposed in the struct.
-		let state_out_packed: StateMatrix<Col<B64, 8>> = StateMatrix::from_fn(|(x,y)| {
+		let state_out_packed: StateMatrix<Col<B64, 8>> = StateMatrix::from_fn(|(x, y)| {
 			table.add_packed(format!("state_out_packed[{x},{y}]"), state[(x, y)])
 		});
 
 		let input = array::from_fn::<_, 25, _>(|i| {
 			let x = i % 5;
 			let y = i / 5;
-			table.add_selected(format!("input[{x},{y}]"), state_in_packed[(x,y)], 0)
+			table.add_selected(format!("input[{x},{y}]"), state_in_packed[(x, y)], 0)
 		});
 
 		let output = array::from_fn::<_, 25, _>(|i| {
 			let x = i % 5;
 			let y = i / 5;
-			table.add_selected(format!("output[{x},{y}]"), state_out_packed[(x,y)], 7)
+			table.add_selected(format!("output[{x},{y}]"), state_out_packed[(x, y)], 7)
 		});
 
 		let link_sel = table.add_constant(
@@ -218,8 +218,7 @@ impl Keccakf {
 							index.get_mut_as(self.output[x + y * 5])?;
 
 						input[k] = pts[k].per_batch(0)[0].state_in[(x, y)];
-						output[k] =
-							pts[k].per_batch(2)[TRACKS_PER_BATCH - 1].state_out[(x, y)];
+						output[k] = pts[k].per_batch(2)[TRACKS_PER_BATCH - 1].state_out[(x, y)];
 					}
 				}
 			}

--- a/crates/m3/src/gadgets/hash/keccak/trace.rs
+++ b/crates/m3/src/gadgets/hash/keccak/trace.rs
@@ -88,6 +88,16 @@ impl PermutationTrace {
 	pub fn per_batch(&self, batch_no: usize) -> PerBatchLens<'_> {
 		PerBatchLens { pt: self, batch_no }
 	}
+
+	/// Get the input state for the permutation.
+	pub fn input(&self) -> &StateMatrix<u64> {
+		&self.round_traces[0].state_in
+	}
+
+	/// Get the output state for the permutation.
+	pub fn output(&self) -> &StateMatrix<u64> {
+		&self.round_traces[ROUNDS_PER_PERMUTATION - 1].state_out
+	}
 }
 
 /// This is specialization of [`PermutationTrace`] for a particular batch.

--- a/examples/keccak.rs
+++ b/examples/keccak.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-use std::{array, iter::repeat_with};
+use std::iter::repeat_with;
 
 use anyhow::Result;
 use binius_circuits::builder::types::U;
@@ -16,7 +16,7 @@ use binius_m3::{
 		ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment, WitnessIndex, B1,
 		B128, B64, B8,
 	},
-	gadgets::hash::keccak::{self, Keccakf},
+	gadgets::hash::keccak::{self, Keccakf, StateMatrix},
 };
 use binius_utils::rayon::adjust_thread_pool;
 use bytesize::ByteSize;
@@ -60,7 +60,7 @@ where
 		+ PackedExtension<B64>,
 	PackedSubfield<P, B8>: PackedTransformationFactory<PackedSubfield<P, B8>>,
 {
-	type Event = [u64; 25];
+	type Event = StateMatrix<u64>;
 
 	fn id(&self) -> TableId {
 		self.table_id
@@ -101,7 +101,7 @@ fn main() -> Result<()> {
 	};
 
 	let mut rng = thread_rng();
-	let events = repeat_with(|| array::from_fn::<u64, 25, _>(|_| rng.next_u64()))
+	let events = repeat_with(|| StateMatrix::from_fn(|_| rng.next_u64()))
 		.take(n_permutations)
 		.collect::<Vec<_>>();
 

--- a/examples/keccak.rs
+++ b/examples/keccak.rs
@@ -98,7 +98,7 @@ fn main() -> Result<()> {
 	};
 
 	let mut rng = thread_rng();
-	let events = repeat_with(|| array::from_fn::<u64, 25, _>(|_|rng.next_u64()))
+	let events = repeat_with(|| array::from_fn::<u64, 25, _>(|_| rng.next_u64()))
 		.take(n_permutations)
 		.collect::<Vec<_>>();
 

--- a/examples/keccak.rs
+++ b/examples/keccak.rs
@@ -14,7 +14,7 @@ use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_m3::{
 	builder::{
 		ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment, WitnessIndex, B1,
-		B128, B8, B64
+		B128, B64, B8,
 	},
 	gadgets::hash::keccak::{self, Keccakf},
 };
@@ -54,7 +54,10 @@ impl PermutationTable {
 
 impl<P> TableFiller<P> for PermutationTable
 where
-	P: PackedFieldIndexable<Scalar = B128> + PackedExtension<B1> + PackedExtension<B8> + PackedExtension<B64>,
+	P: PackedFieldIndexable<Scalar = B128>
+		+ PackedExtension<B1>
+		+ PackedExtension<B8>
+		+ PackedExtension<B64>,
 	PackedSubfield<P, B8>: PackedTransformationFactory<PackedSubfield<P, B8>>,
 {
 	type Event = [u64; 25];

--- a/examples/keccak.rs
+++ b/examples/keccak.rs
@@ -14,9 +14,9 @@ use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_m3::{
 	builder::{
 		ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment, WitnessIndex, B1,
-		B128, B8,
+		B128, B8, B64
 	},
-	gadgets::hash::keccak::{self, Keccakf, StateMatrix},
+	gadgets::hash::keccak::{self, Keccakf},
 };
 use binius_utils::rayon::adjust_thread_pool;
 use bytesize::ByteSize;
@@ -54,7 +54,7 @@ impl PermutationTable {
 
 impl<P> TableFiller<P> for PermutationTable
 where
-	P: PackedFieldIndexable<Scalar = B128> + PackedExtension<B1> + PackedExtension<B8>,
+	P: PackedFieldIndexable<Scalar = B128> + PackedExtension<B1> + PackedExtension<B8> + PackedExtension<B64>,
 	PackedSubfield<P, B8>: PackedTransformationFactory<PackedSubfield<P, B8>>,
 {
 	type Event = [u64; 25];

--- a/examples/keccak.rs
+++ b/examples/keccak.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-use std::iter::repeat_with;
+use std::{array, iter::repeat_with};
 
 use anyhow::Result;
 use binius_circuits::builder::types::U;
@@ -43,8 +43,7 @@ impl PermutationTable {
 	pub fn new(cs: &mut ConstraintSystem) -> Self {
 		let mut table = cs.add_table("Keccak permutation");
 
-		let state_in = StateMatrix::from_fn(|(x, y)| table.add_committed(format!("in[{x},{y}]")));
-		let keccakf = keccak::Keccakf::new(&mut table, state_in);
+		let keccakf = keccak::Keccakf::new(&mut table);
 
 		Self {
 			table_id: table.id(),
@@ -58,7 +57,7 @@ where
 	P: PackedFieldIndexable<Scalar = B128> + PackedExtension<B1> + PackedExtension<B8>,
 	PackedSubfield<P, B8>: PackedTransformationFactory<PackedSubfield<P, B8>>,
 {
-	type Event = StateMatrix<u64>;
+	type Event = [u64; 25];
 
 	fn id(&self) -> TableId {
 		self.table_id
@@ -99,7 +98,7 @@ fn main() -> Result<()> {
 	};
 
 	let mut rng = thread_rng();
-	let events = repeat_with(|| StateMatrix::from_fn(|_| rng.next_u64()))
+	let events = repeat_with(|| array::from_fn::<u64, 25, _>(|_|rng.next_u64()))
 		.take(n_permutations)
 		.collect::<Vec<_>>();
 


### PR DESCRIPTION
Updated the keccak gadget to:

1. Expose the input and output columns to the gadget.
2. Change the interface for the constructor and populate methods.