### PR TITLE
[Fix] gkr_exp claims descending order

### DIFF
--- a/crates/core/src/constraint_system/exp.rs
+++ b/crates/core/src/constraint_system/exp.rs
@@ -12,7 +12,6 @@ use binius_macros::{DeserializeBytes, SerializeBytes};
 use binius_math::{MultilinearExtension, MultilinearPoly};
 use binius_maybe_rayon::prelude::*;
 use binius_utils::bail;
-use itertools::chain;
 use tracing::instrument;
 
 use super::{
@@ -68,16 +67,8 @@ where
 	PackedType<U, Tower::B128>: PackedTransformationFactory<PackedType<U, Tower::FastB128>>,
 	PackedType<U, Tower::FastB128>: PackedTransformationFactory<PackedType<U, Tower::B128>>,
 {
-	// Since dynamic witnesses may need the `exp_result` of static witnesses,
-	// we start processing with static ones first.
-	let static_exponents_iter = exponents
+	exponents
 		.iter()
-		.filter(|exp| matches!(exp.base, OracleOrConst::Const { .. }));
-	let dynamic_exponents_iter = exponents
-		.iter()
-		.filter(|exp| matches!(exp.base, OracleOrConst::Oracle(_)));
-
-	chain!(static_exponents_iter, dynamic_exponents_iter)
 		.map(|exp| {
 			let fast_exponent_witnesses =
 				get_fast_exponent_witnesses::<U, Tower>(witness, &exp.bits_ids)?;
@@ -138,25 +129,17 @@ pub fn make_claims<F>(
 where
 	F: TowerField,
 {
-	let static_exponents_iter = exponents
+	let constant_bases = exponents
 		.iter()
-		.filter(|exp| matches!(exp.base, OracleOrConst::Const { .. }));
-	let dynamic_exponents_iter = exponents
-		.iter()
-		.filter(|exp| matches!(exp.base, OracleOrConst::Oracle(_)));
-	let exponents_iter = chain!(static_exponents_iter, dynamic_exponents_iter);
-
-	let constant_bases = exponents_iter
-		.clone()
 		.map(|exp| match exp.base {
 			OracleOrConst::Const { base, .. } => Some(base),
 			OracleOrConst::Oracle(_) => None,
 		})
 		.collect::<Vec<_>>();
 
-	let exponents_ids = exponents_iter
-		.cloned()
-		.map(|exp| exp.bits_ids)
+	let exponents_ids = exponents
+		.iter()
+		.map(|exp| exp.bits_ids.clone())
 		.collect::<Vec<_>>();
 
 	gkr_exp::construct_gkr_exp_claims(&exponents_ids, evals, constant_bases, oracles, eval_point)
@@ -167,25 +150,17 @@ pub fn make_eval_claims<F: TowerField>(
 	exponents: &[Exp<F>],
 	base_exp_output: BaseExpReductionOutput<F>,
 ) -> Result<Vec<EvalcheckMultilinearClaim<F>>, Error> {
-	let static_exponents_iter = exponents
+	let dynamic_base_ids = exponents
 		.iter()
-		.filter(|exp| matches!(exp.base, OracleOrConst::Const { .. }));
-	let dynamic_exponents_iter = exponents
-		.iter()
-		.filter(|exp| matches!(exp.base, OracleOrConst::Oracle(_)));
-	let exponents_iter = chain!(static_exponents_iter, dynamic_exponents_iter);
-
-	let dynamic_base_ids = exponents_iter
-		.clone()
 		.map(|exp| match exp.base {
 			OracleOrConst::Const { .. } => None,
 			OracleOrConst::Oracle(base_id) => Some(base_id),
 		})
 		.collect::<Vec<_>>();
 
-	let metas = exponents_iter
-		.cloned()
-		.map(|exp| exp.bits_ids)
+	let metas = exponents
+		.iter()
+		.map(|exp| exp.bits_ids.clone())
 		.collect::<Vec<_>>();
 
 	gkr_exp::make_eval_claims(metas, base_exp_output, dynamic_base_ids).map_err(Error::from)
@@ -337,4 +312,13 @@ where
 				.map_err(Error::from)
 		})
 		.collect::<Result<Vec<_>, _>>()
+}
+
+pub fn reorder_exponents<F: Field>(exponents: &mut [Exp<F>]) {
+	// Since dynamic witnesses may need the `exp_result` of static witnesses,
+	// we start processing with static ones first.
+	exponents.sort_by_key(|exp| match exp.base {
+		OracleOrConst::Const { .. } => 0,
+		OracleOrConst::Oracle(_) => 1,
+	});
 }

--- a/crates/core/src/constraint_system/exp.rs
+++ b/crates/core/src/constraint_system/exp.rs
@@ -1,5 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 
+use std::cmp::Reverse;
+
 use binius_field::{
 	as_packed_field::{PackScalar, PackedType},
 	linear_transformation::{PackedTransformationFactory, Transformation},
@@ -314,11 +316,14 @@ where
 		.collect::<Result<Vec<_>, _>>()
 }
 
-pub fn reorder_exponents<F: Field>(exponents: &mut [Exp<F>]) {
+pub fn reorder_exponents<F: TowerField>(
+	exponents: &mut [Exp<F>],
+	oracles: &MultilinearOracleSet<F>,
+) {
 	// Since dynamic witnesses may need the `exp_result` of static witnesses,
 	// we start processing with static ones first.
 	exponents.sort_by_key(|exp| match exp.base {
-		OracleOrConst::Const { .. } => 0,
-		OracleOrConst::Oracle(_) => 1,
+		OracleOrConst::Const { .. } => (Reverse(exp.n_vars(oracles)), 0),
+		OracleOrConst::Oracle(_) => (Reverse(exp.n_vars(oracles)), 1),
 	});
 }

--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -20,7 +20,7 @@ use binius_maybe_rayon::prelude::*;
 use binius_ntt::SingleThreadedNTT;
 use binius_utils::bail;
 use digest::{core_api::BlockSizeUser, Digest, FixedOutputReset, Output};
-use itertools::{chain, izip, multiunzip};
+use itertools::chain;
 use tracing::instrument;
 
 use super::{
@@ -103,7 +103,7 @@ where
 		max_channel_id,
 	} = constraint_system.clone();
 
-	reorder_exponents(&mut exponents);
+	reorder_exponents(&mut exponents, &oracles);
 
 	// We must generate multiplication witnesses before committing, as this function
 	// adds the committed witnesses for exponentiation results to the witness index.
@@ -168,12 +168,6 @@ where
 		.into_iter()
 		.map(|claim| claim.isomorphic())
 		.collect::<Vec<_>>();
-
-	let mut exponents_witnesses_claims =
-		izip!(exponents, exp_witnesses, exp_claims,).collect::<Vec<_>>();
-	exponents_witnesses_claims.sort_by_key(|(_, _, claim)| std::cmp::Reverse(claim.n_vars));
-	let (exponents, exp_witnesses, exp_claims): (Vec<_>, Vec<_>, Vec<_>) =
-		multiunzip(exponents_witnesses_claims);
 
 	let base_exp_output = gkr_exp::batch_prove::<_, _, FFastExt<Tower>, _, _>(
 		EvaluationOrder::HighToLow,


### PR DESCRIPTION
Descending claim order was disrupted when dynamic claims began being processed after static ones — this PR restores the correct order.