### PR TITLE
docs: add badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Binius is a Rust library implementing a cryptographic *succinct non-interactive 
 
 Comprehensive documentation is available at [binius.xyz](https://www.binius.xyz/).
 
+[![Docs](https://img.shields.io/badge/docs-up-green)](https://www.binius.xyz/)
+[![Twitter Irreducible](https://img.shields.io/twitter/follow/Irreducible?style=social)](https://x.com/IrreducibleHW)
+
 ## Usage
 
 At this stage, the primary interfaces are the unit tests and benchmarks. The benchmarks use the [criterion](https://docs.rs/criterion/0.3.4/criterion/) library.


### PR DESCRIPTION
This pull request adds two handy badges to the top of **README.md**:

* **Documentation badge** – points directly to hosted docs, making it super easy for new users (and contributors) to find detailed usage guides and API references with one click.
* **X (Twitter) badge** – links to project’s X account, helping visitors stay up-to-date on announcements, release notes, and community discussions.

Together, these badges boost project discoverability, streamline access to essential resources, and encourage community engagement—all without adding any maintenance overhead.
