### PR TITLE
gpa-high-to-low

### DIFF
--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -243,7 +243,7 @@ where
 
 	let GrandProductBatchProveOutput { final_layer_claims } =
 		gkr_gpa::batch_prove::<FFastExt<Tower>, _, FFastExt<Tower>, _, _>(
-			EvaluationOrder::LowToHigh,
+			EvaluationOrder::HighToLow,
 			all_gpa_witnesses,
 			&all_gpa_claims,
 			&fast_domain_factory,

--- a/crates/core/src/constraint_system/verify.rs
+++ b/crates/core/src/constraint_system/verify.rs
@@ -143,7 +143,7 @@ where
 
 	// Verify grand products
 	let final_layer_claims = gkr_gpa::batch_verify(
-		EvaluationOrder::LowToHigh,
+		EvaluationOrder::HighToLow,
 		[flush_prodcheck_claims, non_zero_prodcheck_claims].concat(),
 		&mut transcript,
 	)?;


### PR DESCRIPTION
### TL;DR

Changed the evaluation order in grand product argument from `LowToHigh` to `HighToLow`.

### What changed?

Modified the evaluation order parameter in both the proving and verification functions from `EvaluationOrder::LowToHigh` to `EvaluationOrder::HighToLow` in the grand product argument batch operations. This change affects:

- `batch_prove` in `prove.rs`
- `batch_verify` in `verify.rs`

### How to test?

Run the existing test suite to ensure that proofs are still generated and verified correctly with the new evaluation order:

```
cargo test
```

### Why make this change?

The `HighToLow` evaluation order likely provides better performance characteristics or improved security properties for the grand product argument. This change ensures consistent evaluation order between proving and verification steps, which is critical for the cryptographic protocol to function correctly.