### PR TITLE
Fold right HAL operation

### DIFF
--- a/crates/compute/src/cpu/layer.rs
+++ b/crates/compute/src/cpu/layer.rs
@@ -1050,7 +1050,7 @@ mod tests {
 			.copy_d2h(<C as ComputeLayer<F2>>::DevMem::as_const(&out_slice), out)
 			.unwrap();
 
-		let mut expected_out = out.iter().map(|x| *x).collect::<Vec<_>>();
+		let mut expected_out = out.iter().map(|_| F2::ZERO).collect::<Vec<_>>();
 		let evals_as_f1_slice = evals
 			.iter()
 			.flat_map(<F2 as ExtensionField<F>>::iter_bases)

--- a/crates/compute/src/layer.rs
+++ b/crates/compute/src/layer.rs
@@ -247,6 +247,37 @@ pub trait ComputeLayer<F: Field> {
 		out: &mut <Self::DevMem as ComputeMemory<F>>::FSliceMut<'_>,
 	) -> Result<(), Error>;
 
+	/// Computes right matrix-vector multiplication of a subfield matrix with a big field vector.
+	///
+	/// ## Mathematical Definition
+	///
+	/// This operation accepts
+	///
+	/// * $n \in \mathbb{N}$ (`vec.len()`),
+	/// * $m \in \mathbb{N}$ (`out.len()`),
+	/// * $M \in K^{n \times m}$ (`mat`),
+	/// * $v \in K^m$ (`vec`),
+	///
+	/// and computes the vector $((v')M)'$. The prime denotes a transpose
+	///
+	/// ## Args
+	///
+	/// * `mat` - a slice of elements from a subfield of `F`.
+	/// * `vec` - a slice of `F` elements.
+	/// * `out` - a buffer for the output vector of `F` elements.
+	///
+	/// ## Throws
+	///
+	/// * Returns an error if `mat.len()` does not equal `vec.len() * out.len()`.
+	/// * Returns an error if `mat` is not a subfield of `F`.
+	fn fold_right<'a>(
+		&'a self,
+		exec: &'a mut Self::Exec,
+		mat: SubfieldSlice<'_, F, Self::DevMem>,
+		vec: <Self::DevMem as ComputeMemory<F>>::FSlice<'_>,
+		out: &mut <Self::DevMem as ComputeMemory<F>>::FSliceMut<'_>,
+	) -> Result<(), Error>;
+
 	/// A kernel-local operation that evaluates a composition polynomial over several buffers,
 	/// row-wise, and returns the sum of the evaluations, scaled by a batching coefficient.
 	///


### PR DESCRIPTION
Added a fold_right operation to the HAL and tied it to a low-performance CPU implementation for testing. Also switched the naming conventions of rows/columns in the left folding implementations to stay consistent with the way those operations are conventionally done.