### PR TITLE
[examples] Use fill_table_parallel instead of sequential

### DIFF
--- a/examples/groestl.rs
+++ b/examples/groestl.rs
@@ -108,7 +108,7 @@ fn main() -> Result<()> {
 
 	let trace_gen_scope = tracing::info_span!("generating trace").entered();
 	let mut witness = WitnessIndex::<PackedType<OptimalUnderlier, B128>>::new(&cs, &allocator);
-	witness.fill_table_sequential(&table, &events)?;
+	witness.fill_table_parallel(&table, &events)?;
 	drop(trace_gen_scope);
 
 	let ccs = cs.compile(&statement).unwrap();

--- a/examples/u32_mul_gkr.rs
+++ b/examples/u32_mul_gkr.rs
@@ -103,7 +103,7 @@ fn main() -> Result<()> {
 
 	let trace_gen_scope = tracing::info_span!("generating trace").entered();
 	let mut witness = WitnessIndex::<PackedType<OptimalUnderlier, B128>>::new(&cs, &allocator);
-	witness.fill_table_sequential(&table, &events)?;
+	witness.fill_table_parallel(&table, &events)?;
 
 	drop(trace_gen_scope);
 

--- a/examples/u64_mul.rs
+++ b/examples/u64_mul.rs
@@ -103,7 +103,7 @@ fn main() -> Result<()> {
 
 	let trace_gen_scope = tracing::info_span!("generating trace").entered();
 	let mut witness = WitnessIndex::<PackedType<OptimalUnderlier, B128>>::new(&cs, &allocator);
-	witness.fill_table_sequential(&table, &events)?;
+	witness.fill_table_parallel(&table, &events)?;
 
 	drop(trace_gen_scope);
 


### PR DESCRIPTION
This will speed up witness generation for examples in multithreaded configurations.