### PR TITLE
[m3] fix underconstraining bug

### DIFF
--- a/crates/m3/src/gadgets/sub.rs
+++ b/crates/m3/src/gadgets/sub.rs
@@ -68,6 +68,14 @@ impl U32Sub {
 			.expose_final_borrow
 			.then(|| table.add_selected("final_borrow", bout, 31));
 
+		// Check that the equation holds:
+		//
+		//     (bin + (1 - xin)) * (bin + yin) + bin = bout
+		//
+		// Note that we can't use the actual expression does `xin - B1::ONE` because of the expr
+		// builder, but in tower fields the order does not matter.
+		table.assert_zero("borrow_out", (bin + (xin - B1::ONE)) * (bin + yin) + bin - bout);
+
 		let zout = if flags.commit_zout {
 			let zout = table.add_committed("zout");
 			table.assert_zero("zout", xin + yin + bin - zout);


### PR DESCRIPTION
Closes [CRY-347].

[CRY-347]: https://linear.app/irreducible/issue/CRY-347/m3-u32sub-gadgets-doesnt-constrain-borrow-out