### PR TITLE
Update github CI pull_request types to support graphite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened]
 
 concurrency:
   group: ${{ github.event_name }}-${{ github.ref }}


### PR DESCRIPTION
The graphite docs recommend this change to the github action `on` spec:

https://graphite.dev/docs/github-configuration-guidelines#github-actions

This is because PRs are stacked and you want to run CI tests on all PRs
in the stack, not just those that are based on the main.

The `edited` type is excluded here because this event is triggered when
Graphite makes changes to PR metadata and we don't want this to trigger
a CI run.