### PR TITLE
[rust] Update from Rust 2021 to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 authors = ["Irreducible Team <opensource@irreducible.com>"]
 
 [workspace.lints.clippy]

--- a/crates/circuits/src/arithmetic/mul.rs
+++ b/crates/circuits/src/arithmetic/mul.rs
@@ -13,9 +13,9 @@ use std::array;
 use anyhow::Error;
 use binius_core::oracle::OracleId;
 use binius_field::{
+	BinaryField, BinaryField1b, BinaryField16b, BinaryField64b, Field, TowerField,
 	as_packed_field::PackedType,
 	packed::{get_packed_slice, set_packed_slice},
-	BinaryField, BinaryField16b, BinaryField1b, BinaryField64b, Field, TowerField,
 };
 use binius_macros::arith_expr;
 use binius_maybe_rayon::iter::{
@@ -26,8 +26,8 @@ use itertools::izip;
 
 use super::static_exp::u16_static_exp_lookups;
 use crate::builder::{
-	types::{F, U},
 	ConstraintSystemBuilder,
+	types::{F, U},
 };
 
 pub fn mul<FExpBase>(
@@ -405,13 +405,13 @@ mod tests {
 		constraint_system::{self},
 		fiat_shamir::HasherChallenger,
 	};
-	use binius_field::{tower::CanonicalTowerFamily, BinaryField1b, BinaryField8b};
+	use binius_field::{BinaryField1b, BinaryField8b, tower::CanonicalTowerFamily};
 	use binius_hal::make_portable_backend;
 	use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 
 	use super::mul;
 	use crate::{
-		builder::{types::U, ConstraintSystemBuilder},
+		builder::{ConstraintSystemBuilder, types::U},
 		unconstrained::unconstrained,
 	};
 

--- a/crates/circuits/src/arithmetic/static_exp.rs
+++ b/crates/circuits/src/arithmetic/static_exp.rs
@@ -2,14 +2,14 @@
 
 use anyhow::Ok;
 use binius_core::oracle::OracleId;
-use binius_field::{BinaryField128b, BinaryField16b, BinaryField64b, PackedField, TowerField};
+use binius_field::{BinaryField16b, BinaryField64b, BinaryField128b, PackedField, TowerField};
 use binius_maybe_rayon::{
 	iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator},
 	slice::ParallelSliceMut,
 };
 
 use crate::{
-	builder::{types::F, ConstraintSystemBuilder},
+	builder::{ConstraintSystemBuilder, types::F},
 	plain_lookup,
 };
 

--- a/crates/circuits/src/arithmetic/u32.rs
+++ b/crates/circuits/src/arithmetic/u32.rs
@@ -5,18 +5,18 @@ use binius_core::{
 	transparent::MultilinearExtensionTransparent,
 };
 use binius_field::{
-	as_packed_field::PackedType, packed::set_packed_slice, underlier::WithUnderlier, BinaryField1b,
-	BinaryField32b, Field, PackedField, TowerField,
+	BinaryField1b, BinaryField32b, Field, PackedField, TowerField, as_packed_field::PackedType,
+	packed::set_packed_slice, underlier::WithUnderlier,
 };
 use binius_macros::arith_expr;
 use binius_maybe_rayon::prelude::*;
 use binius_utils::checked_arithmetics::checked_log_2;
-use bytemuck::{pod_collect_to_vec, Pod};
+use bytemuck::{Pod, pod_collect_to_vec};
 
 use crate::{
 	builder::{
-		types::{F, U},
 		ConstraintSystemBuilder,
+		types::{F, U},
 	},
 	transparent,
 };

--- a/crates/circuits/src/blake3.rs
+++ b/crates/circuits/src/blake3.rs
@@ -8,7 +8,7 @@ use binius_utils::checked_arithmetics::log2_ceil_usize;
 
 use crate::{
 	arithmetic::u32::LOG_U32_BITS,
-	builder::{types::F, ConstraintSystemBuilder},
+	builder::{ConstraintSystemBuilder, types::F},
 };
 
 const STATE_SIZE: usize = 32;
@@ -503,10 +503,10 @@ pub fn blake3_compress(
 mod tests {
 	use std::array;
 
-	use rand::{rngs::StdRng, Rng, SeedableRng};
+	use rand::{Rng, SeedableRng, rngs::StdRng};
 
 	use crate::{
-		blake3::{blake3_compress, Blake3CompressState, F32, IV, MSG_PERMUTATION},
+		blake3::{Blake3CompressState, F32, IV, MSG_PERMUTATION, blake3_compress},
 		builder::test_utils::test_circuit,
 	};
 

--- a/crates/circuits/src/blake3.rs
+++ b/crates/circuits/src/blake3.rs
@@ -594,13 +594,13 @@ mod tests {
 			let mut expected = vec![];
 			let states = (0..compressions)
 				.map(|_| {
-					let cv: [u32; 8] = array::from_fn(|_| rng.gen::<u32>());
-					let block: [u32; 16] = array::from_fn(|_| rng.gen::<u32>());
-					let counter = rng.gen::<u64>();
+					let cv: [u32; 8] = array::from_fn(|_| rng.r#gen::<u32>());
+					let block: [u32; 16] = array::from_fn(|_| rng.r#gen::<u32>());
+					let counter = rng.r#gen::<u64>();
 					let counter_low = counter as u32;
 					let counter_high = (counter >> 32) as u32;
-					let block_len = rng.gen::<u32>();
-					let flags = rng.gen::<u32>();
+					let block_len = rng.r#gen::<u32>();
+					let flags = rng.r#gen::<u32>();
 
 					// save expected value to use later in test
 					expected.push(compress(&cv, &block, counter, block_len, flags).to_vec());

--- a/crates/circuits/src/builder/constraint_system.rs
+++ b/crates/circuits/src/builder/constraint_system.rs
@@ -5,9 +5,9 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc};
 use anyhow::{anyhow, ensure};
 use binius_core::{
 	constraint_system::{
+		ConstraintSystem,
 		channel::{ChannelId, Flush, FlushDirection, OracleOrConst},
 		exp::Exp,
-		ConstraintSystem,
 	},
 	oracle::{
 		ConstraintSetBuilder, Error as OracleError, MultilinearOracleSet, OracleId, ShiftVariant,
@@ -17,8 +17,8 @@ use binius_core::{
 	witness::MultilinearExtensionIndex,
 };
 use binius_field::{
-	as_packed_field::{PackScalar, PackedType},
 	BinaryField1b,
+	as_packed_field::{PackScalar, PackedType},
 };
 use binius_math::ArithCircuit;
 use binius_utils::bail;
@@ -86,7 +86,9 @@ impl<'arena> ConstraintSystemBuilder<'arena> {
 	) -> Result<MultilinearExtensionIndex<'arena, PackedType<U, F>>, anyhow::Error> {
 		Option::take(&mut self.witness)
 			.ok_or_else(|| {
-				anyhow!("Witness is missing. Are you in verifier mode, or have you already extraced the witness?")
+				anyhow!(
+					"Witness is missing. Are you in verifier mode, or have you already extraced the witness?"
+				)
 			})?
 			.build()
 	}

--- a/crates/circuits/src/builder/test_utils.rs
+++ b/crates/circuits/src/builder/test_utils.rs
@@ -2,7 +2,7 @@
 
 use binius_core::constraint_system::{channel::Boundary, validate::validate_witness};
 
-use super::{types::F, ConstraintSystemBuilder};
+use super::{ConstraintSystemBuilder, types::F};
 
 pub fn test_circuit(
 	build_circuit: fn(&mut ConstraintSystemBuilder) -> Result<Vec<Boundary<F>>, anyhow::Error>,

--- a/crates/circuits/src/builder/witness.rs
+++ b/crates/circuits/src/builder/witness.rs
@@ -2,19 +2,19 @@
 
 use std::{cell::RefCell, marker::PhantomData, rc::Rc};
 
-use anyhow::{anyhow, Error};
+use anyhow::{Error, anyhow};
 use binius_core::{
 	oracle::{MultilinearOracleSet, OracleId},
 	witness::{MultilinearExtensionIndex, MultilinearWitness},
 };
 use binius_field::{
+	ExtensionField, PackedField, TowerField,
 	as_packed_field::{PackScalar, PackedType},
 	underlier::WithUnderlier,
-	ExtensionField, PackedField, TowerField,
 };
 use binius_math::MultilinearExtension;
 use binius_utils::bail;
-use bytemuck::{must_cast_slice, must_cast_slice_mut, Pod};
+use bytemuck::{Pod, must_cast_slice, must_cast_slice_mut};
 
 use super::types::{F, U};
 

--- a/crates/circuits/src/collatz.rs
+++ b/crates/circuits/src/collatz.rs
@@ -5,7 +5,7 @@ use binius_core::{
 	oracle::OracleId,
 };
 use binius_field::{
-	as_packed_field::PackScalar, BinaryField1b, BinaryField32b, ExtensionField, TowerField,
+	BinaryField1b, BinaryField32b, ExtensionField, TowerField, as_packed_field::PackScalar,
 };
 use binius_macros::arith_expr;
 use bytemuck::Pod;
@@ -13,8 +13,8 @@ use bytemuck::Pod;
 use crate::{
 	arithmetic,
 	builder::{
-		types::{F, U},
 		ConstraintSystemBuilder,
+		types::{F, U},
 	},
 	transparent,
 };

--- a/crates/circuits/src/keccakf.rs
+++ b/crates/circuits/src/keccakf.rs
@@ -520,7 +520,7 @@ mod tests {
 		test_circuit(|builder| {
 			let log_size = 5;
 			let mut rng = StdRng::seed_from_u64(0);
-			let input_states = vec![KeccakfState(rng.gen())];
+			let input_states = vec![KeccakfState(rng.r#gen())];
 			let _state_out = keccakf(builder, &Some(input_states), log_size)?;
 			Ok(vec![])
 		})

--- a/crates/circuits/src/keccakf.rs
+++ b/crates/circuits/src/keccakf.rs
@@ -8,16 +8,16 @@ use binius_core::{
 	transparent::multilinear_extension::MultilinearExtensionTransparent,
 };
 use binius_field::{
-	as_packed_field::PackedType, underlier::WithUnderlier, BinaryField1b, BinaryField64b, Field,
-	PackedField, TowerField,
+	BinaryField1b, BinaryField64b, Field, PackedField, TowerField, as_packed_field::PackedType,
+	underlier::WithUnderlier,
 };
 use binius_macros::arith_expr;
-use bytemuck::{pod_collect_to_vec, Pod};
+use bytemuck::{Pod, pod_collect_to_vec};
 
 use crate::{
 	builder::{
-		types::{F, U},
 		ConstraintSystemBuilder,
+		types::{F, U},
 	},
 	transparent::step_down,
 };
@@ -510,9 +510,9 @@ const KECCAKF_RC: [u64; ROUNDS_PER_PERMUTATION] = [
 
 #[cfg(test)]
 mod tests {
-	use rand::{rngs::StdRng, Rng, SeedableRng};
+	use rand::{Rng, SeedableRng, rngs::StdRng};
 
-	use super::{keccakf, KeccakfState};
+	use super::{KeccakfState, keccakf};
 	use crate::builder::test_utils::test_circuit;
 
 	#[test]

--- a/crates/circuits/src/lasso/batch.rs
+++ b/crates/circuits/src/lasso/batch.rs
@@ -3,15 +3,15 @@
 use anyhow::Ok;
 use binius_core::oracle::OracleId;
 use binius_field::{
-	as_packed_field::{PackScalar, PackedType},
 	ExtensionField, PackedFieldIndexable, TowerField,
+	as_packed_field::{PackScalar, PackedType},
 };
 use itertools::Itertools;
 
 use super::lasso::lasso;
 use crate::builder::{
-	types::{F, U},
 	ConstraintSystemBuilder,
+	types::{F, U},
 };
 pub struct LookupBatch {
 	lookup_us: Vec<Vec<OracleId>>,

--- a/crates/circuits/src/lasso/big_integer_ops/byte_sliced_add.rs
+++ b/crates/circuits/src/lasso/big_integer_ops/byte_sliced_add.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::U512;
 use anyhow::Result;
 use binius_core::oracle::OracleId;
-use binius_field::{tower_levels::TowerLevel, BinaryField1b, BinaryField8b};
+use binius_field::{BinaryField1b, BinaryField8b, tower_levels::TowerLevel};
 
 use crate::{
 	builder::ConstraintSystemBuilder,

--- a/crates/circuits/src/lasso/big_integer_ops/byte_sliced_add_carryfree.rs
+++ b/crates/circuits/src/lasso/big_integer_ops/byte_sliced_add_carryfree.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::U512;
 use anyhow::Result;
 use binius_core::oracle::OracleId;
-use binius_field::{tower_levels::TowerLevel, BinaryField1b, BinaryField8b};
+use binius_field::{BinaryField1b, BinaryField8b, tower_levels::TowerLevel};
 
 use super::byte_sliced_add;
 use crate::{

--- a/crates/circuits/src/lasso/big_integer_ops/byte_sliced_double_conditional_increment.rs
+++ b/crates/circuits/src/lasso/big_integer_ops/byte_sliced_double_conditional_increment.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::U512;
 use anyhow::Result;
 use binius_core::oracle::OracleId;
-use binius_field::{tower_levels::TowerLevel, BinaryField1b, BinaryField8b};
+use binius_field::{BinaryField1b, BinaryField8b, tower_levels::TowerLevel};
 
 use crate::{
 	builder::ConstraintSystemBuilder,

--- a/crates/circuits/src/lasso/big_integer_ops/byte_sliced_modular_mul.rs
+++ b/crates/circuits/src/lasso/big_integer_ops/byte_sliced_modular_mul.rs
@@ -4,13 +4,13 @@ use alloy_primitives::U512;
 use anyhow::Result;
 use binius_core::{oracle::OracleId, transparent::constant::Constant};
 use binius_field::{
-	tower_levels::TowerLevel, underlier::WithUnderlier, BinaryField32b, BinaryField8b, TowerField,
+	BinaryField8b, BinaryField32b, TowerField, tower_levels::TowerLevel, underlier::WithUnderlier,
 };
 use binius_macros::arith_expr;
 
 use super::{byte_sliced_add_carryfree, byte_sliced_mul};
 use crate::{
-	builder::{types::F, ConstraintSystemBuilder},
+	builder::{ConstraintSystemBuilder, types::F},
 	lasso::{
 		batch::LookupBatch,
 		lookups::u8_arithmetic::{add_carryfree_lookup, add_lookup, dci_lookup, mul_lookup},

--- a/crates/circuits/src/lasso/big_integer_ops/byte_sliced_mul.rs
+++ b/crates/circuits/src/lasso/big_integer_ops/byte_sliced_mul.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::U512;
 use anyhow::Result;
 use binius_core::oracle::OracleId;
-use binius_field::{tower_levels::TowerLevel, BinaryField8b};
+use binius_field::{BinaryField8b, tower_levels::TowerLevel};
 
 use super::{byte_sliced_add, byte_sliced_double_conditional_increment};
 use crate::{

--- a/crates/circuits/src/lasso/big_integer_ops/byte_sliced_test_utils.rs
+++ b/crates/circuits/src/lasso/big_integer_ops/byte_sliced_test_utils.rs
@@ -27,7 +27,7 @@ type B8 = BinaryField8b;
 type B32 = BinaryField32b;
 
 pub fn random_u512(rng: &mut impl Rng) -> U512 {
-	let limbs = array::from_fn(|_| rng.gen());
+	let limbs = array::from_fn(|_| rng.r#gen());
 	U512::from_limbs(limbs)
 }
 
@@ -88,14 +88,14 @@ where
 				let mut y = random_u512(&mut rng);
 				y &= input_bitmask;
 
-				let mut c: bool = rng.gen();
+				let mut c: bool = rng.r#gen();
 
 				while (x + y + U512::from(c)) > input_bitmask {
 					x = random_u512(&mut rng);
 					x &= input_bitmask;
 					y = random_u512(&mut rng);
 					y &= input_bitmask;
-					c = rng.gen();
+					c = rng.r#gen();
 				}
 
 				for byte_idx in 0..WIDTH {

--- a/crates/circuits/src/lasso/big_integer_ops/byte_sliced_test_utils.rs
+++ b/crates/circuits/src/lasso/big_integer_ops/byte_sliced_test_utils.rs
@@ -5,9 +5,9 @@ use std::{array, fmt::Debug};
 use alloy_primitives::U512;
 use binius_core::oracle::OracleId;
 use binius_field::{
-	tower_levels::TowerLevel, BinaryField1b, BinaryField32b, BinaryField8b, Field, TowerField,
+	BinaryField1b, BinaryField8b, BinaryField32b, Field, TowerField, tower_levels::TowerLevel,
 };
-use rand::{rngs::StdRng, thread_rng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng, rngs::StdRng, thread_rng};
 
 use super::{
 	byte_sliced_add, byte_sliced_add_carryfree, byte_sliced_double_conditional_increment,

--- a/crates/circuits/src/lasso/big_integer_ops/mod.rs
+++ b/crates/circuits/src/lasso/big_integer_ops/mod.rs
@@ -16,7 +16,7 @@ pub use byte_sliced_mul::byte_sliced_mul;
 #[cfg(test)]
 mod tests {
 	use binius_field::tower_levels::{
-		TowerLevel1, TowerLevel16, TowerLevel2, TowerLevel4, TowerLevel8,
+		TowerLevel1, TowerLevel2, TowerLevel4, TowerLevel8, TowerLevel16,
 	};
 
 	use super::byte_sliced_test_utils::{

--- a/crates/circuits/src/lasso/lasso.rs
+++ b/crates/circuits/src/lasso/lasso.rs
@@ -1,21 +1,21 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use anyhow::{ensure, Error, Result};
+use anyhow::{Error, Result, ensure};
 use binius_core::{
 	constraint_system::channel::{ChannelId, OracleOrConst},
 	oracle::OracleId,
 };
 use binius_field::{
+	ExtensionField, Field, PackedField, TowerField,
 	as_packed_field::{PackScalar, PackedType},
 	packed::{get_packed_slice, set_packed_slice},
-	ExtensionField, Field, PackedField, TowerField,
 };
-use itertools::{izip, Itertools};
+use itertools::{Itertools, izip};
 
 use crate::{
 	builder::{
-		types::{F, U},
 		ConstraintSystemBuilder,
+		types::{F, U},
 	},
 	transparent,
 };

--- a/crates/circuits/src/lasso/lookups/u8_arithmetic.rs
+++ b/crates/circuits/src/lasso/lookups/u8_arithmetic.rs
@@ -149,7 +149,7 @@ pub fn dci_lookup(
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{BinaryField1b, BinaryField32b, BinaryField8b};
+	use binius_field::{BinaryField1b, BinaryField8b, BinaryField32b};
 
 	use crate::{
 		builder::test_utils::test_circuit,

--- a/crates/circuits/src/lasso/mod.rs
+++ b/crates/circuits/src/lasso/mod.rs
@@ -12,8 +12,8 @@ pub mod u8add_carryfree;
 pub mod u8mul;
 
 pub use sha256::sha256;
-pub use u32add::u32add;
 pub use u8_double_conditional_increment::u8_double_conditional_increment;
 pub use u8add::u8add;
 pub use u8add_carryfree::u8add_carryfree;
 pub use u8mul::u8mul;
+pub use u32add::u32add;

--- a/crates/circuits/src/lasso/sha256.rs
+++ b/crates/circuits/src/lasso/sha256.rs
@@ -3,19 +3,19 @@
 use anyhow::Result;
 use binius_core::oracle::OracleId;
 use binius_field::{
-	as_packed_field::PackedType, packed::packed_from_fn_with_offset, BinaryField16b, BinaryField1b,
-	BinaryField32b, BinaryField4b, PackedField, TowerField,
+	BinaryField1b, BinaryField4b, BinaryField16b, BinaryField32b, PackedField, TowerField,
+	as_packed_field::PackedType, packed::packed_from_fn_with_offset,
 };
 
 use super::{lasso::lasso, u32add::SeveralU32add};
 use crate::{
 	arithmetic::u32::u32const_repeating,
 	builder::{
-		types::{F, U},
 		ConstraintSystemBuilder,
+		types::{F, U},
 	},
 	pack::pack,
-	sha256::{rotate_and_xor, RotateRightType, INIT, ROUND_CONSTS_K},
+	sha256::{INIT, ROUND_CONSTS_K, RotateRightType, rotate_and_xor},
 };
 
 pub const CH_MAJ_T_LOG_SIZE: usize = 12;
@@ -288,7 +288,7 @@ pub fn sha256(
 #[cfg(test)]
 mod tests {
 	use binius_core::oracle::OracleId;
-	use binius_field::{as_packed_field::PackedType, BinaryField1b, BinaryField8b, TowerField};
+	use binius_field::{BinaryField1b, BinaryField8b, TowerField, as_packed_field::PackedType};
 	use sha2::{compress256, digest::generic_array::GenericArray};
 
 	use crate::{

--- a/crates/circuits/src/lasso/u32add.rs
+++ b/crates/circuits/src/lasso/u32add.rs
@@ -5,18 +5,18 @@ use std::marker::PhantomData;
 use anyhow::Result;
 use binius_core::oracle::{OracleId, ShiftVariant};
 use binius_field::{
+	BinaryField1b, BinaryField8b, BinaryField32b, ExtensionField, TowerField,
 	as_packed_field::PackScalar,
 	packed::{packed_from_fn_with_offset, set_packed_slice},
 	underlier::U1,
-	BinaryField1b, BinaryField32b, BinaryField8b, ExtensionField, TowerField,
 };
 use itertools::izip;
 
 use super::lasso::lasso;
 use crate::{
 	builder::{
-		types::{F, U},
 		ConstraintSystemBuilder,
+		types::{F, U},
 	},
 	pack::pack,
 };

--- a/crates/circuits/src/lasso/u8_double_conditional_increment.rs
+++ b/crates/circuits/src/lasso/u8_double_conditional_increment.rs
@@ -2,10 +2,10 @@
 
 use anyhow::Result;
 use binius_core::oracle::OracleId;
-use binius_field::{BinaryField1b, BinaryField32b, BinaryField8b, TowerField};
+use binius_field::{BinaryField1b, BinaryField8b, BinaryField32b, TowerField};
 
 use super::batch::LookupBatch;
-use crate::builder::{types::F, ConstraintSystemBuilder};
+use crate::builder::{ConstraintSystemBuilder, types::F};
 
 type B1 = BinaryField1b;
 type B8 = BinaryField8b;

--- a/crates/circuits/src/lasso/u8add.rs
+++ b/crates/circuits/src/lasso/u8add.rs
@@ -4,10 +4,10 @@ use std::vec;
 
 use anyhow::Result;
 use binius_core::oracle::OracleId;
-use binius_field::{BinaryField1b, BinaryField32b, BinaryField8b, TowerField};
+use binius_field::{BinaryField1b, BinaryField8b, BinaryField32b, TowerField};
 
 use super::batch::LookupBatch;
-use crate::builder::{types::F, ConstraintSystemBuilder};
+use crate::builder::{ConstraintSystemBuilder, types::F};
 
 type B1 = BinaryField1b;
 type B8 = BinaryField8b;

--- a/crates/circuits/src/lasso/u8add_carryfree.rs
+++ b/crates/circuits/src/lasso/u8add_carryfree.rs
@@ -2,10 +2,10 @@
 
 use anyhow::Result;
 use binius_core::oracle::OracleId;
-use binius_field::{BinaryField1b, BinaryField32b, BinaryField8b, TowerField};
+use binius_field::{BinaryField1b, BinaryField8b, BinaryField32b, TowerField};
 
 use super::batch::LookupBatch;
-use crate::builder::{types::F, ConstraintSystemBuilder};
+use crate::builder::{ConstraintSystemBuilder, types::F};
 
 type B1 = BinaryField1b;
 type B8 = BinaryField8b;

--- a/crates/circuits/src/lasso/u8mul.rs
+++ b/crates/circuits/src/lasso/u8mul.rs
@@ -1,12 +1,12 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 use binius_core::oracle::OracleId;
-use binius_field::{BinaryField16b, BinaryField32b, BinaryField8b, TowerField};
+use binius_field::{BinaryField8b, BinaryField16b, BinaryField32b, TowerField};
 use itertools::izip;
 
 use super::batch::LookupBatch;
-use crate::builder::{types::F, ConstraintSystemBuilder};
+use crate::builder::{ConstraintSystemBuilder, types::F};
 
 type B8 = BinaryField8b;
 type B16 = BinaryField16b;

--- a/crates/circuits/src/lib.rs
+++ b/crates/circuits/src/lib.rs
@@ -28,16 +28,16 @@ mod tests {
 	use binius_core::{
 		constraint_system::{
 			self,
-			channel::{validate_witness, Boundary, FlushDirection, OracleOrConst},
+			channel::{Boundary, FlushDirection, OracleOrConst, validate_witness},
 		},
 		fiat_shamir::HasherChallenger,
 		oracle::{OracleId, ShiftVariant},
 		polynomial::ArithCircuitPoly,
 	};
 	use binius_field::{
+		BinaryField1b, BinaryField8b, BinaryField64b, BinaryField128b, Field, TowerField,
 		arch::OptimalUnderlier, as_packed_field::PackedType, tower::CanonicalTowerFamily,
-		underlier::WithUnderlier, BinaryField128b, BinaryField1b, BinaryField64b, BinaryField8b,
-		Field, TowerField,
+		underlier::WithUnderlier,
 	};
 	use binius_hal::make_portable_backend;
 	use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
@@ -50,9 +50,9 @@ mod tests {
 
 	use crate::{
 		builder::{
+			ConstraintSystemBuilder,
 			test_utils::test_circuit,
 			types::{F, U},
-			ConstraintSystemBuilder,
 		},
 		unconstrained::unconstrained,
 	};

--- a/crates/circuits/src/pack.rs
+++ b/crates/circuits/src/pack.rs
@@ -2,11 +2,11 @@
 
 use anyhow::Result;
 use binius_core::oracle::OracleId;
-use binius_field::{as_packed_field::PackScalar, ExtensionField, TowerField};
+use binius_field::{ExtensionField, TowerField, as_packed_field::PackScalar};
 
 use crate::builder::{
-	types::{F, U},
 	ConstraintSystemBuilder,
+	types::{F, U},
 };
 
 pub fn pack<FInput, FOutput>(

--- a/crates/circuits/src/plain_lookup.rs
+++ b/crates/circuits/src/plain_lookup.rs
@@ -2,22 +2,22 @@
 
 use std::{cmp::Reverse, fmt::Debug, hash::Hash};
 
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 use binius_core::{
 	constraint_system::channel::{FlushDirection, OracleOrConst},
 	oracle::OracleId,
 };
 use binius_field::{
+	BinaryField1b, ExtensionField, Field, PackedField, TowerField,
 	as_packed_field::PackScalar,
 	packed::{get_packed_slice, set_packed_slice},
-	BinaryField1b, ExtensionField, Field, PackedField, TowerField,
 };
 use bytemuck::Pod;
 use itertools::izip;
 
 use crate::builder::{
-	types::{F, U},
 	ConstraintSystemBuilder,
+	types::{F, U},
 };
 
 /// A gadget validating the lookup relation between:
@@ -189,7 +189,7 @@ where
 #[cfg(test)]
 pub mod test_plain_lookup {
 	use binius_field::BinaryField32b;
-	use rand::{rngs::StdRng, SeedableRng};
+	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 	use crate::transparent;

--- a/crates/circuits/src/sha256.rs
+++ b/crates/circuits/src/sha256.rs
@@ -1,14 +1,14 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_core::oracle::{OracleId, ShiftVariant};
-use binius_field::{as_packed_field::PackedType, BinaryField1b, Field, TowerField};
+use binius_field::{BinaryField1b, Field, TowerField, as_packed_field::PackedType};
 use binius_macros::arith_expr;
 use itertools::izip;
 
 use crate::{
 	arithmetic,
-	arithmetic::u32::{u32const_repeating, LOG_U32_BITS},
-	builder::{types::U, ConstraintSystemBuilder},
+	arithmetic::u32::{LOG_U32_BITS, u32const_repeating},
+	builder::{ConstraintSystemBuilder, types::U},
 };
 
 type B1 = BinaryField1b;
@@ -260,7 +260,7 @@ pub fn sha256(
 #[cfg(test)]
 mod tests {
 	use binius_core::oracle::OracleId;
-	use binius_field::{as_packed_field::PackedType, BinaryField1b};
+	use binius_field::{BinaryField1b, as_packed_field::PackedType};
 	use sha2::{compress256, digest::generic_array::GenericArray};
 
 	use crate::{

--- a/crates/circuits/src/transparent.rs
+++ b/crates/circuits/src/transparent.rs
@@ -2,13 +2,13 @@
 
 use binius_core::{oracle::OracleId, transparent};
 use binius_field::{
-	as_packed_field::{PackScalar, PackedType},
 	BinaryField1b, ExtensionField, PackedField, TowerField,
+	as_packed_field::{PackScalar, PackedType},
 };
 
 use crate::builder::{
-	types::{F, U},
 	ConstraintSystemBuilder,
+	types::{F, U},
 };
 
 pub fn step_down(

--- a/crates/circuits/src/u32fib.rs
+++ b/crates/circuits/src/u32fib.rs
@@ -30,10 +30,10 @@ pub fn u32fib(
 
 		let mut rng = thread_rng();
 		let current = current.as_mut_slice::<u32>();
-		current[0] = rng.gen();
-		current[1] = rng.gen();
+		current[0] = rng.r#gen();
+		current[1] = rng.r#gen();
 		for i in 2..current.len() {
-			current[i] = rng.gen();
+			current[i] = rng.r#gen();
 			(current[i], _) = current[i - 1].overflowing_add(current[i - 2]);
 		}
 		(next.as_mut_slice::<u32>(), &current[1..])

--- a/crates/circuits/src/u32fib.rs
+++ b/crates/circuits/src/u32fib.rs
@@ -4,11 +4,11 @@ use binius_core::oracle::{OracleId, ShiftVariant};
 use binius_field::{BinaryField1b, BinaryField32b, TowerField};
 use binius_macros::arith_expr;
 use binius_maybe_rayon::prelude::*;
-use rand::{thread_rng, Rng};
+use rand::{Rng, thread_rng};
 
 use crate::{
 	arithmetic,
-	builder::{types::F, ConstraintSystemBuilder},
+	builder::{ConstraintSystemBuilder, types::F},
 	transparent::step_down,
 };
 

--- a/crates/circuits/src/unconstrained.rs
+++ b/crates/circuits/src/unconstrained.rs
@@ -28,7 +28,7 @@ where
 			.as_mut_slice::<u8>()
 			.into_par_iter()
 			.for_each_init(thread_rng, |rng, data| {
-				*data = rng.gen();
+				*data = rng.r#gen();
 			});
 	}
 

--- a/crates/circuits/src/unconstrained.rs
+++ b/crates/circuits/src/unconstrained.rs
@@ -1,13 +1,13 @@
 // Copyright 2024-2025 Irreducible Inc.
 use binius_core::oracle::OracleId;
-use binius_field::{as_packed_field::PackScalar, ExtensionField, TowerField};
+use binius_field::{ExtensionField, TowerField, as_packed_field::PackScalar};
 use binius_maybe_rayon::prelude::*;
 use bytemuck::Pod;
-use rand::{thread_rng, Rng};
+use rand::{Rng, thread_rng};
 
 use crate::builder::{
-	types::{F, U},
 	ConstraintSystemBuilder,
+	types::{F, U},
 };
 
 pub fn unconstrained<FS>(

--- a/crates/circuits/src/vision.rs
+++ b/crates/circuits/src/vision.rs
@@ -12,16 +12,17 @@ use std::array;
 use anyhow::Result;
 use binius_core::{oracle::OracleId, transparent::constant::Constant};
 use binius_field::{
+	BinaryField1b, BinaryField32b, ExtensionField, Field, PackedAESBinaryField8x32b,
+	PackedBinaryField8x32b, PackedExtension, PackedField, TowerField,
 	linear_transformation::Transformation, make_aes_to_binary_packed_transformer,
-	packed::get_packed_slice, BinaryField1b, BinaryField32b, ExtensionField, Field,
-	PackedAESBinaryField8x32b, PackedBinaryField8x32b, PackedExtension, PackedField, TowerField,
+	packed::get_packed_slice,
 };
-use binius_hash::{Vision32MDSTransform, INV_PACKED_TRANS_AES};
+use binius_hash::{INV_PACKED_TRANS_AES, Vision32MDSTransform};
 use binius_macros::arith_expr;
 use binius_math::{ArithCircuit, ArithExpr};
 use bytemuck::must_cast_slice;
 
-use crate::builder::{types::F, ConstraintSystemBuilder};
+use crate::builder::{ConstraintSystemBuilder, types::F};
 
 pub fn vision_permutation(
 	builder: &mut ConstraintSystemBuilder,
@@ -68,7 +69,7 @@ pub fn vision_permutation(
 
 	#[cfg(debug_assertions)]
 	if let Some(witness) = builder.witness() {
-		use binius_hash::{permutation::Permutation, Vision32bPermutation};
+		use binius_hash::{Vision32bPermutation, permutation::Permutation};
 
 		let vision_perm = Vision32bPermutation::default();
 		let p_in_data: [_; STATE_SIZE] =

--- a/crates/compute/src/cpu/layer.rs
+++ b/crates/compute/src/cpu/layer.rs
@@ -3,10 +3,10 @@
 use std::marker::PhantomData;
 
 use binius_field::{
-	tower::TowerFamily, util::inner_product_unchecked, BinaryField, ExtensionField, Field,
-	TowerField,
+	BinaryField, ExtensionField, Field, TowerField, tower::TowerFamily,
+	util::inner_product_unchecked,
 };
-use binius_math::{extrapolate_line_scalar, ArithCircuit, ArithExpr};
+use binius_math::{ArithCircuit, ArithExpr, extrapolate_line_scalar};
 use binius_ntt::AdditiveNTT;
 use binius_utils::checked_arithmetics::checked_log_2;
 use bytemuck::zeroed_vec;
@@ -543,11 +543,11 @@ mod tests {
 
 	use binius_core::protocols::fri::fold_interleaved;
 	use binius_field::{
-		tower::CanonicalTowerFamily, BinaryField128b, BinaryField16b, BinaryField32b,
-		ExtensionField, Field, PackedExtension, PackedField, TowerField,
+		BinaryField16b, BinaryField32b, BinaryField128b, ExtensionField, Field, PackedExtension,
+		PackedField, TowerField, tower::CanonicalTowerFamily,
 	};
-	use binius_math::{tensor_prod_eq_ind, MultilinearExtension, MultilinearQuery};
-	use rand::{prelude::StdRng, SeedableRng};
+	use binius_math::{MultilinearExtension, MultilinearQuery, tensor_prod_eq_ind};
+	use rand::{SeedableRng, prelude::StdRng};
 
 	use super::*;
 	use crate::{

--- a/crates/compute/src/layer.rs
+++ b/crates/compute/src/layer.rs
@@ -467,8 +467,8 @@ pub type FSliceMut<'a, F, HAL> =
 #[cfg(test)]
 mod tests {
 	use assert_matches::assert_matches;
-	use binius_field::{tower::CanonicalTowerFamily, BinaryField128b, Field, TowerField};
-	use rand::{prelude::StdRng, SeedableRng};
+	use binius_field::{BinaryField128b, Field, TowerField, tower::CanonicalTowerFamily};
+	use rand::{SeedableRng, prelude::StdRng};
 
 	use super::*;
 	use crate::{

--- a/crates/core/benches/binary_merkle_tree.rs
+++ b/crates/core/benches/binary_merkle_tree.rs
@@ -5,12 +5,12 @@ use std::iter::repeat_with;
 use binius_core::merkle_tree::{BinaryMerkleTreeProver, MerkleTreeProver};
 use binius_field::{BinaryField128b, Field};
 use binius_hash::{
+	PseudoCompressionFunction, Vision32Compression, Vision32ParallelDigest, VisionHasherDigest,
 	groestl::{Groestl256, Groestl256ByteCompression},
 	multi_digest::ParallelDigest,
-	PseudoCompressionFunction, Vision32Compression, Vision32ParallelDigest, VisionHasherDigest,
 };
-use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use digest::{core_api::BlockSizeUser, FixedOutputReset, Output};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use digest::{FixedOutputReset, Output, core_api::BlockSizeUser};
 use rand::thread_rng;
 
 const LOG_ELEMS: usize = 17;

--- a/crates/core/benches/composition_poly.rs
+++ b/crates/core/benches/composition_poly.rs
@@ -4,13 +4,13 @@ use std::iter::repeat_with;
 
 use binius_core::polynomial::ArithCircuitPoly;
 use binius_field::{
-	BinaryField1b, Field, PackedBinaryField128x1b, PackedBinaryField16x8b, PackedBinaryField1x128b,
+	BinaryField1b, Field, PackedBinaryField1x128b, PackedBinaryField16x8b, PackedBinaryField128x1b,
 	PackedField,
 };
 use binius_macros::{arith_circuit_poly, composition_poly};
 use binius_math::{ArithExpr as Expr, CompositionPoly, RowsBatchRef};
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use rand::{thread_rng, RngCore};
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use rand::{RngCore, thread_rng};
 
 const BATCH_SIZE: usize = 256;
 

--- a/crates/core/benches/multilinear_query.rs
+++ b/crates/core/benches/multilinear_query.rs
@@ -1,15 +1,15 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_field::{
-	arch::ArchOptimal, BinaryField, BinaryField128b, BinaryField1b, ExtensionField, Field,
-	PackedField,
+	BinaryField, BinaryField1b, BinaryField128b, ExtensionField, Field, PackedField,
+	arch::ArchOptimal,
 };
-use binius_hal::{make_portable_backend, ComputationBackend, ComputationBackendExt};
+use binius_hal::{ComputationBackend, ComputationBackendExt, make_portable_backend};
 use binius_math::MultilinearExtension;
 use criterion::{
-	criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, Throughput,
+	BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
-use rand::{thread_rng, Rng};
+use rand::{Rng, thread_rng};
 
 type B1Packed = <BinaryField1b as ArchOptimal>::OptimalThroughputPacked;
 type B128Packed = <BinaryField128b as ArchOptimal>::OptimalThroughputPacked;

--- a/crates/core/benches/poly_commit.rs
+++ b/crates/core/benches/poly_commit.rs
@@ -9,14 +9,14 @@ use binius_core::{
 	protocols::{fri, fri::FRIParams},
 };
 use binius_field::{
-	packed::set_packed_slice, AESTowerField128b, AESTowerField32b, BinaryField, BinaryField128b,
-	BinaryField32b, ByteSlicedAES16x128b, ByteSlicedAES32x128b, ByteSlicedAES64x128b,
-	ExtensionField, PackedBinaryField1x128b, PackedExtension, PackedField, TowerField,
+	AESTowerField32b, AESTowerField128b, BinaryField, BinaryField32b, BinaryField128b,
+	ByteSlicedAES16x128b, ByteSlicedAES32x128b, ByteSlicedAES64x128b, ExtensionField,
+	PackedBinaryField1x128b, PackedExtension, PackedField, TowerField, packed::set_packed_slice,
 };
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_math::{MLEDirectAdapter, MultilinearExtension, MultilinearPoly};
 use binius_ntt::SingleThreadedNTT;
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use itertools::Itertools;
 use rand::thread_rng;
 

--- a/crates/core/benches/prodcheck.rs
+++ b/crates/core/benches/prodcheck.rs
@@ -8,19 +8,19 @@ use binius_core::{
 	transcript::ProverTranscript,
 };
 use binius_field::{
+	AESTowerField8b, AESTowerField128b, BINARY_TO_POLYVAL_TRANSFORMATION, BinaryField,
+	BinaryField8b, BinaryField128b, BinaryField128bPolyval, PackedExtension, PackedField,
+	PackedFieldIndexable, TowerField,
 	arch::{OptimalUnderlier, OptimalUnderlierByteSliced},
 	as_packed_field::{PackScalar, PackedType},
 	linear_transformation::{PackedTransformationFactory, Transformation},
-	AESTowerField128b, AESTowerField8b, BinaryField, BinaryField128b, BinaryField128bPolyval,
-	BinaryField8b, PackedExtension, PackedField, PackedFieldIndexable, TowerField,
-	BINARY_TO_POLYVAL_TRANSFORMATION,
 };
-use binius_hal::{make_portable_backend, CpuBackend};
+use binius_hal::{CpuBackend, make_portable_backend};
 use binius_hash::groestl::Groestl256;
 use binius_math::{EvaluationOrder, IsomorphicEvaluationDomainFactory};
 use binius_maybe_rayon::iter::{IntoParallelIterator, ParallelIterator};
-use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use rand::{rngs::StdRng, SeedableRng};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use rand::{SeedableRng, rngs::StdRng};
 
 // Creates T(x), a multilinear with evaluations over the n-dimensional boolean hypercube
 fn create_numerator<P: PackedField>(n_vars: usize) -> Vec<P> {

--- a/crates/core/benches/sumcheck.rs
+++ b/crates/core/benches/sumcheck.rs
@@ -6,13 +6,13 @@ use binius_core::{
 	composition::BivariateProduct,
 	fiat_shamir::HasherChallenger,
 	polynomial::MultilinearComposite,
-	protocols::sumcheck::{batch_prove, prove::RegularSumcheckProver, CompositeSumClaim},
+	protocols::sumcheck::{CompositeSumClaim, batch_prove, prove::RegularSumcheckProver},
 	transcript::ProverTranscript,
 };
 use binius_field::{
-	arch::OptimalUnderlier, as_packed_field::PackedType, AESTowerField8b, BinaryField,
-	BinaryField128b, BinaryField128bPolyval, BinaryField8b, ByteSlicedAES32x128b, ExtensionField,
-	PackedExtension, PackedField, TowerField,
+	AESTowerField8b, BinaryField, BinaryField8b, BinaryField128b, BinaryField128bPolyval,
+	ByteSlicedAES32x128b, ExtensionField, PackedExtension, PackedField, TowerField,
+	arch::OptimalUnderlier, as_packed_field::PackedType,
 };
 use binius_hal::make_portable_backend;
 use binius_hash::groestl::Groestl256;
@@ -20,7 +20,7 @@ use binius_math::{
 	EvaluationOrder, IsomorphicEvaluationDomainFactory, MLEDirectAdapter, MultilinearExtension,
 };
 use binius_maybe_rayon::prelude::*;
-use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use rand::thread_rng;
 
 fn bench_bivariate_with_evaluation_order<

--- a/crates/core/src/constraint_system/channel.rs
+++ b/crates/core/src/constraint_system/channel.rs
@@ -215,7 +215,7 @@ where
 			let unbalanced_flushes: Vec<_> = channel
 				.multiplicities
 				.iter()
-				.filter(|(_, &c)| c != 0i64)
+				.filter(|(_, c)| **c != 0i64)
 				.collect();
 
 			tracing::debug!("Channel {:?} unbalanced: {:?}", id, unbalanced_flushes);

--- a/crates/core/src/constraint_system/error.rs
+++ b/crates/core/src/constraint_system/error.rs
@@ -11,9 +11,7 @@ use crate::{
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-	#[error(
-		"flush selector with id {oracle} must have tower level 0 instead of {got_tower_level}"
-	)]
+	#[error("flush selector with id {oracle} must have tower level 0 instead of {got_tower_level}")]
 	FlushSelectorTowerLevel {
 		oracle: OracleId,
 		got_tower_level: usize,
@@ -22,10 +20,14 @@ pub enum Error {
 	#[error("flushes must have a non-empty list of oracles")]
 	EmptyFlushOracles,
 
-	#[error("All flushes within a channel must have the same width. Expected flushed values with length {expected}, got {got}")]
+	#[error(
+		"All flushes within a channel must have the same width. Expected flushed values with length {expected}, got {got}"
+	)]
 	ChannelFlushWidthMismatch { expected: usize, got: usize },
 
-	#[error("All oracles within a single flush must have the same n_vars. Expected oracle with n_vars={expected} got {got}")]
+	#[error(
+		"All oracles within a single flush must have the same n_vars. Expected oracle with n_vars={expected} got {got}"
+	)]
 	ChannelFlushNvarsMismatch { expected: usize, got: usize },
 
 	#[error("Channel id out of range. Got {got}, expected max={max}")]
@@ -38,7 +40,9 @@ pub enum Error {
 		reason: String,
 	},
 
-	#[error("{oracle} witness has unexpected n_vars={witness_num_vars}. Expected n_vars={oracle_num_vars}")]
+	#[error(
+		"{oracle} witness has unexpected n_vars={witness_num_vars}. Expected n_vars={oracle_num_vars}"
+	)]
 	VirtualOracleNvarsMismatch {
 		oracle: String,
 		oracle_num_vars: usize,

--- a/crates/core/src/constraint_system/exp.rs
+++ b/crates/core/src/constraint_system/exp.rs
@@ -3,12 +3,12 @@
 use std::cmp::Reverse;
 
 use binius_field::{
+	ExtensionField, Field, PackedExtension, PackedField, RepackedExtension, TowerField,
 	as_packed_field::{PackScalar, PackedType},
 	linear_transformation::{PackedTransformationFactory, Transformation},
 	packed::get_packed_slice_checked,
 	tower::{ProverTowerFamily, ProverTowerUnderlier},
 	underlier::WithUnderlier,
-	ExtensionField, Field, PackedExtension, PackedField, RepackedExtension, TowerField,
 };
 use binius_macros::{DeserializeBytes, SerializeBytes};
 use binius_math::{MultilinearExtension, MultilinearPoly};

--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -3,12 +3,12 @@
 use std::{env, marker::PhantomData};
 
 use binius_field::{
+	BinaryField, ExtensionField, Field, PackedExtension, PackedField, PackedFieldIndexable,
+	RepackedExtension, TowerField,
 	as_packed_field::PackedType,
 	linear_transformation::{PackedTransformationFactory, Transformation},
 	tower::{PackedTop, ProverTowerFamily, ProverTowerUnderlier},
 	underlier::WithUnderlier,
-	BinaryField, ExtensionField, Field, PackedExtension, PackedField, PackedFieldIndexable,
-	RepackedExtension, TowerField,
 };
 use binius_hal::ComputationBackend;
 use binius_hash::PseudoCompressionFunction;
@@ -19,15 +19,15 @@ use binius_math::{
 use binius_maybe_rayon::prelude::*;
 use binius_ntt::SingleThreadedNTT;
 use binius_utils::bail;
-use digest::{core_api::BlockSizeUser, Digest, FixedOutputReset, Output};
+use digest::{Digest, FixedOutputReset, Output, core_api::BlockSizeUser};
 use itertools::chain;
 use tracing::instrument;
 
 use super::{
+	ConstraintSystem, Proof,
 	channel::Boundary,
 	error::Error,
 	verify::{make_flush_oracles, max_n_vars_and_skip_rounds},
-	ConstraintSystem, Proof,
 };
 use crate::{
 	constraint_system::{

--- a/crates/core/src/constraint_system/validate.rs
+++ b/crates/core/src/constraint_system/validate.rs
@@ -6,9 +6,9 @@ use binius_math::MultilinearPoly;
 use binius_utils::bail;
 
 use super::{
+	ConstraintSystem,
 	channel::{self, Boundary},
 	error::Error,
-	ConstraintSystem,
 };
 use crate::{
 	oracle::{
@@ -16,7 +16,7 @@ use crate::{
 		ShiftVariant,
 	},
 	polynomial::{
-		test_utils::decompose_index_to_hypercube_point, ArithCircuitPoly, MultilinearComposite,
+		ArithCircuitPoly, MultilinearComposite, test_utils::decompose_index_to_hypercube_point,
 	},
 	protocols::sumcheck::prove::zerocheck,
 	witness::MultilinearExtensionIndex,

--- a/crates/core/src/constraint_system/validate.rs
+++ b/crates/core/src/constraint_system/validate.rs
@@ -234,7 +234,7 @@ where
 				)?;
 			}
 		}
-		MultilinearPolyVariant::Packed(ref packed) => {
+		MultilinearPolyVariant::Packed(packed) => {
 			let expected = witness.get_multilin_poly(packed.id())?;
 			let got = witness.get_multilin_poly(oracle.id())?;
 			if expected.packed_evals() != got.packed_evals() {

--- a/crates/core/src/constraint_system/verify.rs
+++ b/crates/core/src/constraint_system/verify.rs
@@ -1,21 +1,21 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_field::{
-	tower::{PackedTop, TowerFamily, TowerUnderlier},
 	BinaryField, PackedField, TowerField,
+	tower::{PackedTop, TowerFamily, TowerUnderlier},
 };
 use binius_hash::PseudoCompressionFunction;
 use binius_math::{ArithExpr, CompositionPoly, EvaluationOrder};
 use binius_utils::{bail, checked_arithmetics::log2_ceil_usize};
-use digest::{core_api::BlockSizeUser, Digest, Output};
-use itertools::{chain, Itertools};
+use digest::{Digest, Output, core_api::BlockSizeUser};
+use itertools::{Itertools, chain};
 use tracing::instrument;
 
 use super::{
+	ConstraintSystem, Proof,
 	channel::{Boundary, OracleOrConst},
 	error::{Error, VerificationError},
 	exp::{self, reorder_exponents},
-	ConstraintSystem, Proof,
 };
 use crate::{
 	constraint_system::{
@@ -30,7 +30,7 @@ use crate::{
 		gkr_exp,
 		gkr_gpa::{self},
 		greedy_evalcheck,
-		sumcheck::{self, constraint_set_zerocheck_claim, ZerocheckClaim},
+		sumcheck::{self, ZerocheckClaim, constraint_set_zerocheck_claim},
 	},
 	ring_switch,
 	transcript::VerifierTranscript,

--- a/crates/core/src/fiat_shamir/hasher_challenger.rs
+++ b/crates/core/src/fiat_shamir/hasher_challenger.rs
@@ -2,10 +2,10 @@
 
 use std::{cmp::min, mem};
 
-use bytes::{buf::UninitSlice, Buf, BufMut};
+use bytes::{Buf, BufMut, buf::UninitSlice};
 use digest::{
-	core_api::{Block, BlockSizeUser},
 	Digest, FixedOutputReset, Output,
+	core_api::{Block, BlockSizeUser},
 };
 
 use super::Challenger;
@@ -202,7 +202,7 @@ where
 #[cfg(test)]
 mod tests {
 	use binius_hash::groestl::Groestl256;
-	use rand::{thread_rng, RngCore};
+	use rand::{RngCore, thread_rng};
 
 	use super::*;
 

--- a/crates/core/src/merkle_tree/binary_merkle_tree.rs
+++ b/crates/core/src/merkle_tree/binary_merkle_tree.rs
@@ -223,5 +223,5 @@ where
 ///
 /// [`assume_init_mut`]: MaybeUninit::assume_init_mut
 pub const unsafe fn slice_assume_init_mut<T>(slice: &mut [MaybeUninit<T>]) -> &mut [T] {
-	std::mem::transmute(slice)
+	unsafe { std::mem::transmute(slice) }
 }

--- a/crates/core/src/merkle_tree/binary_merkle_tree.rs
+++ b/crates/core/src/merkle_tree/binary_merkle_tree.rs
@@ -3,10 +3,10 @@
 use std::{array, fmt::Debug, mem::MaybeUninit};
 
 use binius_field::TowerField;
-use binius_hash::{multi_digest::ParallelDigest, PseudoCompressionFunction};
+use binius_hash::{PseudoCompressionFunction, multi_digest::ParallelDigest};
 use binius_maybe_rayon::{prelude::*, slice::ParallelSlice};
 use binius_utils::{bail, checked_arithmetics::log2_strict_usize};
-use digest::{crypto_common::BlockSizeUser, FixedOutputReset, Output};
+use digest::{FixedOutputReset, Output, crypto_common::BlockSizeUser};
 use tracing::instrument;
 
 use super::errors::Error;

--- a/crates/core/src/merkle_tree/prover.rs
+++ b/crates/core/src/merkle_tree/prover.rs
@@ -1,10 +1,10 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_field::TowerField;
-use binius_hash::{multi_digest::ParallelDigest, PseudoCompressionFunction};
+use binius_hash::{PseudoCompressionFunction, multi_digest::ParallelDigest};
 use binius_maybe_rayon::iter::IndexedParallelIterator;
 use bytes::BufMut;
-use digest::{core_api::BlockSizeUser, FixedOutputReset, Output};
+use digest::{FixedOutputReset, Output, core_api::BlockSizeUser};
 use getset::Getters;
 
 use super::{

--- a/crates/core/src/merkle_tree/scheme.rs
+++ b/crates/core/src/merkle_tree/scheme.rs
@@ -5,12 +5,11 @@ use std::{array, fmt::Debug, marker::PhantomData};
 use binius_field::TowerField;
 use binius_hash::{HashBuffer, PseudoCompressionFunction};
 use binius_utils::{
-	bail,
+	SerializationMode, SerializeBytes, bail,
 	checked_arithmetics::{log2_ceil_usize, log2_strict_usize},
-	SerializationMode, SerializeBytes,
 };
 use bytes::Buf;
-use digest::{core_api::BlockSizeUser, Digest, Output};
+use digest::{Digest, Output, core_api::BlockSizeUser};
 use getset::Getters;
 
 use super::{

--- a/crates/core/src/merkle_tree/tests.rs
+++ b/crates/core/src/merkle_tree/tests.rs
@@ -5,7 +5,7 @@ use std::iter::repeat_with;
 
 use binius_field::{BinaryField16b, Field};
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{SeedableRng, rngs::StdRng};
 
 use super::{BinaryMerkleTreeProver, MerkleTreeProver, MerkleTreeScheme};
 use crate::{fiat_shamir::HasherChallenger, transcript::ProverTranscript};

--- a/crates/core/src/oracle/composite.rs
+++ b/crates/core/src/oracle/composite.rs
@@ -74,7 +74,7 @@ impl<F: TowerField> CompositePolyOracle<F> {
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{BinaryField128b, BinaryField2b, BinaryField32b, BinaryField8b, TowerField};
+	use binius_field::{BinaryField2b, BinaryField8b, BinaryField32b, BinaryField128b, TowerField};
 	use binius_math::{ArithCircuit, ArithExpr};
 
 	use super::*;

--- a/crates/core/src/oracle/constraint.rs
+++ b/crates/core/src/oracle/constraint.rs
@@ -166,10 +166,8 @@ impl<F: Field> ConstraintSetBuilder<F> {
 			.iter()
 			.map(|constraint| constraint.oracle_ids.clone())
 			.chain(oracles.polys().filter_map(|oracle| match &oracle.variant {
-				MultilinearPolyVariant::Shifted(ref shifted) => {
-					Some(vec![oracle.id(), shifted.id()])
-				}
-				MultilinearPolyVariant::LinearCombination(ref linear_combination) => {
+				MultilinearPolyVariant::Shifted(shifted) => Some(vec![oracle.id(), shifted.id()]),
+				MultilinearPolyVariant::LinearCombination(linear_combination) => {
 					Some(linear_combination.polys().chain([oracle.id()]).collect())
 				}
 				_ => None,

--- a/crates/core/src/oracle/error.rs
+++ b/crates/core/src/oracle/error.rs
@@ -4,7 +4,9 @@ use crate::oracle::OracleId;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-	#[error("the number of variables of the composition polynomial does not match the number of composed polynomials")]
+	#[error(
+		"the number of variables of the composition polynomial does not match the number of composed polynomials"
+	)]
 	CompositionMismatch,
 	#[error("expected the start index to be at most {expected}")]
 	InvalidStartIndex { expected: usize },
@@ -18,9 +20,7 @@ pub enum Error {
 	InvalidPolynomialIndex,
 	#[error("polynomial error")]
 	Polynomial(#[from] crate::polynomial::Error),
-	#[error(
-		"n_vars ({n_vars}) must be at least as big as the requested log_degree ({log_degree})"
-	)]
+	#[error("n_vars ({n_vars}) must be at least as big as the requested log_degree ({log_degree})")]
 	NotEnoughVarsForPacking { n_vars: usize, log_degree: usize },
 	#[error("no oracle exists in this MultilinearOracleSet with id {0}")]
 	InvalidOracleId(OracleId),
@@ -28,6 +28,8 @@ pub enum Error {
 	TowerLevelTooHigh { tower_level: usize },
 	#[error("constraint set is empty")]
 	EmptyConstraintSet,
-	#[error("expected constraint set to contain only constraints with n_vars={expected}, but found n_vars={got}")]
+	#[error(
+		"expected constraint set to contain only constraints with n_vars={expected}, but found n_vars={got}"
+	)]
 	ConstraintSetNvarsMismatch { got: usize, expected: usize },
 }

--- a/crates/core/src/oracle/multilinear.rs
+++ b/crates/core/src/oracle/multilinear.rs
@@ -5,7 +5,7 @@ use std::{array, sync::Arc};
 use binius_field::{BinaryField128b, Field, TowerField};
 use binius_macros::{DeserializeBytes, SerializeBytes};
 use binius_math::ArithCircuit;
-use binius_utils::{bail, DeserializeBytes, SerializationError, SerializationMode, SerializeBytes};
+use binius_utils::{DeserializeBytes, SerializationError, SerializationMode, SerializeBytes, bail};
 use getset::{CopyGetters, Getters};
 
 use crate::{
@@ -946,7 +946,7 @@ impl<F: TowerField> MultilinearPolyOracle<F> {
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{BinaryField128b, BinaryField1b, Field, TowerField};
+	use binius_field::{BinaryField1b, BinaryField128b, Field, TowerField};
 
 	use super::MultilinearOracleSet;
 

--- a/crates/core/src/piop/commit.rs
+++ b/crates/core/src/piop/commit.rs
@@ -1,9 +1,9 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_field::{
+	TowerField,
 	as_packed_field::{PackScalar, PackedType},
 	underlier::UnderlierType,
-	TowerField,
 };
 use binius_utils::sparse_index::SparseIndex;
 

--- a/crates/core/src/piop/mod.rs
+++ b/crates/core/src/piop/mod.rs
@@ -43,4 +43,4 @@ mod verify;
 pub use commit::*;
 pub use error::*;
 pub use prove::*;
-pub use verify::{make_commit_params_with_optimal_arity, verify, CommitMeta, PIOPSumcheckClaim};
+pub use verify::{CommitMeta, PIOPSumcheckClaim, make_commit_params_with_optimal_arity, verify};

--- a/crates/core/src/piop/prove.rs
+++ b/crates/core/src/piop/prove.rs
@@ -3,7 +3,7 @@
 use std::{borrow::Cow, ops::Deref};
 
 use binius_field::{
-	packed::PackedSliceMut, BinaryField, Field, PackedExtension, PackedField, TowerField,
+	BinaryField, Field, PackedExtension, PackedField, TowerField, packed::PackedSliceMut,
 };
 use binius_hal::ComputationBackend;
 use binius_math::{
@@ -13,34 +13,33 @@ use binius_math::{
 use binius_maybe_rayon::{iter::IntoParallelIterator, prelude::*};
 use binius_ntt::AdditiveNTT;
 use binius_utils::{
-	bail,
+	SerializeBytes, bail,
 	checked_arithmetics::checked_log_2,
 	random_access_sequence::{RandomAccessSequenceMut, SequenceSubrangeMut},
 	sorting::is_sorted_ascending,
-	SerializeBytes,
 };
 use either::Either;
-use itertools::{chain, Itertools};
+use itertools::{Itertools, chain};
 
 use super::{
 	error::Error,
-	verify::{make_sumcheck_claim_descs, PIOPSumcheckClaim},
+	verify::{PIOPSumcheckClaim, make_sumcheck_claim_descs},
 };
 use crate::{
 	fiat_shamir::{CanSample, Challenger},
 	merkle_tree::{MerkleTreeProver, MerkleTreeScheme},
 	oracle::OracleId,
 	piop::{
-		logging::{FriFoldRoundsData, SumcheckBatchProverDimensionsData},
 		CommitMeta,
+		logging::{FriFoldRoundsData, SumcheckBatchProverDimensionsData},
 	},
 	protocols::{
 		fri::{self, FRIFolder, FRIParams, FoldRoundOutput},
 		sumcheck::{
 			self, immediate_switchover_heuristic,
 			prove::{
-				front_loaded::BatchProver as SumcheckBatchProver, RegularSumcheckProver,
-				SumcheckProver,
+				RegularSumcheckProver, SumcheckProver,
+				front_loaded::BatchProver as SumcheckBatchProver,
 			},
 		},
 	},
@@ -476,7 +475,7 @@ mod tests {
 	use std::iter::repeat_with;
 
 	use binius_field::PackedBinaryField2x128b;
-	use rand::{rngs::StdRng, SeedableRng};
+	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 

--- a/crates/core/src/piop/tests.rs
+++ b/crates/core/src/piop/tests.rs
@@ -3,7 +3,7 @@
 use std::iter::repeat_with;
 
 use binius_field::{
-	AESTowerField16b, AESTowerField8b, BinaryField, BinaryField16b, BinaryField8b,
+	AESTowerField8b, AESTowerField16b, BinaryField, BinaryField8b, BinaryField16b,
 	ByteSlicedAES16x128b, Field, PackedBinaryField2x128b, PackedExtension, PackedField, TowerField,
 };
 use binius_hal::make_portable_backend;
@@ -13,14 +13,13 @@ use binius_math::{
 };
 use binius_ntt::SingleThreadedNTT;
 use binius_utils::{DeserializeBytes, SerializeBytes};
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng, rngs::StdRng};
 
 use super::{
-	prove,
+	PIOPSumcheckClaim, prove,
 	prove::commit,
 	verify,
-	verify::{make_commit_params_with_optimal_arity, CommitMeta},
-	PIOPSumcheckClaim,
+	verify::{CommitMeta, make_commit_params_with_optimal_arity},
 };
 use crate::{
 	fiat_shamir::HasherChallenger,

--- a/crates/core/src/piop/verify.rs
+++ b/crates/core/src/piop/verify.rs
@@ -4,7 +4,7 @@ use std::{borrow::Borrow, cmp::Ordering, iter, ops::Range};
 
 use binius_field::{BinaryField, ExtensionField, Field, TowerField};
 use binius_math::evaluate_piecewise_multilinear;
-use binius_utils::{bail, checked_arithmetics::log2_ceil_usize, DeserializeBytes};
+use binius_utils::{DeserializeBytes, bail, checked_arithmetics::log2_ceil_usize};
 use getset::CopyGetters;
 use tracing::instrument;
 
@@ -16,9 +16,9 @@ use crate::{
 	piop::util::ResizeableIndex,
 	polynomial::MultivariatePoly,
 	protocols::{
-		fri::{self, estimate_optimal_arity, FRIParams, FRIVerifier},
+		fri::{self, FRIParams, FRIVerifier, estimate_optimal_arity},
 		sumcheck::{
-			front_loaded::BatchVerifier as SumcheckBatchVerifier, CompositeSumClaim, SumcheckClaim,
+			CompositeSumClaim, SumcheckClaim, front_loaded::BatchVerifier as SumcheckBatchVerifier,
 		},
 	},
 	reed_solomon::reed_solomon::ReedSolomonCode,

--- a/crates/core/src/polynomial/arith_circuit.rs
+++ b/crates/core/src/polynomial/arith_circuit.rs
@@ -4,7 +4,7 @@ use std::{fmt::Debug, mem::MaybeUninit, sync::Arc};
 
 use binius_field::{ExtensionField, Field, PackedField, TowerField};
 use binius_math::{ArithCircuit, ArithCircuitStep, CompositionPoly, Error, RowsBatchRef};
-use binius_utils::{bail, DeserializeBytes, SerializationError, SerializationMode, SerializeBytes};
+use binius_utils::{DeserializeBytes, SerializationError, SerializationMode, SerializeBytes, bail};
 use stackalloc::{
 	helpers::{slice_assume_init, slice_assume_init_mut},
 	stackalloc_uninit,
@@ -539,7 +539,7 @@ fn apply_binary_op<F: Field, P: PackedField<Scalar: ExtensionField<F>>>(
 #[cfg(test)]
 mod tests {
 	use binius_field::{
-		BinaryField16b, BinaryField8b, PackedBinaryField8x16b, PackedField, TowerField,
+		BinaryField8b, BinaryField16b, PackedBinaryField8x16b, PackedField, TowerField,
 	};
 	use binius_math::{ArithExpr, CompositionPoly, RowsBatch};
 	use binius_utils::felts;

--- a/crates/core/src/polynomial/error.rs
+++ b/crates/core/src/polynomial/error.rs
@@ -33,9 +33,13 @@ pub enum Error {
 	ArgumentRangeError { arg: String, range: Range<usize> },
 	#[error("{0}")]
 	FieldError(#[from] FieldError),
-	#[error("not enough field elements to fill a single packed field element ({length} / {packed_width})")]
+	#[error(
+		"not enough field elements to fill a single packed field element ({length} / {packed_width})"
+	)]
 	PackedFieldNotFilled { length: usize, packed_width: usize },
-	#[error("one of the defining inputs to the ring switching eq-indicator function has length {actual}, rather than {expected}")]
+	#[error(
+		"one of the defining inputs to the ring switching eq-indicator function has length {actual}, rather than {expected}"
+	)]
 	RingSwitchWrongLength { expected: usize, actual: usize },
 	#[error("{0}")]
 	MathError(#[from] binius_math::Error),

--- a/crates/core/src/polynomial/multivariate.rs
+++ b/crates/core/src/polynomial/multivariate.rs
@@ -7,10 +7,10 @@ use binius_field::{Field, PackedField, TowerField};
 use binius_math::{
 	ArithCircuit, CompositionPoly, MLEDirectAdapter, MultilinearPoly, MultilinearQueryRef,
 };
-use binius_utils::{bail, SerializationError, SerializationMode};
+use binius_utils::{SerializationError, SerializationMode, bail};
 use bytes::BufMut;
 use itertools::Itertools;
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{SeedableRng, rngs::StdRng};
 
 use super::error::Error;
 

--- a/crates/core/src/polynomial/test_utils.rs
+++ b/crates/core/src/polynomial/test_utils.rs
@@ -1,6 +1,6 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use binius_field::{packed::set_packed_slice, BinaryField1b, Field, PackedField};
+use binius_field::{BinaryField1b, Field, PackedField, packed::set_packed_slice};
 
 use crate::polynomial::MultivariatePoly;
 

--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -11,14 +11,14 @@ use itertools::{chain, izip};
 use tracing::instrument;
 
 use super::{
+	EvalPoint, EvalPointOracleIdMap,
 	error::Error,
 	evalcheck::{EvalcheckHint, EvalcheckMultilinearClaim},
 	serialize_evalcheck_proof,
 	subclaims::{
-		add_composite_sumcheck_to_constraints, calculate_projected_mles, MemoizedData,
-		ProjectedBivariateMeta,
+		MemoizedData, ProjectedBivariateMeta, add_composite_sumcheck_to_constraints,
+		calculate_projected_mles,
 	},
-	EvalPoint, EvalPointOracleIdMap,
 };
 use crate::{
 	fiat_shamir::Challenger,

--- a/crates/core/src/protocols/evalcheck/subclaims.rs
+++ b/crates/core/src/protocols/evalcheck/subclaims.rs
@@ -365,14 +365,14 @@ impl<'a, P: PackedField, Backend: ComputationBackend> MemoizedData<'a, P, Backen
 			.iter()
 			.position(|(memo_eval_point, _)| memo_eval_point.as_slice() == eval_point)
 		{
-			let (_, ref query) = &self.query[index];
+			let (_, query) = &self.query[index];
 			return Ok(query);
 		}
 
 		let query = backend.multilinear_query(eval_point)?;
 		self.query.push((eval_point.to_vec(), query));
 
-		let (_, ref query) = self.query.last().expect("pushed query immediately above");
+		let (_, query) = self.query.last().expect("pushed query immediately above");
 		Ok(query)
 	}
 
@@ -385,7 +385,7 @@ impl<'a, P: PackedField, Backend: ComputationBackend> MemoizedData<'a, P, Backen
 			.iter()
 			.position(|(memo_eval_point, _)| memo_eval_point.as_slice() == eval_point)
 			.map(|index| {
-				let (_, ref query) = &self.query[index];
+				let (_, query) = &self.query[index];
 				query
 			})
 	}

--- a/crates/core/src/protocols/evalcheck/subclaims.rs
+++ b/crates/core/src/protocols/evalcheck/subclaims.rs
@@ -21,7 +21,7 @@ use binius_maybe_rayon::prelude::*;
 use binius_utils::bail;
 use tracing::instrument;
 
-use super::{error::Error, evalcheck::EvalcheckMultilinearClaim, EvalPoint, EvalPointOracleIdMap};
+use super::{EvalPoint, EvalPointOracleIdMap, error::Error, evalcheck::EvalcheckMultilinearClaim};
 use crate::{
 	fiat_shamir::Challenger,
 	oracle::{
@@ -30,15 +30,14 @@ use crate::{
 	},
 	polynomial::MultivariatePoly,
 	protocols::sumcheck::{
-		self,
+		self, Error as SumcheckError,
 		prove::{
 			front_loaded,
 			oracles::{
-				constraint_sets_mlecheck_prover_meta, constraint_sets_sumcheck_provers_metas,
 				MLECheckProverWithMeta, SumcheckProversWithMetas,
+				constraint_sets_mlecheck_prover_meta, constraint_sets_sumcheck_provers_metas,
 			},
 		},
-		Error as SumcheckError,
 	},
 	transcript::ProverTranscript,
 	transparent::{shift_ind::ShiftIndPartialEval, tower_basis::TowerBasis},

--- a/crates/core/src/protocols/evalcheck/tests.rs
+++ b/crates/core/src/protocols/evalcheck/tests.rs
@@ -3,28 +3,28 @@
 use std::{array, iter::repeat_with};
 
 use binius_field::{
+	AESTowerField128b, BinaryField1b, BinaryField128b, ByteSliced16x128x1b, ByteSlicedAES16x16x8b,
+	ByteSlicedAES16x128b, ExtensionField, Field, PackedBinaryField1x128b, PackedBinaryField16x8b,
+	PackedBinaryField128x1b, PackedField, RepackedExtension, TowerField,
 	packed::{get_packed_slice, len_packed_slice, set_packed_slice},
-	AESTowerField128b, BinaryField128b, BinaryField1b, ByteSliced16x128x1b, ByteSlicedAES16x128b,
-	ByteSlicedAES16x16x8b, ExtensionField, Field, PackedBinaryField128x1b, PackedBinaryField16x8b,
-	PackedBinaryField1x128b, PackedField, RepackedExtension, TowerField,
 };
-use binius_hal::{make_portable_backend, ComputationBackendExt};
+use binius_hal::{ComputationBackendExt, make_portable_backend};
 use binius_hash::groestl::Groestl256;
 use binius_macros::arith_expr;
 use binius_math::{
-	extrapolate_line, CompositionPoly, MultilinearExtension, MultilinearPoly, MultilinearQuery,
+	CompositionPoly, MultilinearExtension, MultilinearPoly, MultilinearQuery, extrapolate_line,
 };
-use bytemuck::{cast_slice_mut, Pod};
+use bytemuck::{Pod, cast_slice_mut};
 use itertools::Either;
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{SeedableRng, rngs::StdRng};
 
 use crate::{
 	fiat_shamir::HasherChallenger,
 	oracle::{MultilinearOracleSet, ShiftVariant},
 	polynomial::{ArithCircuitPoly, MultivariatePoly},
 	protocols::evalcheck::{
-		deserialize_evalcheck_proof, serialize_evalcheck_proof, EvalcheckHint,
-		EvalcheckMultilinearClaim, EvalcheckProver, EvalcheckVerifier,
+		EvalcheckHint, EvalcheckMultilinearClaim, EvalcheckProver, EvalcheckVerifier,
+		deserialize_evalcheck_proof, serialize_evalcheck_proof,
 	},
 	transcript::ProverTranscript,
 	transparent::select_row::SelectRow,

--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -2,20 +2,19 @@
 
 use std::mem;
 
-use binius_field::{util::inner_product_unchecked, Field, TowerField};
+use binius_field::{Field, TowerField, util::inner_product_unchecked};
 use getset::{Getters, MutGetters};
 use itertools::chain;
 use tracing::instrument;
 
 use super::{
-	deserialize_evalcheck_proof,
+	EvalPoint, deserialize_evalcheck_proof,
 	error::{Error, VerificationError},
 	evalcheck::{EvalcheckHint, EvalcheckMultilinearClaim},
 	subclaims::{
 		add_bivariate_sumcheck_to_constraints, add_composite_sumcheck_to_constraints,
 		packed_sumcheck_meta, shifted_sumcheck_meta,
 	},
-	EvalPoint,
 };
 use crate::{
 	fiat_shamir::Challenger,

--- a/crates/core/src/protocols/fri/common.rs
+++ b/crates/core/src/protocols/fri/common.rs
@@ -334,7 +334,7 @@ pub fn estimate_optimal_arity(
 #[cfg(test)]
 mod tests {
 	use assert_matches::assert_matches;
-	use binius_field::{BinaryField128b, BinaryField32b};
+	use binius_field::{BinaryField32b, BinaryField128b};
 
 	use super::*;
 

--- a/crates/core/src/protocols/fri/error.rs
+++ b/crates/core/src/protocols/fri/error.rs
@@ -46,7 +46,9 @@ pub enum VerificationError {
 	IncorrectFold { query_round: usize, index: usize },
 	#[error("the size of the query proof is incorrect, expected {expected}")]
 	IncorrectQueryProofLength { expected: usize },
-	#[error("the number of values in round {round} of the query proof is incorrect, expected {coset_size}")]
+	#[error(
+		"the number of values in round {round} of the query proof is incorrect, expected {coset_size}"
+	)]
 	IncorrectQueryProofValuesLength { round: usize, coset_size: usize },
 	#[error("The dimension-1 codeword must contain the same values")]
 	IncorrectDegree,

--- a/crates/core/src/protocols/fri/mod.rs
+++ b/crates/core/src/protocols/fri/mod.rs
@@ -31,7 +31,7 @@ mod prove;
 mod tests;
 mod verify;
 
-pub use common::{calculate_n_test_queries, estimate_optimal_arity, FRIParams, TerminateCodeword};
+pub use common::{FRIParams, TerminateCodeword, calculate_n_test_queries, estimate_optimal_arity};
 pub use error::*;
 pub use prove::*;
 pub use verify::*;

--- a/crates/core/src/protocols/fri/prove.rs
+++ b/crates/core/src/protocols/fri/prove.rs
@@ -1,23 +1,23 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_field::{
-	packed::{iter_packed_slice_with_offset, len_packed_slice},
 	BinaryField, ExtensionField, PackedExtension, PackedField, TowerField,
+	packed::{iter_packed_slice_with_offset, len_packed_slice},
 };
 use binius_math::MultilinearQuery;
 use binius_maybe_rayon::prelude::*;
 use binius_ntt::AdditiveNTT;
-use binius_utils::{bail, checked_arithmetics::log2_strict_usize, SerializeBytes};
+use binius_utils::{SerializeBytes, bail, checked_arithmetics::log2_strict_usize};
 use bytemuck::zeroed_vec;
 use bytes::BufMut;
 use itertools::izip;
 use tracing::instrument;
 
 use super::{
-	common::{vcs_optimal_layers_depths_iter, FRIParams},
+	TerminateCodeword,
+	common::{FRIParams, vcs_optimal_layers_depths_iter},
 	error::Error,
 	logging::{MerkleTreeDimensionData, RSEncodeDimensionData, SortAndMergeDimensionData},
-	TerminateCodeword,
 };
 use crate::{
 	fiat_shamir::{CanSampleBits, Challenger},

--- a/crates/core/src/protocols/fri/tests.rs
+++ b/crates/core/src/protocols/fri/tests.rs
@@ -3,13 +3,13 @@
 use std::{iter::repeat_with, vec};
 
 use binius_field::{
-	arch::{packed_64::PackedBinaryField4x16b, OptimalUnderlier128b},
+	BinaryField, BinaryField16b, BinaryField32b, BinaryField128b, ExtensionField,
+	PackedBinaryField16x16b, PackedField, TowerField,
+	arch::{OptimalUnderlier128b, packed_64::PackedBinaryField4x16b},
 	as_packed_field::{PackScalar, PackedType},
 	underlier::UnderlierType,
-	BinaryField, BinaryField128b, BinaryField16b, BinaryField32b, ExtensionField,
-	PackedBinaryField16x16b, PackedField, TowerField,
 };
-use binius_hal::{make_portable_backend, ComputationBackendExt};
+use binius_hal::{ComputationBackendExt, make_portable_backend};
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_math::MultilinearExtension;
 use binius_maybe_rayon::prelude::ParallelIterator;
@@ -22,8 +22,8 @@ use crate::{
 	fiat_shamir::{CanSample, HasherChallenger},
 	merkle_tree::{BinaryMerkleTreeProver, MerkleTreeProver},
 	protocols::fri::{
-		self, to_par_scalar_small_chunks, CommitOutput, FRIFolder, FRIParams, FRIVerifier,
-		FoldRoundOutput,
+		self, CommitOutput, FRIFolder, FRIParams, FRIVerifier, FoldRoundOutput,
+		to_par_scalar_small_chunks,
 	},
 	reed_solomon::reed_solomon::ReedSolomonCode,
 	transcript::ProverTranscript,

--- a/crates/core/src/protocols/fri/verify.rs
+++ b/crates/core/src/protocols/fri/verify.rs
@@ -3,18 +3,18 @@
 use std::iter;
 
 use binius_field::{BinaryField, ExtensionField, TowerField};
-use binius_hal::{make_portable_backend, ComputationBackend};
+use binius_hal::{ComputationBackend, make_portable_backend};
 use binius_ntt::SingleThreadedNTT;
-use binius_utils::{bail, DeserializeBytes};
+use binius_utils::{DeserializeBytes, bail};
 use bytes::Buf;
 use itertools::izip;
 use tracing::instrument;
 
-use super::{common::vcs_optimal_layers_depths_iter, error::Error, VerificationError};
+use super::{VerificationError, common::vcs_optimal_layers_depths_iter, error::Error};
 use crate::{
 	fiat_shamir::{CanSampleBits, Challenger},
 	merkle_tree::MerkleTreeScheme,
-	protocols::fri::common::{fold_chunk, fold_interleaved_chunk, FRIParams},
+	protocols::fri::common::{FRIParams, fold_chunk, fold_interleaved_chunk},
 	transcript::{TranscriptReader, VerifierTranscript},
 };
 

--- a/crates/core/src/protocols/gkr_exp/batch_prove.rs
+++ b/crates/core/src/protocols/gkr_exp/batch_prove.rs
@@ -19,7 +19,7 @@ use super::{
 use crate::{
 	fiat_shamir::Challenger,
 	protocols::sumcheck::{
-		self, immediate_switchover_heuristic, BatchSumcheckOutput, CompositeSumClaim,
+		self, BatchSumcheckOutput, CompositeSumClaim, immediate_switchover_heuristic,
 	},
 	transcript::ProverTranscript,
 	witness::MultilinearWitness,

--- a/crates/core/src/protocols/gkr_exp/oracles.rs
+++ b/crates/core/src/protocols/gkr_exp/oracles.rs
@@ -7,7 +7,7 @@ use binius_utils::bail;
 use itertools::izip;
 use tracing::instrument;
 
-use super::{error::Error, BaseExpReductionOutput, BaseExpWitness, ExpClaim};
+use super::{BaseExpReductionOutput, BaseExpWitness, ExpClaim, error::Error};
 use crate::{
 	oracle::{MultilinearOracleSet, OracleId},
 	protocols::{evalcheck::EvalcheckMultilinearClaim, gkr_exp::LayerClaim},

--- a/crates/core/src/protocols/gkr_exp/provers.rs
+++ b/crates/core/src/protocols/gkr_exp/provers.rs
@@ -227,11 +227,7 @@ where
 	}
 
 	fn layer_n_claims(&self, layer_no: usize) -> usize {
-		if self.is_last_layer(layer_no) {
-			0
-		} else {
-			1
-		}
+		if self.is_last_layer(layer_no) { 0 } else { 1 }
 	}
 }
 

--- a/crates/core/src/protocols/gkr_exp/tests.rs
+++ b/crates/core/src/protocols/gkr_exp/tests.rs
@@ -1,9 +1,9 @@
 // Copyright 2025 Irreducible Inc.
 
 use binius_field::{
+	AESTowerField8b, AESTowerField128b, BinaryField, BinaryField1b, ByteSliced16x128x1b,
+	ByteSlicedAES16x16x8b, ByteSlicedAES16x128b, Field, PackedExtension, PackedField,
 	packed::{get_packed_slice, set_packed_slice},
-	AESTowerField128b, AESTowerField8b, BinaryField, BinaryField1b, ByteSliced16x128x1b,
-	ByteSlicedAES16x128b, ByteSlicedAES16x16x8b, Field, PackedExtension, PackedField,
 };
 use binius_hal::make_portable_backend;
 use binius_hash::groestl::Groestl256;
@@ -11,7 +11,7 @@ use binius_math::{
 	DefaultEvaluationDomainFactory, EvaluationOrder, MLEEmbeddingAdapter, MultilinearExtension,
 	MultilinearPoly, MultilinearQuery, MultilinearQueryRef,
 };
-use rand::{thread_rng, Rng};
+use rand::{Rng, thread_rng};
 
 use super::{batch_prove, common::BaseExpReductionOutput};
 use crate::{
@@ -134,8 +134,8 @@ fn generate_mul_witnesses_claims<'a, const LOG_SIZE: usize, const COLUMN_LEN: us
 }
 
 #[allow(clippy::type_complexity)]
-fn generate_mul_witnesses_claims_with_different_log_size<'a>(
-) -> (Vec<BaseExpWitness<'a, P>>, Vec<ExpClaim<F>>) {
+fn generate_mul_witnesses_claims_with_different_log_size<'a>()
+-> (Vec<BaseExpWitness<'a, P>>, Vec<ExpClaim<F>>) {
 	const LOG_SIZE_1: usize = 14usize;
 	const COLUMN_LEN_1: usize = 1usize << LOG_SIZE_1;
 	const EXPONENT_BIT_WIDTH_1: usize = 3usize;

--- a/crates/core/src/protocols/gkr_exp/tests.rs
+++ b/crates/core/src/protocols/gkr_exp/tests.rs
@@ -103,10 +103,10 @@ fn generate_mul_witnesses_claims<'a, const LOG_SIZE: usize, const COLUMN_LEN: us
 	let mut rng = thread_rng();
 
 	let a: Vec<_> = (0..COLUMN_LEN)
-		.map(|_| rng.gen::<u64>() % (1 << exponent_bit_width))
+		.map(|_| rng.r#gen::<u64>() % (1 << exponent_bit_width))
 		.collect();
 	let b: Vec<_> = (0..COLUMN_LEN)
-		.map(|_| rng.gen::<u64>() % (1 << exponent_bit_width))
+		.map(|_| rng.r#gen::<u64>() % (1 << exponent_bit_width))
 		.collect();
 	let c: Vec<_> = a.iter().zip(&b).map(|(ai, bi)| ai * bi).collect();
 

--- a/crates/core/src/protocols/gkr_exp/verifiers.rs
+++ b/crates/core/src/protocols/gkr_exp/verifiers.rs
@@ -164,11 +164,7 @@ where
 	}
 
 	fn layer_n_claims(&self, layer_no: usize) -> usize {
-		if self.is_last_layer(layer_no) {
-			0
-		} else {
-			1
-		}
+		if self.is_last_layer(layer_no) { 0 } else { 1 }
 	}
 }
 

--- a/crates/core/src/protocols/gkr_gpa/gkr_gpa.rs
+++ b/crates/core/src/protocols/gkr_gpa/gkr_gpa.rs
@@ -1,6 +1,6 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use binius_field::{packed::get_packed_slice, Field, PackedField};
+use binius_field::{Field, PackedField, packed::get_packed_slice};
 use binius_maybe_rayon::prelude::*;
 use binius_utils::bail;
 use bytemuck::zeroed_vec;

--- a/crates/core/src/protocols/gkr_gpa/oracles.rs
+++ b/crates/core/src/protocols/gkr_gpa/oracles.rs
@@ -6,7 +6,7 @@ use binius_field::{Field, PackedField, TowerField};
 use binius_utils::bail;
 use tracing::instrument;
 
-use super::{gkr_gpa::LayerClaim, Error, GrandProductClaim, GrandProductWitness};
+use super::{Error, GrandProductClaim, GrandProductWitness, gkr_gpa::LayerClaim};
 use crate::{
 	oracle::{MultilinearOracleSet, OracleId},
 	protocols::evalcheck::EvalcheckMultilinearClaim,

--- a/crates/core/src/protocols/gkr_gpa/prove.rs
+++ b/crates/core/src/protocols/gkr_gpa/prove.rs
@@ -2,7 +2,7 @@
 
 use binius_field::{Field, PackedExtension, PackedField, TowerField};
 use binius_hal::ComputationBackend;
-use binius_math::{extrapolate_line_scalar, EvaluationDomainFactory, EvaluationOrder};
+use binius_math::{EvaluationDomainFactory, EvaluationOrder, extrapolate_line_scalar};
 use binius_utils::{
 	bail,
 	sorting::{stable_sort, unsort},
@@ -11,15 +11,15 @@ use itertools::izip;
 use tracing::instrument;
 
 use super::{
-	gkr_gpa::{GrandProductBatchProveOutput, LayerClaim},
 	Error, GrandProductClaim, GrandProductWitness,
+	gkr_gpa::{GrandProductBatchProveOutput, LayerClaim},
 };
 use crate::{
 	composition::{BivariateProduct, IndexComposition},
 	fiat_shamir::{CanSample, Challenger},
 	protocols::sumcheck::{
-		prove::{eq_ind::EqIndSumcheckProverBuilder, front_loaded, SumcheckProver},
 		BatchSumcheckOutput, CompositeSumClaim,
+		prove::{SumcheckProver, eq_ind::EqIndSumcheckProverBuilder, front_loaded},
 	},
 	transcript::ProverTranscript,
 };

--- a/crates/core/src/protocols/gkr_gpa/tests.rs
+++ b/crates/core/src/protocols/gkr_gpa/tests.rs
@@ -3,23 +3,23 @@
 use std::iter::repeat_with;
 
 use binius_field::{
+	BinaryField32b, BinaryField128b, Field, PackedExtension, PackedField, PackedFieldIndexable,
+	RepackedExtension, TowerField,
 	arch::{OptimalUnderlier256b, OptimalUnderlier512b},
 	as_packed_field::{PackScalar, PackedType},
 	packed::set_packed_slice,
 	underlier::{UnderlierType, WithUnderlier},
-	BinaryField128b, BinaryField32b, Field, PackedExtension, PackedField, PackedFieldIndexable,
-	RepackedExtension, TowerField,
 };
 use binius_hash::groestl::Groestl256;
 use binius_math::{EvaluationOrder, IsomorphicEvaluationDomainFactory, MultilinearExtension};
 use bytemuck::zeroed_vec;
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{SeedableRng, rngs::StdRng};
 
 use super::{GrandProductClaim, GrandProductWitness};
 use crate::{
 	fiat_shamir::HasherChallenger,
 	oracle::MultilinearOracleSet,
-	protocols::gkr_gpa::{batch_prove, batch_verify, GrandProductBatchProveOutput},
+	protocols::gkr_gpa::{GrandProductBatchProveOutput, batch_prove, batch_verify},
 	transcript::ProverTranscript,
 	witness::MultilinearExtensionIndex,
 };

--- a/crates/core/src/protocols/gkr_gpa/verify.rs
+++ b/crates/core/src/protocols/gkr_gpa/verify.rs
@@ -1,20 +1,20 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_field::{Field, TowerField};
-use binius_math::{extrapolate_line_scalar, EvaluationOrder};
+use binius_math::{EvaluationOrder, extrapolate_line_scalar};
 use binius_utils::{
 	bail,
 	sorting::{stable_sort, unsort},
 };
 use tracing::instrument;
 
-use super::{gkr_gpa::LayerClaim, Error, GrandProductClaim};
+use super::{Error, GrandProductClaim, gkr_gpa::LayerClaim};
 use crate::{
 	composition::{BivariateProduct, IndexComposition},
 	fiat_shamir::{CanSample, Challenger},
 	polynomial::Error as PolynomialError,
 	protocols::sumcheck::{
-		self, eq_ind::ClaimsSortingOrder, front_loaded, CompositeSumClaim, EqIndSumcheckClaim,
+		self, CompositeSumClaim, EqIndSumcheckClaim, eq_ind::ClaimsSortingOrder, front_loaded,
 	},
 	transcript::VerifierTranscript,
 };

--- a/crates/core/src/protocols/greedy_evalcheck/prove.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/prove.rs
@@ -9,10 +9,10 @@ use crate::{
 	fiat_shamir::Challenger,
 	oracle::MultilinearOracleSet,
 	protocols::evalcheck::{
-		subclaims::{
-			prove_bivariate_sumchecks_with_switchover, prove_mlecheck_with_switchover, MemoizedData,
-		},
 		ConstraintSetEqIndPoint, EvalcheckMultilinearClaim, EvalcheckProver,
+		subclaims::{
+			MemoizedData, prove_bivariate_sumchecks_with_switchover, prove_mlecheck_with_switchover,
+		},
 	},
 	transcript::ProverTranscript,
 	witness::MultilinearExtensionIndex,

--- a/crates/core/src/protocols/greedy_evalcheck/tests.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/tests.rs
@@ -2,17 +2,17 @@
 use std::iter::repeat_with;
 
 use binius_field::{
+	BinaryField1b, BinaryField32b, BinaryField128b, ExtensionField, Field, PackedBinaryField1x128b,
+	PackedBinaryField128x1b, PackedExtension, PackedField, RepackedExtension, TowerField,
 	packed::{get_packed_slice, len_packed_slice, pack_slice, set_packed_slice},
-	BinaryField128b, BinaryField1b, BinaryField32b, ExtensionField, Field, PackedBinaryField128x1b,
-	PackedBinaryField1x128b, PackedExtension, PackedField, RepackedExtension, TowerField,
 };
-use binius_hal::{make_portable_backend, ComputationBackendExt};
+use binius_hal::{ComputationBackendExt, make_portable_backend};
 use binius_hash::groestl::Groestl256;
 use binius_macros::arith_expr;
 use binius_math::{DefaultEvaluationDomainFactory, MultilinearExtension};
 use bytemuck::Pod;
 use either::Either;
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{SeedableRng, rngs::StdRng};
 
 use crate::{
 	fiat_shamir::HasherChallenger,

--- a/crates/core/src/protocols/greedy_evalcheck/verify.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/verify.rs
@@ -12,9 +12,10 @@ use crate::{
 	protocols::{
 		evalcheck::{ConstraintSetsEqIndPoints, EvalcheckMultilinearClaim, EvalcheckVerifier},
 		sumcheck::{
-			self, constraint_set_mlecheck_claims, constraint_set_sumcheck_claims,
-			eq_ind::{self, reduce_to_regular_sumchecks, ClaimsSortingOrder},
-			front_loaded, MLEcheckClaimsWithMeta, SumcheckClaimsWithMeta,
+			self, MLEcheckClaimsWithMeta, SumcheckClaimsWithMeta, constraint_set_mlecheck_claims,
+			constraint_set_sumcheck_claims,
+			eq_ind::{self, ClaimsSortingOrder, reduce_to_regular_sumchecks},
+			front_loaded,
 		},
 	},
 	transcript::VerifierTranscript,

--- a/crates/core/src/protocols/sumcheck/common.rs
+++ b/crates/core/src/protocols/sumcheck/common.rs
@@ -57,10 +57,7 @@ where
 		n_multilinears: usize,
 		composite_sums: Vec<CompositeSumClaim<F, Composition>>,
 	) -> Result<Self, Error> {
-		for CompositeSumClaim {
-			ref composition, ..
-		} in &composite_sums
-		{
+		for CompositeSumClaim { composition, .. } in &composite_sums {
 			if composition.n_vars() != n_multilinears {
 				bail!(Error::InvalidComposition {
 					actual: composition.n_vars(),

--- a/crates/core/src/protocols/sumcheck/common.rs
+++ b/crates/core/src/protocols/sumcheck/common.rs
@@ -3,8 +3,8 @@
 use std::ops::{Add, AddAssign, Mul, MulAssign};
 
 use binius_field::{
-	util::{inner_product_unchecked, powers},
 	ExtensionField, Field, PackedField,
+	util::{inner_product_unchecked, powers},
 };
 use binius_math::{CompositionPoly, EvaluationDomainFactory, InterpolationDomain, MultilinearPoly};
 use binius_utils::bail;
@@ -186,7 +186,7 @@ impl<F: Field> RoundProof<F> {
 
 	/// The truncated polynomial coefficients.
 	pub fn coeffs(&self) -> &[F] {
-		&self.0 .0
+		&self.0.0
 	}
 
 	/// Representation in an isomorphic field
@@ -351,13 +351,13 @@ mod tests {
 	fn test_round_coeffs_truncate_non_empty() {
 		let coeffs = RoundCoeffs(vec![F::from(1), F::from(2), F::from(3)]);
 		let truncated = coeffs.truncate();
-		assert_eq!(truncated.0 .0, vec![F::from(1), F::from(2)]);
+		assert_eq!(truncated.0.0, vec![F::from(1), F::from(2)]);
 	}
 
 	#[test]
 	fn test_round_coeffs_truncate_empty() {
 		let coeffs = RoundCoeffs::<F>(vec![]);
 		let truncated = coeffs.truncate();
-		assert!(truncated.0 .0.is_empty());
+		assert!(truncated.0.0.is_empty());
 	}
 }

--- a/crates/core/src/protocols/sumcheck/eq_ind.rs
+++ b/crates/core/src/protocols/sumcheck/eq_ind.rs
@@ -1,10 +1,10 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_field::{util::eq, Field, PackedField};
+use binius_field::{Field, PackedField, util::eq};
 use binius_math::{ArithCircuit, CompositionPoly};
 use binius_utils::bail;
 use getset::CopyGetters;
-use itertools::{izip, Either};
+use itertools::{Either, izip};
 
 use super::{
 	common::{CompositeSumClaim, SumcheckClaim},
@@ -225,16 +225,16 @@ mod tests {
 	use std::{iter, sync::Arc};
 
 	use binius_field::{
+		BinaryField8b, BinaryField32b, BinaryField128b, ExtensionField, Field,
+		PackedBinaryField1x128b, PackedExtension, PackedField, PackedFieldIndexable,
+		PackedSubfield, RepackedExtension, TowerField,
 		arch::{OptimalUnderlier128b, OptimalUnderlier256b, OptimalUnderlier512b},
 		as_packed_field::{PackScalar, PackedType},
 		packed::set_packed_slice,
 		underlier::UnderlierType,
-		BinaryField128b, BinaryField32b, BinaryField8b, ExtensionField, Field,
-		PackedBinaryField1x128b, PackedExtension, PackedField, PackedFieldIndexable,
-		PackedSubfield, RepackedExtension, TowerField,
 	};
 	use binius_hal::{
-		make_portable_backend, ComputationBackend, ComputationBackendExt, SumcheckMultilinear,
+		ComputationBackend, ComputationBackendExt, SumcheckMultilinear, make_portable_backend,
 	};
 	use binius_hash::groestl::Groestl256;
 	use binius_math::{
@@ -242,24 +242,23 @@ mod tests {
 		IsomorphicEvaluationDomainFactory, MLEDirectAdapter, MultilinearExtension, MultilinearPoly,
 		MultilinearQuery,
 	};
-	use rand::{rngs::StdRng, Rng, SeedableRng};
+	use rand::{Rng, SeedableRng, rngs::StdRng};
 
 	use crate::{
 		composition::BivariateProduct,
 		fiat_shamir::{CanSample, HasherChallenger},
 		protocols::{
 			sumcheck::{
-				self,
+				self, BatchSumcheckOutput, CompositeSumClaim, EqIndSumcheckClaim,
 				eq_ind::{ClaimsSortingOrder, ExtraProduct},
 				immediate_switchover_heuristic,
 				prove::{
-					eq_ind::{ConstEvalSuffix, EqIndSumcheckProverBuilder},
 					RegularSumcheckProver,
+					eq_ind::{ConstEvalSuffix, EqIndSumcheckProverBuilder},
 				},
-				BatchSumcheckOutput, CompositeSumClaim, EqIndSumcheckClaim,
 			},
 			test_utils::{
-				generate_zero_product_multilinears, AddOneComposition, TestProductComposition,
+				AddOneComposition, TestProductComposition, generate_zero_product_multilinears,
 			},
 		},
 		transcript::ProverTranscript,

--- a/crates/core/src/protocols/sumcheck/eq_ind.rs
+++ b/crates/core/src/protocols/sumcheck/eq_ind.rs
@@ -41,10 +41,7 @@ where
 		n_multilinears: usize,
 		eq_ind_composite_sums: Vec<CompositeSumClaim<F, Composition>>,
 	) -> Result<Self, Error> {
-		for CompositeSumClaim {
-			ref composition, ..
-		} in &eq_ind_composite_sums
-		{
+		for CompositeSumClaim { composition, .. } in &eq_ind_composite_sums {
 			if composition.n_vars() != n_multilinears {
 				bail!(Error::InvalidComposition {
 					actual: composition.n_vars(),

--- a/crates/core/src/protocols/sumcheck/error.rs
+++ b/crates/core/src/protocols/sumcheck/error.rs
@@ -33,23 +33,27 @@ pub enum Error {
 	ExpectedProjection,
 	#[error("the number of variables for the prover multilinears must all be equal")]
 	NumberOfVariablesMismatch,
-	#[error(
-		"ProverState::execute called with incorrect number of evaluators, expected {expected}"
-	)]
+	#[error("ProverState::execute called with incorrect number of evaluators, expected {expected}")]
 	IncorrectNumberOfEvaluators { expected: usize },
 	#[error("sumcheck naive witness validation failed: composition index {composition_index}")]
 	SumcheckNaiveValidationFailure { composition_index: usize },
-	#[error("zerocheck naive witness validation failed: {composition_name}, vertex index {vertex_index}")]
+	#[error(
+		"zerocheck naive witness validation failed: {composition_name}, vertex index {vertex_index}"
+	)]
 	ZerocheckNaiveValidationFailure {
 		composition_name: String,
 		vertex_index: usize,
 	},
-	#[error("nonzerocheck naive witness validation failed: oracle {oracle}, hypercube index {hypercube_index}")]
+	#[error(
+		"nonzerocheck naive witness validation failed: oracle {oracle}, hypercube index {hypercube_index}"
+	)]
 	NonzerocheckNaiveValidationFailure {
 		oracle: String,
 		hypercube_index: usize,
 	},
-	#[error("evaluation domain should start with zero and one, and contain Karatsuba infinity for degrees above 1")]
+	#[error(
+		"evaluation domain should start with zero and one, and contain Karatsuba infinity for degrees above 1"
+	)]
 	IncorrectSumcheckEvaluationDomain,
 	#[error("evaluation domains are not proper prefixes of each other")]
 	NonProperPrefixEvaluationDomain,
@@ -65,7 +69,9 @@ pub enum Error {
 	IncorrectEqIndChallengesLength,
 	#[error("zerocheck challenges number does not equal number of variables")]
 	IncorrectZerocheckChallengesLength,
-	#[error("suffixes count not equal to multilinear count, const suffix longer than multilinear, or not const")]
+	#[error(
+		"suffixes count not equal to multilinear count, const suffix longer than multilinear, or not const"
+	)]
 	IncorrectConstSuffixes,
 	#[error("incorrect size of the equality indicator expansion in eq_ind sumcheck")]
 	IncorrectEqIndPartialEvalsSize,
@@ -87,9 +93,7 @@ pub enum Error {
 	IncorrectNumberOfBatchCoeffs,
 	#[error("cannot skip more rounds than the total number of variables")]
 	TooManySkippedRounds,
-	#[error(
-		"univariatizing reduction claim count does not match sumcheck, or n_vars is incorrect"
-	)]
+	#[error("univariatizing reduction claim count does not match sumcheck, or n_vars is incorrect")]
 	IncorrectUnivariatizingReductionClaims,
 	#[error("univariatizing reduction sumcheck of incorrect length")]
 	IncorrectUnivariatizingReductionSumcheck,
@@ -139,7 +143,9 @@ pub enum VerificationError {
 	IncorrectLagrangeMultilinearEvaluation,
 	#[error("skipped rounds count is more than the number of variables in a univariate claim")]
 	IncorrectSkippedRoundsCount,
-	#[error("zero eval prefix does not match the skipped variables of the smaller univariate multinears")]
+	#[error(
+		"zero eval prefix does not match the skipped variables of the smaller univariate multinears"
+	)]
 	IncorrectZerosPrefixLen,
 	#[error("non-zero Lagrange evals count does not match expected univariate domain size")]
 	IncorrectLagrangeRoundEvalsLen,

--- a/crates/core/src/protocols/sumcheck/front_loaded.rs
+++ b/crates/core/src/protocols/sumcheck/front_loaded.rs
@@ -3,15 +3,15 @@
 use std::{cmp, cmp::Ordering, collections::VecDeque, iter};
 
 use binius_field::{Field, TowerField};
-use binius_math::{evaluate_univariate, CompositionPoly};
+use binius_math::{CompositionPoly, evaluate_univariate};
 use binius_utils::sorting::is_sorted_ascending;
 use bytes::Buf;
 
 use super::{
+	RoundCoeffs, RoundProof,
 	common::batch_weighted_value,
 	error::{Error, VerificationError},
 	verify_sumcheck::compute_expected_batch_composite_evaluation_single_claim,
-	RoundCoeffs, RoundProof,
 };
 use crate::{
 	fiat_shamir::{CanSample, Challenger},

--- a/crates/core/src/protocols/sumcheck/mod.rs
+++ b/crates/core/src/protocols/sumcheck/mod.rs
@@ -19,8 +19,8 @@ pub mod verify_zerocheck;
 pub mod zerocheck;
 
 pub use common::{
-	equal_n_vars_check, immediate_switchover_heuristic, standard_switchover_heuristic,
 	BatchSumcheckOutput, CompositeSumClaim, RoundCoeffs, RoundProof, SumcheckClaim,
+	equal_n_vars_check, immediate_switchover_heuristic, standard_switchover_heuristic,
 };
 pub use eq_ind::EqIndSumcheckClaim;
 pub use error::*;

--- a/crates/core/src/protocols/sumcheck/prove/batch_zerocheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/batch_zerocheck.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use binius_field::{ExtensionField, PackedExtension, PackedField, TowerField};
-use binius_hal::{make_portable_backend, CpuBackend};
+use binius_hal::{CpuBackend, make_portable_backend};
 use binius_math::{
 	BinarySubspace, EvaluationDomain, EvaluationOrder, IsomorphicEvaluationDomainFactory,
 	MLEDirectAdapter, MultilinearPoly,
@@ -13,15 +13,14 @@ use binius_utils::{bail, sorting::is_sorted_ascending};
 use crate::{
 	fiat_shamir::{CanSample, Challenger},
 	protocols::sumcheck::{
-		immediate_switchover_heuristic,
+		BatchSumcheckOutput, Error, immediate_switchover_heuristic,
 		prove::{
-			front_loaded, logging::FoldLowDimensionsData, RegularSumcheckProver, SumcheckProver,
+			RegularSumcheckProver, SumcheckProver, front_loaded, logging::FoldLowDimensionsData,
 		},
 		zerocheck::{
-			lagrange_evals_multilinear_extension, univariatizing_reduction_claim,
-			BatchZerocheckOutput, ZerocheckRoundEvals,
+			BatchZerocheckOutput, ZerocheckRoundEvals, lagrange_evals_multilinear_extension,
+			univariatizing_reduction_claim,
 		},
-		BatchSumcheckOutput, Error,
 	},
 	transcript::ProverTranscript,
 };

--- a/crates/core/src/protocols/sumcheck/prove/common.rs
+++ b/crates/core/src/protocols/sumcheck/prove/common.rs
@@ -1,8 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_field::{
-	packed::{get_packed_slice, packed_from_fn_with_offset},
 	PackedField,
+	packed::{get_packed_slice, packed_from_fn_with_offset},
 };
 use binius_hal::ComputationBackend;
 use binius_math::EvaluationOrder;

--- a/crates/core/src/protocols/sumcheck/prove/eq_ind.rs
+++ b/crates/core/src/protocols/sumcheck/prove/eq_ind.rs
@@ -2,10 +2,10 @@
 
 use std::{cmp::Reverse, marker::PhantomData, ops::Range};
 
-use binius_field::{util::eq, ExtensionField, Field, PackedExtension, PackedField, TowerField};
+use binius_field::{ExtensionField, Field, PackedExtension, PackedField, TowerField, util::eq};
 use binius_hal::{
-	make_portable_backend, ComputationBackend, Error as HalError, SumcheckEvaluator,
-	SumcheckMultilinear,
+	ComputationBackend, Error as HalError, SumcheckEvaluator, SumcheckMultilinear,
+	make_portable_backend,
 };
 use binius_math::{
 	CompositionPoly, EvaluationDomainFactory, EvaluationOrder, InterpolationDomain,
@@ -21,12 +21,12 @@ use tracing::instrument;
 use crate::{
 	polynomial::{ArithCircuitPoly, Error as PolynomialError, MultivariatePoly},
 	protocols::sumcheck::{
-		common::{
-			equal_n_vars_check, get_nontrivial_evaluation_points,
-			interpolation_domains_for_composition_degrees, RoundCoeffs,
-		},
-		prove::{common::fold_partial_eq_ind, ProverState, SumcheckInterpolator, SumcheckProver},
 		CompositeSumClaim, Error,
+		common::{
+			RoundCoeffs, equal_n_vars_check, get_nontrivial_evaluation_points,
+			interpolation_domains_for_composition_degrees,
+		},
+		prove::{ProverState, SumcheckInterpolator, SumcheckProver, common::fold_partial_eq_ind},
 	},
 	transparent::{eq_ind::EqIndPartialEval, step_up::StepUp},
 };

--- a/crates/core/src/protocols/sumcheck/prove/mod.rs
+++ b/crates/core/src/protocols/sumcheck/prove/mod.rs
@@ -12,8 +12,8 @@ pub mod regular_sumcheck;
 pub mod univariate;
 pub mod zerocheck;
 
-pub use batch_sumcheck::{batch_prove, SumcheckProver};
-pub use batch_zerocheck::{batch_prove as batch_prove_zerocheck, ZerocheckProver};
+pub use batch_sumcheck::{SumcheckProver, batch_prove};
+pub use batch_zerocheck::{ZerocheckProver, batch_prove as batch_prove_zerocheck};
 pub use logging::PIOPCompilerFoldData;
 pub use oracles::{
 	constraint_set_sumcheck_prover, constraint_set_zerocheck_prover, split_constraint_set,

--- a/crates/core/src/protocols/sumcheck/prove/oracles.rs
+++ b/crates/core/src/protocols/sumcheck/prove/oracles.rs
@@ -6,17 +6,17 @@ use binius_math::{EvaluationDomainFactory, EvaluationOrder, MultilinearPoly};
 use binius_utils::bail;
 
 use super::{
-	eq_ind::{EqIndSumcheckProver, EqIndSumcheckProverBuilder},
 	RegularSumcheckProver, ZerocheckProverImpl,
+	eq_ind::{EqIndSumcheckProver, EqIndSumcheckProverBuilder},
 };
 use crate::{
 	oracle::{Constraint, ConstraintPredicate, ConstraintSet},
 	polynomial::ArithCircuitPoly,
 	protocols::{
-		evalcheck::{subclaims::MemoizedData, EvalPoint},
+		evalcheck::{EvalPoint, subclaims::MemoizedData},
 		sumcheck::{
-			constraint_set_mlecheck_claim, constraint_set_sumcheck_claim, CompositeSumClaim, Error,
-			OracleClaimMeta,
+			CompositeSumClaim, Error, OracleClaimMeta, constraint_set_mlecheck_claim,
+			constraint_set_sumcheck_claim,
 		},
 	},
 	witness::{MultilinearExtensionIndex, MultilinearWitness},

--- a/crates/core/src/protocols/sumcheck/prove/prover_state.rs
+++ b/crates/core/src/protocols/sumcheck/prove/prover_state.rs
@@ -1,9 +1,9 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use binius_field::{util::powers, Field, PackedExtension, PackedField};
+use binius_field::{Field, PackedExtension, PackedField, util::powers};
 use binius_hal::{ComputationBackend, RoundEvals, SumcheckEvaluator, SumcheckMultilinear};
 use binius_math::{
-	evaluate_univariate, CompositionPoly, EvaluationOrder, MultilinearPoly, MultilinearQuery,
+	CompositionPoly, EvaluationOrder, MultilinearPoly, MultilinearQuery, evaluate_univariate,
 };
 use binius_maybe_rayon::prelude::*;
 use binius_utils::bail;
@@ -202,10 +202,9 @@ where
 						multilinear: inner_multilinear,
 						..
 					} => {
-						let tensor_query = self.tensor_query.as_ref()
-							.expect(
-								"tensor_query is guaranteed to be Some while there is still a transparent multilinear"
-							);
+						let tensor_query = self.tensor_query.as_ref().expect(
+							"tensor_query is guaranteed to be Some while there is still a transparent multilinear",
+						);
 						inner_multilinear.evaluate(tensor_query.to_ref())
 					}
 					SumcheckMultilinear::Folded {

--- a/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/regular_sumcheck.rs
@@ -18,8 +18,8 @@ use crate::{
 	polynomial::{ArithCircuitPoly, Error as PolynomialError, MultilinearComposite},
 	protocols::sumcheck::{
 		common::{
-			equal_n_vars_check, get_nontrivial_evaluation_points,
-			interpolation_domains_for_composition_degrees, CompositeSumClaim, RoundCoeffs,
+			CompositeSumClaim, RoundCoeffs, equal_n_vars_check, get_nontrivial_evaluation_points,
+			interpolation_domains_for_composition_degrees,
 		},
 		error::Error,
 		prove::{ProverState, SumcheckInterpolator, SumcheckProver},

--- a/crates/core/src/protocols/sumcheck/prove/univariate.rs
+++ b/crates/core/src/protocols/sumcheck/prove/univariate.rs
@@ -3,10 +3,10 @@
 use std::{collections::HashMap, iter::repeat_n};
 
 use binius_field::{
+	BinaryField, ExtensionField, Field, PackedExtension, PackedField, PackedSubfield, TowerField,
 	packed::{get_packed_slice, get_packed_slice_checked},
 	recast_packed_mut,
 	util::inner_product_unchecked,
-	BinaryField, ExtensionField, Field, PackedExtension, PackedField, PackedSubfield, TowerField,
 };
 use binius_hal::ComputationBackend;
 use binius_math::{
@@ -24,13 +24,13 @@ use tracing::instrument;
 use crate::{
 	composition::{BivariateProduct, IndexComposition},
 	protocols::sumcheck::{
+		Error,
 		common::{equal_n_vars_check, small_field_embedding_degree_check},
 		prove::{
-			logging::{ExpandQueryData, UnivariateSkipCalculateCoeffsData},
 			RegularSumcheckProver,
+			logging::{ExpandQueryData, UnivariateSkipCalculateCoeffsData},
 		},
 		zerocheck::{domain_size, extrapolated_scalars_count},
-		Error,
 	},
 };
 
@@ -607,9 +607,11 @@ fn extrapolate_round_evals<F: TowerField>(
 		ntt.forward_transform(round_evals, shape, 0, 0)?;
 
 		// Sanity check: first 1 << skip_rounds evals are still zeros.
-		debug_assert!(round_evals[..1 << skip_rounds]
-			.iter()
-			.all(|&coeff| coeff == F::ZERO));
+		debug_assert!(
+			round_evals[..1 << skip_rounds]
+				.iter()
+				.all(|&coeff| coeff == F::ZERO)
+		);
 
 		// Trim the result.
 		round_evals.resize(max_domain_size, F::ZERO);
@@ -666,16 +668,16 @@ mod tests {
 	use std::sync::Arc;
 
 	use binius_field::{
+		BinaryField1b, BinaryField8b, BinaryField16b, BinaryField128b, ExtensionField, Field,
+		PackedBinaryField4x32b, PackedExtension, PackedField, PackedFieldIndexable, TowerField,
 		arch::{OptimalUnderlier128b, OptimalUnderlier512b},
 		as_packed_field::{PackScalar, PackedType},
 		underlier::UnderlierType,
-		BinaryField128b, BinaryField16b, BinaryField1b, BinaryField8b, ExtensionField, Field,
-		PackedBinaryField4x32b, PackedExtension, PackedField, PackedFieldIndexable, TowerField,
 	};
 	use binius_hal::make_portable_backend;
 	use binius_math::{BinarySubspace, CompositionPoly, EvaluationDomain, MultilinearPoly};
 	use binius_ntt::SingleThreadedNTT;
-	use rand::{prelude::StdRng, SeedableRng};
+	use rand::{SeedableRng, prelude::StdRng};
 
 	use crate::{
 		composition::{IndexComposition, ProductComposition},
@@ -840,10 +842,12 @@ mod tests {
 
 			// naive computation of the univariate skip output
 			let round_evals_len = 4usize << skip_rounds;
-			assert!(output
-				.round_evals
-				.iter()
-				.all(|round_evals| round_evals.len() == round_evals_len));
+			assert!(
+				output
+					.round_evals
+					.iter()
+					.all(|round_evals| round_evals.len() == round_evals_len)
+			);
 
 			let compositions = compositions
 				.iter()

--- a/crates/core/src/protocols/sumcheck/prove/zerocheck.rs
+++ b/crates/core/src/protocols/sumcheck/prove/zerocheck.rs
@@ -3,10 +3,10 @@
 use std::{marker::PhantomData, mem, sync::Arc};
 
 use binius_field::{
-	packed::{copy_packed_from_scalars_slice, get_packed_slice, set_packed_slice},
-	util::powers,
 	ExtensionField, Field, PackedExtension, PackedField, PackedSubfield, RepackedExtension,
 	TowerField,
+	packed::{copy_packed_from_scalars_slice, get_packed_slice, set_packed_slice},
+	util::powers,
 };
 use binius_hal::{ComputationBackend, ComputationBackendExt};
 use binius_math::{
@@ -16,24 +16,24 @@ use binius_math::{
 use binius_maybe_rayon::prelude::*;
 use binius_utils::bail;
 use bytemuck::zeroed_vec;
-use itertools::{izip, Either};
+use itertools::{Either, izip};
 use tracing::instrument;
 
 use crate::{
 	polynomial::MultilinearComposite,
 	protocols::sumcheck::{
-		common::{equal_n_vars_check, CompositeSumClaim},
+		Error,
+		common::{CompositeSumClaim, equal_n_vars_check},
 		prove::{
+			SumcheckProver, ZerocheckProver,
 			common::fold_partial_eq_ind,
 			eq_ind::EqIndSumcheckProverBuilder,
 			univariate::{
-				zerocheck_univariate_evals, ZerocheckUnivariateEvalsOutput,
-				ZerocheckUnivariateFoldResult,
+				ZerocheckUnivariateEvalsOutput, ZerocheckUnivariateFoldResult,
+				zerocheck_univariate_evals,
 			},
-			SumcheckProver, ZerocheckProver,
 		},
-		zerocheck::{domain_size, ZerocheckRoundEvals},
-		Error,
+		zerocheck::{ZerocheckRoundEvals, domain_size},
 	},
 };
 

--- a/crates/core/src/protocols/sumcheck/tests.rs
+++ b/crates/core/src/protocols/sumcheck/tests.rs
@@ -6,15 +6,15 @@ use std::{
 };
 
 use binius_field::{
+	BinaryField, BinaryField8b, BinaryField32b, BinaryField128b, ExtensionField, Field,
+	PackedBinaryField1x128b, PackedBinaryField4x32b, PackedExtension, PackedField,
+	RepackedExtension, TowerField,
 	arch::{OptimalUnderlier128b, OptimalUnderlier512b},
 	as_packed_field::{PackScalar, PackedType},
 	packed::set_packed_slice,
 	underlier::UnderlierType,
-	BinaryField, BinaryField128b, BinaryField32b, BinaryField8b, ExtensionField, Field,
-	PackedBinaryField1x128b, PackedBinaryField4x32b, PackedExtension, PackedField,
-	RepackedExtension, TowerField,
 };
-use binius_hal::{make_portable_backend, ComputationBackend, ComputationBackendExt};
+use binius_hal::{ComputationBackend, ComputationBackendExt, make_portable_backend};
 use binius_hash::groestl::Groestl256;
 use binius_math::{
 	ArithCircuit, CompositionPoly, EvaluationDomainFactory, EvaluationOrder,
@@ -24,16 +24,16 @@ use binius_math::{
 use binius_maybe_rayon::{current_num_threads, prelude::*};
 use binius_utils::checked_arithmetics::log2_ceil_usize;
 use itertools::izip;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng, rngs::StdRng};
 
 use super::{
+	BatchSumcheckOutput, SumcheckClaim,
 	common::CompositeSumClaim,
 	front_loaded::BatchVerifier as FrontLoadedBatchVerifier,
 	prove::{
-		batch_prove, front_loaded::BatchProver as FrontLoadedBatchProver, RegularSumcheckProver,
+		RegularSumcheckProver, batch_prove, front_loaded::BatchProver as FrontLoadedBatchProver,
 	},
 	verify_sumcheck::batch_verify,
-	BatchSumcheckOutput, SumcheckClaim,
 };
 use crate::{
 	composition::index_composition,

--- a/crates/core/src/protocols/sumcheck/verify_sumcheck.rs
+++ b/crates/core/src/protocols/sumcheck/verify_sumcheck.rs
@@ -1,14 +1,14 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_field::{Field, TowerField};
-use binius_math::{evaluate_univariate, CompositionPoly, EvaluationOrder};
+use binius_math::{CompositionPoly, EvaluationOrder, evaluate_univariate};
 use binius_utils::{bail, sorting::is_sorted_ascending};
 use itertools::izip;
 
 use super::{
-	common::{batch_weighted_value, BatchSumcheckOutput, RoundProof, SumcheckClaim},
-	error::{Error, VerificationError},
 	RoundCoeffs,
+	common::{BatchSumcheckOutput, RoundProof, SumcheckClaim, batch_weighted_value},
+	error::{Error, VerificationError},
 };
 use crate::{
 	fiat_shamir::{CanSample, Challenger},

--- a/crates/core/src/protocols/sumcheck/verify_zerocheck.rs
+++ b/crates/core/src/protocols/sumcheck/verify_zerocheck.rs
@@ -1,16 +1,16 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use binius_field::{util::inner_product_unchecked, TowerField};
+use binius_field::{TowerField, util::inner_product_unchecked};
 use binius_math::{BinarySubspace, CompositionPoly, EvaluationDomain};
 use binius_utils::{bail, checked_arithmetics::log2_ceil_usize, sorting::is_sorted_ascending};
 use tracing::instrument;
 
 use super::{
+	BatchSumcheckOutput,
 	eq_ind::{self, ClaimsSortingOrder},
 	error::{Error, VerificationError},
 	front_loaded,
-	zerocheck::{self, univariatizing_reduction_claim, BatchZerocheckOutput, ZerocheckClaim},
-	BatchSumcheckOutput,
+	zerocheck::{self, BatchZerocheckOutput, ZerocheckClaim, univariatizing_reduction_claim},
 };
 use crate::{
 	fiat_shamir::{CanSample, Challenger},

--- a/crates/core/src/protocols/sumcheck/zerocheck.rs
+++ b/crates/core/src/protocols/sumcheck/zerocheck.rs
@@ -5,8 +5,8 @@ use std::{
 	ops::{Mul, MulAssign},
 };
 
-use binius_field::{packed::set_packed_slice, ExtensionField, Field, PackedField, TowerField};
-use binius_hal::{make_portable_backend, ComputationBackendExt};
+use binius_field::{ExtensionField, Field, PackedField, TowerField, packed::set_packed_slice};
+use binius_hal::{ComputationBackendExt, make_portable_backend};
 use binius_math::{BinarySubspace, CompositionPoly, EvaluationDomain, MultilinearExtension};
 use binius_utils::{bail, checked_arithmetics::log2_strict_usize, sorting::is_sorted_ascending};
 use bytemuck::zeroed_vec;
@@ -18,8 +18,8 @@ use crate::{
 	composition::{BivariateProduct, IndexComposition},
 	polynomial::Error as PolynomialError,
 	protocols::sumcheck::{
-		eq_ind::EqIndSumcheckClaim, BatchSumcheckOutput, CompositeSumClaim, SumcheckClaim,
-		VerificationError,
+		BatchSumcheckOutput, CompositeSumClaim, SumcheckClaim, VerificationError,
+		eq_ind::EqIndSumcheckClaim,
 	},
 };
 
@@ -316,16 +316,16 @@ mod tests {
 	use std::sync::Arc;
 
 	use binius_field::{
+		AESTowerField8b, AESTowerField16b, AESTowerField128b, BinaryField8b, BinaryField16b,
+		BinaryField128b, ByteSlicedAES64x128b,
 		arch::{OptimalUnderlier128b, OptimalUnderlier512b},
 		as_packed_field::{PackScalar, PackedType},
 		underlier::{UnderlierType, WithUnderlier},
-		AESTowerField128b, AESTowerField16b, AESTowerField8b, BinaryField128b, BinaryField16b,
-		BinaryField8b, ByteSlicedAES64x128b,
 	};
 	use binius_hal::make_portable_backend;
 	use binius_hash::groestl::Groestl256;
 	use binius_math::IsomorphicEvaluationDomainFactory;
-	use rand::{prelude::StdRng, SeedableRng};
+	use rand::{SeedableRng, prelude::StdRng};
 
 	use super::*;
 	use crate::{

--- a/crates/core/src/ring_switch/eq_ind.rs
+++ b/crates/core/src/ring_switch/eq_ind.rs
@@ -3,13 +3,13 @@
 use std::{any::TypeId, iter, marker::PhantomData, sync::Arc};
 
 use binius_field::{
+	BinaryField1b, ExtensionField, Field, PackedExtension, PackedField, TowerField,
 	byte_iteration::{
-		can_iterate_bytes, create_partial_sums_lookup_tables, iterate_bytes, ByteIteratorCallback,
+		ByteIteratorCallback, can_iterate_bytes, create_partial_sums_lookup_tables, iterate_bytes,
 	},
 	util::inner_product_unchecked,
-	BinaryField1b, ExtensionField, Field, PackedExtension, PackedField, TowerField,
 };
-use binius_math::{tensor_prod_eq_ind, MultilinearExtension};
+use binius_math::{MultilinearExtension, tensor_prod_eq_ind};
 use binius_maybe_rayon::prelude::*;
 use binius_utils::bail;
 use bytemuck::zeroed_vec;
@@ -184,10 +184,10 @@ where
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{BinaryField128b, BinaryField8b};
+	use binius_field::{BinaryField8b, BinaryField128b};
 	use binius_math::MultilinearQuery;
 	use iter::repeat_with;
-	use rand::{prelude::StdRng, SeedableRng};
+	use rand::{SeedableRng, prelude::StdRng};
 
 	use super::*;
 

--- a/crates/core/src/ring_switch/prove.rs
+++ b/crates/core/src/ring_switch/prove.rs
@@ -3,8 +3,8 @@
 use std::{iter, sync::Arc};
 
 use binius_field::{
-	tower::{PackedTop, TowerFamily},
 	PackedField, PackedFieldIndexable, TowerField,
+	tower::{PackedTop, TowerFamily},
 };
 use binius_hal::ComputationBackend;
 use binius_math::{MLEDirectAdapter, MultilinearPoly, MultilinearQuery};

--- a/crates/core/src/ring_switch/tests.rs
+++ b/crates/core/src/ring_switch/tests.rs
@@ -3,11 +3,11 @@
 use std::{cmp::Ordering, iter::repeat_with};
 
 use binius_field::{
+	ExtensionField, Field, PackedField, PackedFieldIndexable, TowerField,
 	arch::OptimalUnderlier128b,
 	as_packed_field::{PackScalar, PackedType},
 	tower::{CanonicalTowerFamily, PackedTop, TowerFamily, TowerUnderlier},
 	underlier::UnderlierType,
-	ExtensionField, Field, PackedField, PackedFieldIndexable, TowerField,
 };
 use binius_hal::make_portable_backend;
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
@@ -22,7 +22,7 @@ use rand::prelude::*;
 use super::{
 	common::EvalClaimSystem,
 	prove,
-	verify::{verify, ReducedClaim},
+	verify::{ReducedClaim, verify},
 };
 use crate::{
 	fiat_shamir::HasherChallenger,
@@ -30,7 +30,7 @@ use crate::{
 	oracle::{MultilinearOracleSet, MultilinearPolyVariant, OracleId},
 	piop,
 	protocols::{
-		evalcheck::{subclaims::MemoizedData, EvalcheckMultilinearClaim},
+		evalcheck::{EvalcheckMultilinearClaim, subclaims::MemoizedData},
 		fri::CommitOutput,
 	},
 	ring_switch::prove::ReducedWitness,

--- a/crates/core/src/ring_switch/verify.rs
+++ b/crates/core/src/ring_switch/verify.rs
@@ -3,8 +3,8 @@
 use std::{iter, sync::Arc};
 
 use binius_field::{
-	tower::{PackedTop, TowerFamily},
 	Field, TowerField,
+	tower::{PackedTop, TowerFamily},
 };
 use binius_math::{MultilinearExtension, MultilinearQuery};
 use binius_utils::checked_arithmetics::log2_ceil_usize;
@@ -17,8 +17,8 @@ use crate::{
 	piop::PIOPSumcheckClaim,
 	polynomial::MultivariatePoly,
 	ring_switch::{
-		eq_ind::RingSwitchEqInd, tower_tensor_algebra::TowerTensorAlgebra, Error,
-		EvalClaimSuffixDesc, EvalClaimSystem, PIOPSumcheckClaimDesc, VerificationError,
+		Error, EvalClaimSuffixDesc, EvalClaimSystem, PIOPSumcheckClaimDesc, VerificationError,
+		eq_ind::RingSwitchEqInd, tower_tensor_algebra::TowerTensorAlgebra,
 	},
 	transcript::{TranscriptReader, VerifierTranscript},
 };
@@ -235,7 +235,7 @@ where
 		_ => {
 			return Err(Error::PackingDegreeNotSupported {
 				kappa: suffix_desc.kappa,
-			})
+			});
 		}
 	};
 	Ok(eq_ind)

--- a/crates/core/src/tensor_algebra.rs
+++ b/crates/core/src/tensor_algebra.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use binius_field::{
-	square_transpose, util::inner_product_unchecked, ExtensionField, Field, PackedExtension,
+	ExtensionField, Field, PackedExtension, square_transpose, util::inner_product_unchecked,
 };
 
 /// An element of the tensor algebra defined as the tensor product of `FE` and `FE` as fields.
@@ -214,8 +214,8 @@ where
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{BinaryField128b, BinaryField8b};
-	use rand::{rngs::StdRng, SeedableRng};
+	use binius_field::{BinaryField8b, BinaryField128b};
+	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 

--- a/crates/core/src/transcript/mod.rs
+++ b/crates/core/src/transcript/mod.rs
@@ -86,10 +86,12 @@ unsafe impl<Inner: BufMut, Challenger_: Challenger> BufMut for FiatShamirBuf<Inn
 
 		// NOTE: This is the unsafe part, you are reading the next cnt bytes on the assumption that
 		// caller has ensured us the next cnt bytes are initialized.
-		let written: &[u8] = slice::from_raw_parts(written.as_mut_ptr(), cnt);
+		let written: &[u8] = unsafe { slice::from_raw_parts(written.as_mut_ptr(), cnt) };
 
 		self.challenger.observer().put_slice(written);
-		self.buffer.advance_mut(cnt);
+		unsafe {
+			self.buffer.advance_mut(cnt);
+		}
 	}
 
 	fn chunk_mut(&mut self) -> &mut UninitSlice {

--- a/crates/core/src/transcript/mod.rs
+++ b/crates/core/src/transcript/mod.rs
@@ -18,7 +18,7 @@ use std::{iter::repeat_with, slice};
 
 use binius_field::{PackedField, TowerField};
 use binius_utils::{DeserializeBytes, SerializationMode, SerializeBytes};
-use bytes::{buf::UninitSlice, Buf, BufMut, Bytes, BytesMut};
+use bytes::{Buf, BufMut, Bytes, BytesMut, buf::UninitSlice};
 pub use error::Error;
 use tracing::warn;
 
@@ -487,11 +487,11 @@ pub fn write_u64<B: BufMut>(transcript: &mut TranscriptWriter<B>, n: u64) {
 #[cfg(test)]
 mod tests {
 	use binius_field::{
-		AESTowerField128b, AESTowerField16b, AESTowerField32b, AESTowerField8b, BinaryField128b,
-		BinaryField128bPolyval, BinaryField32b, BinaryField64b, BinaryField8b,
+		AESTowerField8b, AESTowerField16b, AESTowerField32b, AESTowerField128b, BinaryField8b,
+		BinaryField32b, BinaryField64b, BinaryField128b, BinaryField128bPolyval,
 	};
 	use binius_hash::groestl::Groestl256;
-	use rand::{thread_rng, RngCore};
+	use rand::{RngCore, thread_rng};
 
 	use super::*;
 	use crate::fiat_shamir::HasherChallenger;

--- a/crates/core/src/transparent/constant.rs
+++ b/crates/core/src/transparent/constant.rs
@@ -1,8 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_field::{BinaryField128b, ExtensionField, TowerField};
-use binius_macros::{erased_serialize_bytes, DeserializeBytes, SerializeBytes};
-use binius_utils::{bail, DeserializeBytes};
+use binius_macros::{DeserializeBytes, SerializeBytes, erased_serialize_bytes};
+use binius_utils::{DeserializeBytes, bail};
 
 use crate::polynomial::{Error, MultivariatePoly};
 

--- a/crates/core/src/transparent/eq_ind.rs
+++ b/crates/core/src/transparent/eq_ind.rs
@@ -84,8 +84,8 @@ mod tests {
 	use std::iter::repeat_with;
 
 	use binius_field::{BinaryField32b, PackedBinaryField4x32b, PackedField};
-	use binius_hal::{make_portable_backend, ComputationBackendExt};
-	use rand::{rngs::StdRng, SeedableRng};
+	use binius_hal::{ComputationBackendExt, make_portable_backend};
+	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::EqIndPartialEval;
 	use crate::polynomial::MultivariatePoly;

--- a/crates/core/src/transparent/multilinear_extension.rs
+++ b/crates/core/src/transparent/multilinear_extension.rs
@@ -3,11 +3,11 @@
 use std::{fmt::Debug, ops::Deref};
 
 use binius_field::{
-	arch::OptimalUnderlier, as_packed_field::PackedType, packed::pack_slice, BinaryField128b,
-	BinaryField16b, BinaryField1b, BinaryField2b, BinaryField32b, BinaryField4b, BinaryField64b,
-	BinaryField8b, ExtensionField, PackedField, RepackedExtension, TowerField,
+	BinaryField1b, BinaryField2b, BinaryField4b, BinaryField8b, BinaryField16b, BinaryField32b,
+	BinaryField64b, BinaryField128b, ExtensionField, PackedField, RepackedExtension, TowerField,
+	arch::OptimalUnderlier, as_packed_field::PackedType, packed::pack_slice,
 };
-use binius_hal::{make_portable_backend, ComputationBackendExt};
+use binius_hal::{ComputationBackendExt, make_portable_backend};
 use binius_macros::erased_serialize_bytes;
 use binius_math::{MLEEmbeddingAdapter, MultilinearExtension, MultilinearPoly};
 use binius_utils::{DeserializeBytes, SerializationError, SerializationMode, SerializeBytes};

--- a/crates/core/src/transparent/powers.rs
+++ b/crates/core/src/transparent/powers.rs
@@ -3,12 +3,12 @@
 use std::iter::successors;
 
 use binius_field::{BinaryField128b, PackedField, TowerField};
-use binius_macros::{erased_serialize_bytes, DeserializeBytes, SerializeBytes};
+use binius_macros::{DeserializeBytes, SerializeBytes, erased_serialize_bytes};
 use binius_math::MultilinearExtension;
 use binius_maybe_rayon::prelude::*;
-use binius_utils::{bail, DeserializeBytes};
+use binius_utils::{DeserializeBytes, bail};
 use bytemuck::zeroed_vec;
-use itertools::{izip, Itertools};
+use itertools::{Itertools, izip};
 
 use crate::polynomial::{Error, MultivariatePoly};
 
@@ -91,7 +91,7 @@ impl<F: TowerField, P: PackedField<Scalar = F>> MultivariatePoly<P> for Powers<F
 #[cfg(test)]
 mod tests {
 	use binius_field::{BinaryField32b, Field, PackedBinaryField4x32b, PackedField, TowerField};
-	use rand::{prelude::StdRng, SeedableRng};
+	use rand::{SeedableRng, prelude::StdRng};
 
 	use super::Powers;
 	use crate::polynomial::MultivariatePoly;

--- a/crates/core/src/transparent/select_row.rs
+++ b/crates/core/src/transparent/select_row.rs
@@ -1,9 +1,9 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use binius_field::{packed::set_packed_slice, BinaryField128b, BinaryField1b, Field, PackedField};
-use binius_macros::{erased_serialize_bytes, DeserializeBytes, SerializeBytes};
+use binius_field::{BinaryField1b, BinaryField128b, Field, PackedField, packed::set_packed_slice};
+use binius_macros::{DeserializeBytes, SerializeBytes, erased_serialize_bytes};
 use binius_math::MultilinearExtension;
-use binius_utils::{bail, DeserializeBytes};
+use binius_utils::{DeserializeBytes, bail};
 
 use crate::polynomial::{Error, MultivariatePoly};
 

--- a/crates/core/src/transparent/shift_ind.rs
+++ b/crates/core/src/transparent/shift_ind.rs
@@ -1,6 +1,6 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use binius_field::{util::eq, Field, PackedField, TowerField};
+use binius_field::{Field, PackedField, TowerField, util::eq};
 use binius_math::MultilinearExtension;
 use binius_utils::bail;
 
@@ -431,8 +431,8 @@ mod tests {
 	use std::iter::repeat_with;
 
 	use binius_field::{BinaryField32b, PackedBinaryField4x32b};
-	use binius_hal::{make_portable_backend, ComputationBackendExt};
-	use rand::{rngs::StdRng, SeedableRng};
+	use binius_hal::{ComputationBackendExt, make_portable_backend};
+	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 	use crate::polynomial::test_utils::decompose_index_to_hypercube_point;

--- a/crates/core/src/transparent/step_down.rs
+++ b/crates/core/src/transparent/step_down.rs
@@ -1,9 +1,9 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_field::{BinaryField128b, Field, PackedField};
-use binius_macros::{erased_serialize_bytes, DeserializeBytes, SerializeBytes};
+use binius_macros::{DeserializeBytes, SerializeBytes, erased_serialize_bytes};
 use binius_math::MultilinearExtension;
-use binius_utils::{bail, DeserializeBytes};
+use binius_utils::{DeserializeBytes, bail};
 
 use crate::polynomial::{Error, MultivariatePoly};
 

--- a/crates/core/src/transparent/step_up.rs
+++ b/crates/core/src/transparent/step_up.rs
@@ -1,9 +1,9 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_field::{BinaryField128b, Field, PackedField};
-use binius_macros::{erased_serialize_bytes, DeserializeBytes, SerializeBytes};
+use binius_macros::{DeserializeBytes, SerializeBytes, erased_serialize_bytes};
 use binius_math::MultilinearExtension;
-use binius_utils::{bail, DeserializeBytes};
+use binius_utils::{DeserializeBytes, bail};
 
 use crate::polynomial::{Error, MultivariatePoly};
 

--- a/crates/core/src/transparent/tower_basis.rs
+++ b/crates/core/src/transparent/tower_basis.rs
@@ -3,9 +3,9 @@
 use std::marker::PhantomData;
 
 use binius_field::{BinaryField128b, Field, PackedField, TowerField};
-use binius_macros::{erased_serialize_bytes, DeserializeBytes, SerializeBytes};
+use binius_macros::{DeserializeBytes, SerializeBytes, erased_serialize_bytes};
 use binius_math::MultilinearExtension;
-use binius_utils::{bail, DeserializeBytes};
+use binius_utils::{DeserializeBytes, bail};
 
 use crate::polynomial::{Error, MultivariatePoly};
 
@@ -107,9 +107,9 @@ where
 mod tests {
 	use std::iter::repeat_with;
 
-	use binius_field::{BinaryField128b, BinaryField32b, PackedBinaryField4x32b};
-	use binius_hal::{make_portable_backend, ComputationBackendExt};
-	use rand::{rngs::StdRng, SeedableRng};
+	use binius_field::{BinaryField32b, BinaryField128b, PackedBinaryField4x32b};
+	use binius_hal::{ComputationBackendExt, make_portable_backend};
+	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 

--- a/crates/core/src/witness.rs
+++ b/crates/core/src/witness.rs
@@ -33,7 +33,9 @@ pub enum Error {
 	MissingWitness { id: OracleId },
 	#[error("witness for oracle id {id} does not have an explicit backing multilinear")]
 	NoExplicitBackingMultilinearExtension { id: OracleId },
-	#[error("log degree mismatch for oracle id {oracle_id}. field_log_extension_degree = {field_log_extension_degree} entry_log_extension_degree = {entry_log_extension_degree}")]
+	#[error(
+		"log degree mismatch for oracle id {oracle_id}. field_log_extension_degree = {field_log_extension_degree} entry_log_extension_degree = {entry_log_extension_degree}"
+	)]
 	OracleExtensionDegreeMismatch {
 		oracle_id: OracleId,
 		field_log_extension_degree: usize,

--- a/crates/field/benches/binary_field.rs
+++ b/crates/field/benches/binary_field.rs
@@ -3,14 +3,14 @@
 use std::array;
 
 use binius_field::{
+	BinaryField8b, BinaryField16b, BinaryField32b, BinaryField64b, BinaryField128b,
+	BinaryField128bPolyval, Field,
 	aes_field::{
-		AESTowerField128b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField8b,
+		AESTowerField8b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField128b,
 	},
-	BinaryField128b, BinaryField128bPolyval, BinaryField16b, BinaryField32b, BinaryField64b,
-	BinaryField8b, Field,
 };
 use criterion::{
-	criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, Criterion,
+	BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
 use rand::thread_rng;
 

--- a/crates/field/benches/binary_field_util.rs
+++ b/crates/field/benches/binary_field_util.rs
@@ -2,9 +2,9 @@
 
 use std::iter::repeat_with;
 
-use binius_field::{BinaryField128b, BinaryField1b, BinaryField32b, ExtensionField, PackedField};
+use binius_field::{BinaryField1b, BinaryField32b, BinaryField128b, ExtensionField, PackedField};
 use criterion::{
-	criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
+	BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::WallTime,
 };
 
 pub fn bench_inner_product_par<FX, PX, PY>(

--- a/crates/field/benches/byte_iteration.rs
+++ b/crates/field/benches/byte_iteration.rs
@@ -3,11 +3,11 @@
 use std::iter::repeat_with;
 
 use binius_field::{
-	arch::ArchOptimal, byte_iteration::create_partial_sums_lookup_tables, packed::PackedSlice,
-	BinaryField128b, BinaryField1b, BinaryField8b, PackedField,
+	BinaryField1b, BinaryField8b, BinaryField128b, PackedField, arch::ArchOptimal,
+	byte_iteration::create_partial_sums_lookup_tables, packed::PackedSlice,
 };
 use criterion::{
-	criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
+	BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::WallTime,
 };
 
 pub fn bench_create_partial_sums<P>(

--- a/crates/field/benches/byte_sliced.rs
+++ b/crates/field/benches/byte_sliced.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_field::{arch::byte_sliced::*, PackedField};
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use binius_field::{PackedField, arch::byte_sliced::*};
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use rand::thread_rng;
 
 macro_rules! bench_transform_to_byte_sliced {

--- a/crates/field/benches/main_field_binary_ops.rs
+++ b/crates/field/benches/main_field_binary_ops.rs
@@ -5,11 +5,11 @@ mod packed_field_utils;
 use std::ops::Mul;
 
 use binius_field::{
+	AESTowerField8b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField128b,
+	BinaryField1b, BinaryField8b, BinaryField16b, BinaryField32b, BinaryField64b, BinaryField128b,
+	BinaryField128bPolyval,
 	arch::{OptimalUnderlier, OptimalUnderlierByteSliced},
 	as_packed_field::PackedType,
-	AESTowerField128b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField8b,
-	BinaryField128b, BinaryField128bPolyval, BinaryField16b, BinaryField1b, BinaryField32b,
-	BinaryField64b, BinaryField8b,
 };
 use criterion::criterion_main;
 use packed_field_utils::benchmark_packed_operation;

--- a/crates/field/benches/main_field_unary_ops.rs
+++ b/crates/field/benches/main_field_unary_ops.rs
@@ -3,11 +3,11 @@
 mod packed_field_utils;
 
 use binius_field::{
+	AESTowerField8b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField128b,
+	BinaryField1b, BinaryField8b, BinaryField16b, BinaryField32b, BinaryField64b, BinaryField128b,
+	BinaryField128bPolyval, PackedField,
 	arch::{OptimalUnderlier, OptimalUnderlierByteSliced},
 	as_packed_field::PackedType,
-	AESTowerField128b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField8b,
-	BinaryField128b, BinaryField128bPolyval, BinaryField16b, BinaryField1b, BinaryField32b,
-	BinaryField64b, BinaryField8b, PackedField,
 };
 use criterion::criterion_main;
 use packed_field_utils::benchmark_packed_operation;

--- a/crates/field/benches/packed_extension_mul.rs
+++ b/crates/field/benches/packed_extension_mul.rs
@@ -1,11 +1,11 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_field::{
-	ext_base_mul, packed::set_packed_slice_unchecked, BinaryField128b, BinaryField16b,
-	BinaryField1b, BinaryField8b, ExtensionField, Field, PackedBinaryField2x128b, PackedExtension,
-	PackedField,
+	BinaryField1b, BinaryField8b, BinaryField16b, BinaryField128b, ExtensionField, Field,
+	PackedBinaryField2x128b, PackedExtension, PackedField, ext_base_mul,
+	packed::set_packed_slice_unchecked,
 };
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use rand::thread_rng;
 
 // Constants for input sizes

--- a/crates/field/benches/packed_field_element_access.rs
+++ b/crates/field/benches/packed_field_element_access.rs
@@ -3,11 +3,11 @@
 use std::array;
 
 use binius_field::{
-	arch::{byte_sliced::*, packed_128::*, packed_256::*, packed_512::*},
 	PackedField,
+	arch::{byte_sliced::*, packed_128::*, packed_256::*, packed_512::*},
 };
 use criterion::{
-	criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, Throughput,
+	BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
 use rand::{
 	distributions::{Distribution, Uniform},

--- a/crates/field/benches/packed_field_init.rs
+++ b/crates/field/benches/packed_field_init.rs
@@ -3,11 +3,11 @@
 use std::array;
 
 use binius_field::{
-	arch::{byte_sliced::*, packed_128::*, packed_256::*, packed_512::*},
 	PackedField,
+	arch::{byte_sliced::*, packed_128::*, packed_256::*, packed_512::*},
 };
 use criterion::{
-	criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, Throughput,
+	BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
 use rand::thread_rng;
 

--- a/crates/field/benches/packed_field_invert.rs
+++ b/crates/field/benches/packed_field_invert.rs
@@ -3,13 +3,13 @@
 mod packed_field_utils;
 
 use binius_field::{
+	PackedField,
 	arch::{
-		byte_sliced::*, packed_128::*, packed_16::*, packed_256::*, packed_32::*, packed_512::*,
-		packed_64::*, packed_8::*, packed_aes_128::*, packed_aes_16::*, packed_aes_256::*,
-		packed_aes_32::*, packed_aes_512::*, packed_aes_64::*, packed_aes_8::*,
+		byte_sliced::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*,
+		packed_256::*, packed_512::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,
+		packed_aes_64::*, packed_aes_128::*, packed_aes_256::*, packed_aes_512::*,
 		packed_polyval_128::*, packed_polyval_256::*, packed_polyval_512::*,
 	},
-	PackedField,
 };
 use cfg_if::cfg_if;
 use criterion::criterion_main;

--- a/crates/field/benches/packed_field_iter.rs
+++ b/crates/field/benches/packed_field_iter.rs
@@ -3,11 +3,11 @@
 use std::time::Duration;
 
 use binius_field::{
-	arch::{byte_sliced::*, packed_128::*, packed_256::*, packed_512::*},
 	PackedField,
+	arch::{byte_sliced::*, packed_128::*, packed_256::*, packed_512::*},
 };
 use criterion::{
-	criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, Throughput,
+	BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
 use rand::thread_rng;
 

--- a/crates/field/benches/packed_field_linear_transform.rs
+++ b/crates/field/benches/packed_field_linear_transform.rs
@@ -1,16 +1,16 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_field::{
+	ExtensionField, PackedField,
 	arch::{
-		byte_sliced::*, packed_128::*, packed_16::*, packed_256::*, packed_32::*, packed_512::*,
-		packed_64::*, packed_8::*, packed_aes_128::*, packed_aes_16::*, packed_aes_256::*,
-		packed_aes_32::*, packed_aes_512::*, packed_aes_64::*, packed_aes_8::*,
+		byte_sliced::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*,
+		packed_256::*, packed_512::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,
+		packed_aes_64::*, packed_aes_128::*, packed_aes_256::*, packed_aes_512::*,
 		packed_polyval_128::*, packed_polyval_256::*, packed_polyval_512::*,
 	},
 	linear_transformation::{
 		FieldLinearTransformation, PackedTransformationFactory, Transformation,
 	},
-	ExtensionField, PackedField,
 };
 use cfg_if::cfg_if;
 use criterion::criterion_main;

--- a/crates/field/benches/packed_field_mul_alpha.rs
+++ b/crates/field/benches/packed_field_mul_alpha.rs
@@ -4,9 +4,9 @@ mod packed_field_utils;
 
 use binius_field::{
 	arch::{
-		byte_sliced::*, packed_128::*, packed_16::*, packed_256::*, packed_32::*, packed_512::*,
-		packed_64::*, packed_8::*, packed_aes_128::*, packed_aes_16::*, packed_aes_256::*,
-		packed_aes_32::*, packed_aes_512::*, packed_aes_64::*, packed_aes_8::*,
+		byte_sliced::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*,
+		packed_256::*, packed_512::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,
+		packed_aes_64::*, packed_aes_128::*, packed_aes_256::*, packed_aes_512::*,
 		packed_polyval_128::*, packed_polyval_256::*, packed_polyval_512::*,
 	},
 	arithmetic_traits::MulAlpha,

--- a/crates/field/benches/packed_field_multiply.rs
+++ b/crates/field/benches/packed_field_multiply.rs
@@ -5,10 +5,10 @@ mod packed_field_utils;
 use std::ops::Mul;
 
 use binius_field::arch::{
-	byte_sliced::*, packed_128::*, packed_16::*, packed_256::*, packed_32::*, packed_512::*,
-	packed_64::*, packed_8::*, packed_aes_128::*, packed_aes_16::*, packed_aes_256::*,
-	packed_aes_32::*, packed_aes_512::*, packed_aes_64::*, packed_aes_8::*, packed_polyval_128::*,
-	packed_polyval_256::*, packed_polyval_512::*,
+	byte_sliced::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*,
+	packed_256::*, packed_512::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,
+	packed_aes_64::*, packed_aes_128::*, packed_aes_256::*, packed_aes_512::*,
+	packed_polyval_128::*, packed_polyval_256::*, packed_polyval_512::*,
 };
 use cfg_if::cfg_if;
 use criterion::criterion_main;

--- a/crates/field/benches/packed_field_slice_iter.rs
+++ b/crates/field/benches/packed_field_slice_iter.rs
@@ -3,15 +3,15 @@
 use std::iter::repeat_with;
 
 use binius_field::{
-	packed::iter_packed_slice_with_offset, PackedBinaryField128x1b, PackedBinaryField16x32b,
-	PackedBinaryField16x8b, PackedBinaryField1x128b, PackedBinaryField256x1b,
-	PackedBinaryField2x128b, PackedBinaryField2x64b, PackedBinaryField32x8b,
-	PackedBinaryField4x128b, PackedBinaryField4x32b, PackedBinaryField4x64b,
-	PackedBinaryField512x1b, PackedBinaryField64x8b, PackedBinaryField8x32b,
-	PackedBinaryField8x64b, PackedField,
+	PackedBinaryField1x128b, PackedBinaryField2x64b, PackedBinaryField2x128b,
+	PackedBinaryField4x32b, PackedBinaryField4x64b, PackedBinaryField4x128b,
+	PackedBinaryField8x32b, PackedBinaryField8x64b, PackedBinaryField16x8b,
+	PackedBinaryField16x32b, PackedBinaryField32x8b, PackedBinaryField64x8b,
+	PackedBinaryField128x1b, PackedBinaryField256x1b, PackedBinaryField512x1b, PackedField,
+	packed::iter_packed_slice_with_offset,
 };
 use criterion::{
-	criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, Throughput,
+	BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
 use rand::thread_rng;
 

--- a/crates/field/benches/packed_field_spread.rs
+++ b/crates/field/benches/packed_field_spread.rs
@@ -3,13 +3,13 @@
 use std::array;
 
 use binius_field::{
-	PackedBinaryField128x1b, PackedBinaryField16x16b, PackedBinaryField16x8b,
-	PackedBinaryField256x1b, PackedBinaryField32x16b, PackedBinaryField32x8b,
-	PackedBinaryField4x16b, PackedBinaryField512x1b, PackedBinaryField64x1b,
-	PackedBinaryField64x8b, PackedBinaryField8x16b, PackedBinaryField8x8b, PackedField,
+	PackedBinaryField4x16b, PackedBinaryField8x8b, PackedBinaryField8x16b, PackedBinaryField16x8b,
+	PackedBinaryField16x16b, PackedBinaryField32x8b, PackedBinaryField32x16b,
+	PackedBinaryField64x1b, PackedBinaryField64x8b, PackedBinaryField128x1b,
+	PackedBinaryField256x1b, PackedBinaryField512x1b, PackedField,
 };
 use criterion::{
-	criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Throughput,
+	BenchmarkGroup, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
 use rand::thread_rng;
 

--- a/crates/field/benches/packed_field_square.rs
+++ b/crates/field/benches/packed_field_square.rs
@@ -3,13 +3,13 @@
 mod packed_field_utils;
 
 use binius_field::{
+	PackedField,
 	arch::{
-		byte_sliced::*, packed_128::*, packed_16::*, packed_256::*, packed_32::*, packed_512::*,
-		packed_64::*, packed_8::*, packed_aes_128::*, packed_aes_16::*, packed_aes_256::*,
-		packed_aes_32::*, packed_aes_512::*, packed_aes_64::*, packed_aes_8::*,
+		byte_sliced::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*,
+		packed_256::*, packed_512::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,
+		packed_aes_64::*, packed_aes_128::*, packed_aes_256::*, packed_aes_512::*,
 		packed_polyval_128::*, packed_polyval_256::*, packed_polyval_512::*,
 	},
-	PackedField,
 };
 use cfg_if::cfg_if;
 use criterion::criterion_main;

--- a/crates/field/benches/packed_field_subfield_ops.rs
+++ b/crates/field/benches/packed_field_subfield_ops.rs
@@ -3,15 +3,15 @@
 use std::{array, time::Duration};
 
 use binius_field::{
+	BinaryField1b, BinaryField4b, BinaryField8b, BinaryField32b, BinaryField64b, Field,
+	PackedBinaryField1x128b, PackedBinaryField2x128b, PackedBinaryField4x32b,
+	PackedBinaryField4x128b, PackedBinaryField8x32b, PackedBinaryField8x64b,
+	PackedBinaryField16x8b, PackedBinaryField32x8b, PackedBinaryField64x8b, PackedExtension,
 	packed::mul_by_subfield_scalar,
 	underlier::{UnderlierType, WithUnderlier},
-	BinaryField1b, BinaryField32b, BinaryField4b, BinaryField64b, BinaryField8b, Field,
-	PackedBinaryField16x8b, PackedBinaryField1x128b, PackedBinaryField2x128b,
-	PackedBinaryField32x8b, PackedBinaryField4x128b, PackedBinaryField4x32b,
-	PackedBinaryField64x8b, PackedBinaryField8x32b, PackedBinaryField8x64b, PackedExtension,
 };
 use criterion::{
-	criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Throughput,
+	BenchmarkGroup, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
 use rand::thread_rng;
 

--- a/crates/field/benches/packed_field_utils.rs
+++ b/crates/field/benches/packed_field_utils.rs
@@ -1,6 +1,6 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use criterion::{measurement::WallTime, BenchmarkGroup};
+use criterion::{BenchmarkGroup, measurement::WallTime};
 
 pub fn run_benchmark<R>(
 	group: &mut BenchmarkGroup<WallTime>,

--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -9,20 +9,23 @@ use std::{
 };
 
 use binius_utils::{
-	bytes::{Buf, BufMut},
 	DeserializeBytes, SerializationError, SerializationMode, SerializeBytes,
+	bytes::{Buf, BufMut},
 };
 use bytemuck::{Pod, Zeroable};
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use super::{
+	BinaryField8b, Error, PackedExtension, PackedSubfield,
 	arithmetic_traits::InvertOrZero,
-	binary_field::{binary_field, impl_field_extension, BinaryField, BinaryField1b},
+	binary_field::{BinaryField, BinaryField1b, binary_field, impl_field_extension},
 	binary_field_arithmetic::TowerFieldArithmetic,
-	mul_by_binary_field_1b, BinaryField8b, Error, PackedExtension, PackedSubfield,
+	mul_by_binary_field_1b,
 };
 use crate::{
+	BinaryField16b, BinaryField32b, BinaryField64b, BinaryField128b, ExtensionField, Field,
+	TowerField,
 	as_packed_field::AsPackedField,
 	binary_field_arithmetic::{impl_arithmetic_using_packed, impl_mul_primitive},
 	binary_tower,
@@ -31,8 +34,6 @@ use crate::{
 	},
 	packed::PackedField,
 	underlier::U1,
-	BinaryField128b, BinaryField16b, BinaryField32b, BinaryField64b, ExtensionField, Field,
-	TowerField,
 };
 
 // These fields represent a tower based on AES GF(2^8) field (GF(256)/x^8+x^4+x^3+x+1)
@@ -349,15 +350,15 @@ serialize_deserialize_non_canonical!(AESTowerField128b, canonical = BinaryField1
 
 #[cfg(test)]
 mod tests {
-	use binius_utils::{bytes::BytesMut, SerializationMode, SerializeBytes};
+	use binius_utils::{SerializationMode, SerializeBytes, bytes::BytesMut};
 	use proptest::{arbitrary::any, proptest};
 	use rand::thread_rng;
 
 	use super::*;
 	use crate::{
+		PackedAESBinaryField4x32b, PackedAESBinaryField8x32b, PackedAESBinaryField16x32b,
+		PackedBinaryField4x32b, PackedBinaryField8x32b, PackedBinaryField16x32b,
 		binary_field::tests::is_binary_field_valid_generator, underlier::WithUnderlier,
-		PackedAESBinaryField16x32b, PackedAESBinaryField4x32b, PackedAESBinaryField8x32b,
-		PackedBinaryField16x32b, PackedBinaryField4x32b, PackedBinaryField8x32b,
 	};
 
 	fn check_square(f: impl Field) {

--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -12,18 +12,18 @@ use seq_macro::seq;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use super::super::portable::{
-	packed::{impl_pack_scalar, PackedPrimitiveType},
-	packed_arithmetic::{interleave_mask_even, interleave_mask_odd, UnderlierWithBitConstants},
+	packed::{PackedPrimitiveType, impl_pack_scalar},
+	packed_arithmetic::{UnderlierWithBitConstants, interleave_mask_even, interleave_mask_odd},
 };
 use crate::{
+	BinaryField,
 	arch::binary_utils::{as_array_mut, as_array_ref},
 	arithmetic_traits::Broadcast,
 	tower_levels::TowerLevel,
 	underlier::{
-		impl_divisible, impl_iteration, transpose_128b_values, unpack_lo_128b_fallback, NumCast,
-		Random, SmallU, UnderlierType, UnderlierWithBitOps, WithUnderlier, U1, U2, U4,
+		NumCast, Random, SmallU, U1, U2, U4, UnderlierType, UnderlierWithBitOps, WithUnderlier,
+		impl_divisible, impl_iteration, transpose_128b_values, unpack_lo_128b_fallback,
 	},
-	BinaryField,
 };
 
 /// 128-bit value that is used for 128-bit SIMD operations

--- a/crates/field/src/arch/aarch64/packed_128.rs
+++ b/crates/field/src/arch/aarch64/packed_128.rs
@@ -4,7 +4,7 @@ use std::ops::Mul;
 
 use super::{
 	super::portable::{
-		packed::{impl_ops_for_zero_height, PackedPrimitiveType},
+		packed::{PackedPrimitiveType, impl_ops_for_zero_height},
 		packed_arithmetic::{alphas, impl_tower_constants},
 	},
 	m128::M128,
@@ -14,14 +14,14 @@ use super::{
 	},
 };
 use crate::{
+	BinaryField1b, BinaryField2b, BinaryField4b, BinaryField8b, BinaryField16b, BinaryField32b,
+	BinaryField64b, BinaryField128b, PackedAESBinaryField16x8b,
 	arch::{PackedStrategy, PairwiseRecursiveStrategy, PairwiseStrategy, SimdStrategy},
 	arithmetic_traits::{
-		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
-		impl_transformation_with_strategy, InvertOrZero, MulAlpha, Square,
+		InvertOrZero, MulAlpha, Square, impl_invert_with, impl_mul_alpha_with, impl_mul_with,
+		impl_square_with, impl_transformation_with_strategy,
 	},
 	underlier::WithUnderlier,
-	BinaryField128b, BinaryField16b, BinaryField1b, BinaryField2b, BinaryField32b, BinaryField4b,
-	BinaryField64b, BinaryField8b, PackedAESBinaryField16x8b,
 };
 
 // Define 128 bit packed field types

--- a/crates/field/src/arch/aarch64/packed_aes_128.rs
+++ b/crates/field/src/arch/aarch64/packed_aes_128.rs
@@ -10,22 +10,22 @@ use super::{
 	},
 };
 use crate::{
+	PackedBinaryField16x8b,
 	aes_field::{
-		AESTowerField128b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField8b,
+		AESTowerField8b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField128b,
 	},
 	arch::{
+		PackedStrategy, PairwiseRecursiveStrategy, PairwiseStrategy, SimdStrategy,
 		portable::{
 			packed::PackedPrimitiveType,
 			packed_arithmetic::{alphas, impl_tower_constants},
 		},
-		PackedStrategy, PairwiseRecursiveStrategy, PairwiseStrategy, SimdStrategy,
 	},
 	arithmetic_traits::{
-		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
-		impl_transformation_with_strategy, InvertOrZero, MulAlpha, Square,
+		InvertOrZero, MulAlpha, Square, impl_invert_with, impl_mul_alpha_with, impl_mul_with,
+		impl_square_with, impl_transformation_with_strategy,
 	},
 	underlier::WithUnderlier,
-	PackedBinaryField16x8b,
 };
 
 // Define 128 bit packed field types

--- a/crates/field/src/arch/aarch64/packed_polyval_128.rs
+++ b/crates/field/src/arch/aarch64/packed_polyval_128.rs
@@ -75,13 +75,15 @@ unsafe fn karatsuba1(x: uint8x16_t, y: uint8x16_t) -> (uint8x16_t, uint8x16_t, u
 	//        M                                 H         L
 	//
 	// m = x.hi^x.lo * y.hi^y.lo
-	let m = pmull(
-		veorq_u8(x, vextq_u8(x, x, 8)), // x.hi^x.lo
-		veorq_u8(y, vextq_u8(y, y, 8)), // y.hi^y.lo
-	);
-	let h = pmull2(x, y); // h = x.hi * y.hi
-	let l = pmull(x, y); // l = x.lo * y.lo
-	(h, m, l)
+	unsafe {
+		let m = pmull(
+			veorq_u8(x, vextq_u8(x, x, 8)), // x.hi^x.lo
+			veorq_u8(y, vextq_u8(y, y, 8)), // y.hi^y.lo
+		);
+		let h = pmull2(x, y); // h = x.hi * y.hi
+		let l = pmull(x, y); // l = x.lo * y.lo
+		(h, m, l)
+	}
 }
 
 /// Karatsuba combine.
@@ -94,35 +96,37 @@ unsafe fn karatsuba2(h: uint8x16_t, m: uint8x16_t, l: uint8x16_t) -> (uint8x16_t
 	// l1 ^= m0      // = l1^(m0^l0^h0)
 	// h0 ^= l0 ^ m1 // = h0^(l0^m1^l1^h1)
 	// h1 ^= l1      // = h1^(l1^m0^l0^h0)
-	let t = {
-		//   {m0, m1} ^ {l1, h0}
-		// = {m0^l1, m1^h0}
-		let t0 = veorq_u8(m, vextq_u8(l, h, 8));
+	unsafe {
+		let t = {
+			//   {m0, m1} ^ {l1, h0}
+			// = {m0^l1, m1^h0}
+			let t0 = veorq_u8(m, vextq_u8(l, h, 8));
 
-		//   {h0, h1} ^ {l0, l1}
-		// = {h0^l0, h1^l1}
-		let t1 = veorq_u8(h, l);
+			//   {h0, h1} ^ {l0, l1}
+			// = {h0^l0, h1^l1}
+			let t1 = veorq_u8(h, l);
 
-		//   {m0^l1, m1^h0} ^ {h0^l0, h1^l1}
-		// = {m0^l1^h0^l0, m1^h0^h1^l1}
-		veorq_u8(t0, t1)
-	};
+			//   {m0^l1, m1^h0} ^ {h0^l0, h1^l1}
+			// = {m0^l1^h0^l0, m1^h0^h1^l1}
+			veorq_u8(t0, t1)
+		};
 
-	// {m0^l1^h0^l0, l0}
-	let x01 = vextq_u8(
-		vextq_u8(l, l, 8), // {l1, l0}
-		t,
-		8,
-	);
+		// {m0^l1^h0^l0, l0}
+		let x01 = vextq_u8(
+			vextq_u8(l, l, 8), // {l1, l0}
+			t,
+			8,
+		);
 
-	// {h1, m1^h0^h1^l1}
-	let x23 = vextq_u8(
-		t,
-		vextq_u8(h, h, 8), // {h1, h0}
-		8,
-	);
+		// {h1, m1^h0^h1^l1}
+		let x23 = vextq_u8(
+			t,
+			vextq_u8(h, h, 8), // {h1, h0}
+			8,
+		);
 
-	(x23, x01)
+		(x23, x01)
+	}
 }
 
 #[inline]
@@ -133,27 +137,34 @@ unsafe fn mont_reduce(x23: uint8x16_t, x01: uint8x16_t) -> uint8x16_t {
 	//    [C1:C0] = B0 • poly
 	//    [D1:D0] = [B0 ⊕ C1 : B1 ⊕ C0]
 	// Output: [D1 ⊕ X3 : D0 ⊕ X2]
-	let poly = vreinterpretq_u8_p128(1 << 127 | 1 << 126 | 1 << 121 | 1 << 63 | 1 << 62 | 1 << 57);
-	let a = pmull(x01, poly);
-	let b = veorq_u8(x01, vextq_u8(a, a, 8));
-	let c = pmull2(b, poly);
-	veorq_u8(x23, veorq_u8(c, b))
+	unsafe {
+		let poly =
+			vreinterpretq_u8_p128(1 << 127 | 1 << 126 | 1 << 121 | 1 << 63 | 1 << 62 | 1 << 57);
+		let a = pmull(x01, poly);
+		let b = veorq_u8(x01, vextq_u8(a, a, 8));
+		let c = pmull2(b, poly);
+		veorq_u8(x23, veorq_u8(c, b))
+	}
 }
 
 /// Multiplies the low bits in `a` and `b`.
 #[inline]
 unsafe fn pmull(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
-	mem::transmute(vmull_p64(
-		vgetq_lane_u64(vreinterpretq_u64_u8(a), 0),
-		vgetq_lane_u64(vreinterpretq_u64_u8(b), 0),
-	))
+	unsafe {
+		mem::transmute(vmull_p64(
+			vgetq_lane_u64(vreinterpretq_u64_u8(a), 0),
+			vgetq_lane_u64(vreinterpretq_u64_u8(b), 0),
+		))
+	}
 }
 
 /// Multiplies the high bits in `a` and `b`.
 #[inline]
 unsafe fn pmull2(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
-	mem::transmute(vmull_p64(
-		vgetq_lane_u64(vreinterpretq_u64_u8(a), 1),
-		vgetq_lane_u64(vreinterpretq_u64_u8(b), 1),
-	))
+	unsafe {
+		mem::transmute(vmull_p64(
+			vgetq_lane_u64(vreinterpretq_u64_u8(a), 1),
+			vgetq_lane_u64(vreinterpretq_u64_u8(b), 1),
+		))
+	}
 }

--- a/crates/field/src/arch/aarch64/packed_polyval_128.rs
+++ b/crates/field/src/arch/aarch64/packed_polyval_128.rs
@@ -19,9 +19,9 @@ use std::ops::Mul;
 
 use super::{super::portable::packed::PackedPrimitiveType, m128::M128};
 use crate::{
-	arch::{PairwiseStrategy, ReuseMultiplyStrategy},
-	arithmetic_traits::{impl_square_with, impl_transformation_with_strategy, InvertOrZero},
 	BinaryField128bPolyval, PackedField,
+	arch::{PairwiseStrategy, ReuseMultiplyStrategy},
+	arithmetic_traits::{InvertOrZero, impl_square_with, impl_transformation_with_strategy},
 };
 
 pub type PackedBinaryPolyval1x128b = PackedPrimitiveType<M128, BinaryField128bPolyval>;

--- a/crates/field/src/arch/aarch64/simd_arithmetic.rs
+++ b/crates/field/src/arch/aarch64/simd_arithmetic.rs
@@ -6,17 +6,17 @@ use seq_macro::seq;
 
 use super::m128::M128;
 use crate::{
+	BinaryField, TowerField,
 	arch::{
+		SimdStrategy,
 		portable::packed_arithmetic::{
 			PackedTowerField, TowerConstants, UnderlierWithBitConstants,
 		},
-		SimdStrategy,
 	},
 	arithmetic_traits::{
 		MulAlpha, Square, TaggedInvertOrZero, TaggedMul, TaggedMulAlpha, TaggedSquare,
 	},
 	underlier::{UnderlierWithBitOps, WithUnderlier},
-	BinaryField, TowerField,
 };
 
 #[inline]

--- a/crates/field/src/arch/arch_optimal.rs
+++ b/crates/field/src/arch/arch_optimal.rs
@@ -3,9 +3,9 @@
 use cfg_if::cfg_if;
 
 use crate::{
+	ByteSlicedUnderlier, Field, PackedField,
 	as_packed_field::{PackScalar, PackedType},
 	underlier::WithUnderlier,
-	ByteSlicedUnderlier, Field, PackedField,
 };
 
 /// A trait to retrieve the optimal throughput `ordinal` packed field for a given architecture.

--- a/crates/field/src/arch/binary_utils.rs
+++ b/crates/field/src/arch/binary_utils.rs
@@ -1,6 +1,6 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use bytemuck::{must_cast_mut, must_cast_ref, AnyBitPattern, NoUninit};
+use bytemuck::{AnyBitPattern, NoUninit, must_cast_mut, must_cast_ref};
 
 use crate::underlier::{NumCast, UnderlierType};
 

--- a/crates/field/src/arch/mod.rs
+++ b/crates/field/src/arch/mod.rs
@@ -28,7 +28,7 @@ cfg_if! {
 
 pub use arch_optimal::*;
 pub use portable::{
-	byte_sliced, packed_1, packed_16, packed_2, packed_32, packed_4, packed_64, packed_8,
-	packed_aes_16, packed_aes_32, packed_aes_64, packed_aes_8,
+	byte_sliced, packed_1, packed_2, packed_4, packed_8, packed_16, packed_32, packed_64,
+	packed_aes_8, packed_aes_16, packed_aes_32, packed_aes_64,
 };
 pub use strategies::*;

--- a/crates/field/src/arch/portable/byte_sliced/invert.rs
+++ b/crates/field/src/arch/portable/byte_sliced/invert.rs
@@ -4,9 +4,9 @@ use super::{
 	square::square_main,
 };
 use crate::{
+	AESTowerField8b, PackedField,
 	tower_levels::{TowerLevel, TowerLevelWithArithOps},
 	underlier::WithUnderlier,
-	AESTowerField8b, PackedField,
 };
 
 #[inline(always)]

--- a/crates/field/src/arch/portable/byte_sliced/mod.rs
+++ b/crates/field/src/arch/portable/byte_sliced/mod.rs
@@ -12,22 +12,22 @@ pub use underlier::ByteSlicedUnderlier;
 #[cfg(test)]
 pub mod tests {
 	use proptest::prelude::*;
-	use rand::{distributions::Uniform, rngs::StdRng, SeedableRng};
+	use rand::{SeedableRng, distributions::Uniform, rngs::StdRng};
 
 	use super::*;
 	use crate::{
+		PackedAESBinaryField1x128b, PackedAESBinaryField2x64b, PackedAESBinaryField2x128b,
+		PackedAESBinaryField4x32b, PackedAESBinaryField4x64b, PackedAESBinaryField4x128b,
+		PackedAESBinaryField8x16b, PackedAESBinaryField8x32b, PackedAESBinaryField8x64b,
+		PackedAESBinaryField16x8b, PackedAESBinaryField16x16b, PackedAESBinaryField16x32b,
+		PackedAESBinaryField32x8b, PackedAESBinaryField32x16b, PackedAESBinaryField64x8b,
+		PackedBinaryField128x1b, PackedBinaryField256x1b, PackedBinaryField512x1b, PackedField,
 		packed::{get_packed_slice, set_packed_slice},
 		underlier::WithUnderlier,
-		PackedAESBinaryField16x16b, PackedAESBinaryField16x32b, PackedAESBinaryField16x8b,
-		PackedAESBinaryField1x128b, PackedAESBinaryField2x128b, PackedAESBinaryField2x64b,
-		PackedAESBinaryField32x16b, PackedAESBinaryField32x8b, PackedAESBinaryField4x128b,
-		PackedAESBinaryField4x32b, PackedAESBinaryField4x64b, PackedAESBinaryField64x8b,
-		PackedAESBinaryField8x16b, PackedAESBinaryField8x32b, PackedAESBinaryField8x64b,
-		PackedBinaryField128x1b, PackedBinaryField256x1b, PackedBinaryField512x1b, PackedField,
 	};
 
-	fn scalars_vec_strategy<P: PackedField<Scalar: WithUnderlier<Underlier: Arbitrary>>>(
-	) -> impl Strategy<Value = Vec<P::Scalar>> {
+	fn scalars_vec_strategy<P: PackedField<Scalar: WithUnderlier<Underlier: Arbitrary>>>()
+	-> impl Strategy<Value = Vec<P::Scalar>> {
 		proptest::collection::vec(
 			any::<<P::Scalar as WithUnderlier>::Underlier>().prop_map(P::Scalar::from_underlier),
 			P::WIDTH..=P::WIDTH,

--- a/crates/field/src/arch/portable/byte_sliced/multiply.rs
+++ b/crates/field/src/arch/portable/byte_sliced/multiply.rs
@@ -1,8 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
 use crate::{
+	AESTowerField8b, PackedField,
 	tower_levels::{TowerLevel, TowerLevelWithArithOps},
 	underlier::WithUnderlier,
-	AESTowerField8b, PackedField,
 };
 
 #[inline(always)]

--- a/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
+++ b/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
@@ -67,11 +67,13 @@ macro_rules! define_byte_sliced_3d {
 			#[inline(always)]
 			pub unsafe fn get_byte_unchecked(&self, byte_index: usize) -> u8 {
 				let row = byte_index % Self::HEIGHT_BYTES;
-				self.data
-					.get_unchecked(row / Self::SCALAR_BYTES)
-					.get_unchecked(row % Self::SCALAR_BYTES)
-					.get_unchecked(byte_index / Self::HEIGHT_BYTES)
-					.to_underlier()
+				unsafe {
+					self.data
+						.get_unchecked(row / Self::SCALAR_BYTES)
+						.get_unchecked(row % Self::SCALAR_BYTES)
+						.get_unchecked(byte_index / Self::HEIGHT_BYTES)
+						.to_underlier()
+				}
 			}
 
 			/// Convert the byte-sliced field to an array of "ordinary" packed fields preserving the order of scalars.
@@ -126,8 +128,8 @@ macro_rules! define_byte_sliced_3d {
 			#[allow(clippy::modulo_one)]
 			#[inline(always)]
 			unsafe fn get_unchecked(&self, i: usize) -> Self::Scalar {
-				let element_rows = self.data.get_unchecked(i % Self::HEIGHT);
-				Self::Scalar::from_bases((0..Self::SCALAR_BYTES).map(|byte_index| {
+				let element_rows = unsafe { self.data.get_unchecked(i % Self::HEIGHT) };
+				Self::Scalar::from_bases((0..Self::SCALAR_BYTES).map(|byte_index| unsafe {
 					element_rows
 						.get_unchecked(byte_index)
 						.get_unchecked(i / Self::HEIGHT)
@@ -138,14 +140,16 @@ macro_rules! define_byte_sliced_3d {
 			#[allow(clippy::modulo_one)]
 			#[inline(always)]
 			unsafe fn set_unchecked(&mut self, i: usize, scalar: Self::Scalar) {
-				let element_rows = self.data.get_unchecked_mut(i % Self::HEIGHT);
+				let element_rows = unsafe { self.data.get_unchecked_mut(i % Self::HEIGHT) };
 				for byte_index in 0..Self::SCALAR_BYTES {
-					element_rows
-						.get_unchecked_mut(byte_index)
-						.set_unchecked(
-							i / Self::HEIGHT,
-							scalar.get_base_unchecked(byte_index),
-						);
+					unsafe {
+						element_rows
+							.get_unchecked_mut(byte_index)
+							.set_unchecked(
+								i / Self::HEIGHT,
+								scalar.get_base_unchecked(byte_index),
+							);
+					}
 				}
 			}
 
@@ -430,7 +434,7 @@ macro_rules! impl_spread {
 			let scaled_data: ScaledPackedField<PackedSequentialField, { Self::HEIGHT_BYTES }> =
 				bytemuck::must_cast(self);
 
-			let mut result = scaled_data.spread_unchecked(log_block_len, block_idx);
+			let mut result = unsafe { scaled_data.spread_unchecked(log_block_len, block_idx) };
 			let data: &mut [$packed_storage; Self::HEIGHT_BYTES] =
 				bytemuck::must_cast_mut(&mut result);
 			let underliers = WithUnderlier::to_underliers_arr_ref_mut(data);
@@ -639,9 +643,11 @@ macro_rules! define_byte_sliced_3d_1b {
 				type Packed8b =
 					PackedType<<$packed_storage as WithUnderlier>::Underlier, AESTowerField8b>;
 
-				Packed8b::cast_ext_ref(self.data.get_unchecked(byte_index % Self::HEIGHT_BYTES))
-					.get_unchecked(byte_index / Self::HEIGHT_BYTES)
-					.to_underlier()
+				unsafe {
+					Packed8b::cast_ext_ref(self.data.get_unchecked(byte_index % Self::HEIGHT_BYTES))
+						.get_unchecked(byte_index / Self::HEIGHT_BYTES)
+						.to_underlier()
+				}
 			}
 
 			/// Convert the byte-sliced field to an array of "ordinary" packed fields preserving the
@@ -707,17 +713,21 @@ macro_rules! define_byte_sliced_3d_1b {
 			#[allow(clippy::modulo_one)]
 			#[inline(always)]
 			unsafe fn get_unchecked(&self, i: usize) -> Self::Scalar {
-				self.data
-					.get_unchecked((i / 8) % Self::HEIGHT_BYTES)
-					.get_unchecked(8 * (i / (Self::HEIGHT_BYTES * 8)) + i % 8)
+				unsafe {
+					self.data
+						.get_unchecked((i / 8) % Self::HEIGHT_BYTES)
+						.get_unchecked(8 * (i / (Self::HEIGHT_BYTES * 8)) + i % 8)
+				}
 			}
 
 			#[allow(clippy::modulo_one)]
 			#[inline(always)]
 			unsafe fn set_unchecked(&mut self, i: usize, scalar: Self::Scalar) {
-				self.data
-					.get_unchecked_mut((i / 8) % Self::HEIGHT_BYTES)
-					.set_unchecked(8 * (i / (Self::HEIGHT_BYTES * 8)) + i % 8, scalar);
+				unsafe {
+					self.data
+						.get_unchecked_mut((i / 8) % Self::HEIGHT_BYTES)
+						.set_unchecked(8 * (i / (Self::HEIGHT_BYTES * 8)) + i % 8, scalar);
+				}
 			}
 
 			fn random(mut rng: impl rand::RngCore) -> Self {

--- a/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
+++ b/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
@@ -3,7 +3,7 @@
 use std::{
 	array,
 	fmt::Debug,
-	iter::{zip, Product, Sum},
+	iter::{Product, Sum, zip},
 	ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
 };
 
@@ -12,6 +12,10 @@ use bytemuck::{Pod, Zeroable};
 
 use super::{invert::invert_or_zero, multiply::mul, square::square};
 use crate::{
+	AESTowerField8b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField128b,
+	BinaryField1b, ExtensionField, PackedAESBinaryField16x8b, PackedAESBinaryField64x8b,
+	PackedBinaryField128x1b, PackedBinaryField256x1b, PackedBinaryField512x1b, PackedExtension,
+	PackedField,
 	arch::{
 		byte_sliced::underlier::ByteSlicedUnderlier, portable::packed_scaled::ScaledPackedField,
 	},
@@ -21,12 +25,8 @@ use crate::{
 		FieldLinearTransformation, IDTransformation, PackedTransformationFactory, Transformation,
 	},
 	packed_aes_field::PackedAESBinaryField32x8b,
-	tower_levels::{TowerLevel, TowerLevel1, TowerLevel16, TowerLevel2, TowerLevel4, TowerLevel8},
+	tower_levels::{TowerLevel, TowerLevel1, TowerLevel2, TowerLevel4, TowerLevel8, TowerLevel16},
 	underlier::{UnderlierWithBitOps, WithUnderlier},
-	AESTowerField128b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField8b,
-	BinaryField1b, ExtensionField, PackedAESBinaryField16x8b, PackedAESBinaryField64x8b,
-	PackedBinaryField128x1b, PackedBinaryField256x1b, PackedBinaryField512x1b, PackedExtension,
-	PackedField,
 };
 
 /// Packed transformation for byte-sliced fields with a scalar bigger than 8b.

--- a/crates/field/src/arch/portable/byte_sliced/square.rs
+++ b/crates/field/src/arch/portable/byte_sliced/square.rs
@@ -1,9 +1,9 @@
 // Copyright 2024-2025 Irreducible Inc.
 use super::multiply::mul_alpha;
 use crate::{
+	AESTowerField8b, PackedField,
 	tower_levels::{TowerLevel, TowerLevelWithArithOps},
 	underlier::WithUnderlier,
-	AESTowerField8b, PackedField,
 };
 
 #[inline(always)]

--- a/crates/field/src/arch/portable/hybrid_recursive_arithmetics.rs
+++ b/crates/field/src/arch/portable/hybrid_recursive_arithmetics.rs
@@ -2,10 +2,10 @@
 
 use super::packed_arithmetic::PackedTowerField;
 use crate::{
+	TowerExtensionField,
 	arch::HybridRecursiveStrategy,
 	arithmetic_traits::{MulAlpha, TaggedMul, TaggedMulAlpha, TaggedSquare},
 	packed::PackedField,
-	TowerExtensionField,
 };
 
 impl<P> TaggedMul<HybridRecursiveStrategy> for P

--- a/crates/field/src/arch/portable/packed.rs
+++ b/crates/field/src/arch/portable/packed.rs
@@ -293,12 +293,14 @@ where
 
 	#[inline]
 	unsafe fn get_unchecked(&self, i: usize) -> Self::Scalar {
-		Scalar::from_underlier(self.0.get_subvalue(i))
+		Scalar::from_underlier(unsafe { self.0.get_subvalue(i) })
 	}
 
 	#[inline]
 	unsafe fn set_unchecked(&mut self, i: usize, scalar: Scalar) {
-		self.0.set_subvalue(i, scalar.to_underlier());
+		unsafe {
+			self.0.set_subvalue(i, scalar.to_underlier());
+		}
 	}
 
 	#[inline]
@@ -354,9 +356,11 @@ where
 			1 << (Self::LOG_WIDTH - log_block_len)
 		);
 
-		self.0
-			.spread::<<Self::Scalar as WithUnderlier>::Underlier>(log_block_len, block_idx)
-			.into()
+		unsafe {
+			self.0
+				.spread::<<Self::Scalar as WithUnderlier>::Underlier>(log_block_len, block_idx)
+				.into()
+		}
 	}
 
 	#[inline]

--- a/crates/field/src/arch/portable/packed.rs
+++ b/crates/field/src/arch/portable/packed.rs
@@ -20,12 +20,12 @@ use subtle::{Choice, ConstantTimeEq};
 
 use super::packed_arithmetic::UnderlierWithBitConstants;
 use crate::{
+	BinaryField, PackedField,
 	arithmetic_traits::{Broadcast, InvertOrZero, MulAlpha, Square},
 	underlier::{
-		IterationMethods, IterationStrategy, NumCast, UnderlierType, UnderlierWithBitOps,
-		WithUnderlier, U1, U2, U4,
+		IterationMethods, IterationStrategy, NumCast, U1, U2, U4, UnderlierType,
+		UnderlierWithBitOps, WithUnderlier,
 	},
-	BinaryField, PackedField,
 };
 
 #[derive(PartialEq, Eq, Clone, Copy, Default, bytemuck::TransparentWrapper)]

--- a/crates/field/src/arch/portable/packed_1.rs
+++ b/crates/field/src/arch/portable/packed_1.rs
@@ -1,9 +1,9 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use super::packed::{impl_broadcast, impl_ops_for_zero_height, PackedPrimitiveType};
+use super::packed::{PackedPrimitiveType, impl_broadcast, impl_ops_for_zero_height};
 use crate::{
-	arch::PairwiseStrategy, arithmetic_traits::impl_transformation_with_strategy, underlier::U1,
-	BinaryField1b,
+	BinaryField1b, arch::PairwiseStrategy, arithmetic_traits::impl_transformation_with_strategy,
+	underlier::U1,
 };
 
 // Define 1 bit packed field types

--- a/crates/field/src/arch/portable/packed_128.rs
+++ b/crates/field/src/arch/portable/packed_128.rs
@@ -1,17 +1,17 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use super::{
-	packed::{impl_broadcast, impl_ops_for_zero_height, PackedPrimitiveType},
+	packed::{PackedPrimitiveType, impl_broadcast, impl_ops_for_zero_height},
 	packed_arithmetic::{alphas, impl_tower_constants},
 };
 use crate::{
+	BinaryField1b, BinaryField2b, BinaryField4b, BinaryField8b, BinaryField16b, BinaryField32b,
+	BinaryField64b, BinaryField128b,
 	arch::{PackedStrategy, PairwiseRecursiveStrategy, PairwiseStrategy, PairwiseTableStrategy},
 	arithmetic_traits::{
 		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
 		impl_transformation_with_strategy,
 	},
-	BinaryField128b, BinaryField16b, BinaryField1b, BinaryField2b, BinaryField32b, BinaryField4b,
-	BinaryField64b, BinaryField8b,
 };
 
 // Define 128 bit packed field types

--- a/crates/field/src/arch/portable/packed_16.rs
+++ b/crates/field/src/arch/portable/packed_16.rs
@@ -1,16 +1,16 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use super::{
-	packed::{impl_broadcast, impl_ops_for_zero_height, PackedPrimitiveType},
+	packed::{PackedPrimitiveType, impl_broadcast, impl_ops_for_zero_height},
 	packed_arithmetic::{alphas, impl_tower_constants},
 };
 use crate::{
+	BinaryField1b, BinaryField2b, BinaryField4b, BinaryField8b, BinaryField16b,
 	arch::{PackedStrategy, PairwiseRecursiveStrategy, PairwiseStrategy, PairwiseTableStrategy},
 	arithmetic_traits::{
 		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
 		impl_transformation_with_strategy,
 	},
-	BinaryField16b, BinaryField1b, BinaryField2b, BinaryField4b, BinaryField8b,
 };
 
 // Define 16 bit packed field types

--- a/crates/field/src/arch/portable/packed_2.rs
+++ b/crates/field/src/arch/portable/packed_2.rs
@@ -1,18 +1,18 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use super::{
-	packed::{impl_broadcast, impl_ops_for_zero_height, PackedPrimitiveType},
+	packed::{PackedPrimitiveType, impl_broadcast, impl_ops_for_zero_height},
 	packed_arithmetic::TowerConstants,
 	reuse_multiply_arithmetic::Alpha,
 };
 use crate::{
+	BinaryField1b, BinaryField2b,
 	arch::{PackedStrategy, PairwiseStrategy, PairwiseTableStrategy, ReuseMultiplyStrategy},
 	arithmetic_traits::{
 		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
 		impl_transformation_with_strategy,
 	},
-	underlier::{UnderlierType, U2},
-	BinaryField1b, BinaryField2b,
+	underlier::{U2, UnderlierType},
 };
 
 // Define 2 bit packed field types

--- a/crates/field/src/arch/portable/packed_256.rs
+++ b/crates/field/src/arch/portable/packed_256.rs
@@ -2,9 +2,9 @@
 
 use super::packed_scaled::packed_scaled_field;
 use crate::{
-	PackedBinaryField128x1b, PackedBinaryField16x8b, PackedBinaryField1x128b,
-	PackedBinaryField2x64b, PackedBinaryField32x4b, PackedBinaryField4x32b, PackedBinaryField64x2b,
-	PackedBinaryField8x16b,
+	PackedBinaryField1x128b, PackedBinaryField2x64b, PackedBinaryField4x32b,
+	PackedBinaryField8x16b, PackedBinaryField16x8b, PackedBinaryField32x4b, PackedBinaryField64x2b,
+	PackedBinaryField128x1b,
 };
 
 packed_scaled_field!(PackedBinaryField256x1b = [PackedBinaryField128x1b; 2]);

--- a/crates/field/src/arch/portable/packed_32.rs
+++ b/crates/field/src/arch/portable/packed_32.rs
@@ -3,16 +3,16 @@
 use cfg_if::cfg_if;
 
 use super::{
-	packed::{impl_broadcast, impl_ops_for_zero_height, PackedPrimitiveType},
+	packed::{PackedPrimitiveType, impl_broadcast, impl_ops_for_zero_height},
 	packed_arithmetic::{alphas, impl_tower_constants},
 };
 use crate::{
+	BinaryField1b, BinaryField2b, BinaryField4b, BinaryField8b, BinaryField16b, BinaryField32b,
 	arch::{PackedStrategy, PairwiseRecursiveStrategy, PairwiseStrategy},
 	arithmetic_traits::{
 		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
 		impl_transformation_with_strategy,
 	},
-	BinaryField16b, BinaryField1b, BinaryField2b, BinaryField32b, BinaryField4b, BinaryField8b,
 };
 
 // Define 32 bit packed field types

--- a/crates/field/src/arch/portable/packed_4.rs
+++ b/crates/field/src/arch/portable/packed_4.rs
@@ -1,18 +1,18 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use super::{
-	packed::{impl_broadcast, impl_ops_for_zero_height, PackedPrimitiveType},
+	packed::{PackedPrimitiveType, impl_broadcast, impl_ops_for_zero_height},
 	packed_arithmetic::TowerConstants,
 	reuse_multiply_arithmetic::Alpha,
 };
 use crate::{
+	BinaryField1b, BinaryField2b, BinaryField4b,
 	arch::{PackedStrategy, PairwiseRecursiveStrategy, PairwiseStrategy, ReuseMultiplyStrategy},
 	arithmetic_traits::{
 		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
 		impl_transformation_with_strategy,
 	},
-	underlier::{UnderlierType, U4},
-	BinaryField1b, BinaryField2b, BinaryField4b,
+	underlier::{U4, UnderlierType},
 };
 
 // Define 4 bit packed field types

--- a/crates/field/src/arch/portable/packed_64.rs
+++ b/crates/field/src/arch/portable/packed_64.rs
@@ -3,17 +3,17 @@
 use cfg_if::cfg_if;
 
 use super::{
-	packed::{impl_broadcast, impl_ops_for_zero_height, PackedPrimitiveType},
+	packed::{PackedPrimitiveType, impl_broadcast, impl_ops_for_zero_height},
 	packed_arithmetic::{alphas, impl_tower_constants},
 };
 use crate::{
+	BinaryField1b, BinaryField2b, BinaryField4b, BinaryField8b, BinaryField16b, BinaryField32b,
+	BinaryField64b,
 	arch::{PackedStrategy, PairwiseRecursiveStrategy, PairwiseStrategy},
 	arithmetic_traits::{
 		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
 		impl_transformation_with_strategy,
 	},
-	BinaryField16b, BinaryField1b, BinaryField2b, BinaryField32b, BinaryField4b, BinaryField64b,
-	BinaryField8b,
 };
 
 // Define 64 bit packed field types

--- a/crates/field/src/arch/portable/packed_8.rs
+++ b/crates/field/src/arch/portable/packed_8.rs
@@ -1,16 +1,16 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use super::{
-	packed::{impl_broadcast, impl_ops_for_zero_height, PackedPrimitiveType},
+	packed::{PackedPrimitiveType, impl_broadcast, impl_ops_for_zero_height},
 	packed_arithmetic::{alphas, impl_tower_constants},
 };
 use crate::{
+	BinaryField1b, BinaryField2b, BinaryField4b, BinaryField8b,
 	arch::{PackedStrategy, PairwiseRecursiveStrategy, PairwiseStrategy, PairwiseTableStrategy},
 	arithmetic_traits::{
 		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
 		impl_transformation_with_strategy,
 	},
-	BinaryField1b, BinaryField2b, BinaryField4b, BinaryField8b,
 };
 
 // Define 8 bit packed field types

--- a/crates/field/src/arch/portable/packed_aes_128.rs
+++ b/crates/field/src/arch/portable/packed_aes_128.rs
@@ -1,12 +1,12 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use super::{
-	packed::{impl_broadcast, PackedPrimitiveType},
+	packed::{PackedPrimitiveType, impl_broadcast},
 	packed_arithmetic::{alphas, impl_tower_constants},
 };
 use crate::{
 	aes_field::{
-		AESTowerField128b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField8b,
+		AESTowerField8b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField128b,
 	},
 	arch::{PackedStrategy, PairwiseRecursiveStrategy, PairwiseStrategy, PairwiseTableStrategy},
 	arithmetic_traits::{

--- a/crates/field/src/arch/portable/packed_aes_16.rs
+++ b/crates/field/src/arch/portable/packed_aes_16.rs
@@ -1,16 +1,16 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use super::{
-	packed::{impl_broadcast, PackedPrimitiveType},
+	packed::{PackedPrimitiveType, impl_broadcast},
 	packed_arithmetic::impl_tower_constants,
 };
 use crate::{
+	AESTowerField8b, AESTowerField16b,
 	arch::{PackedStrategy, PairwiseRecursiveStrategy, PairwiseStrategy, PairwiseTableStrategy},
 	arithmetic_traits::{
 		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
 		impl_transformation_with_strategy,
 	},
-	AESTowerField16b, AESTowerField8b,
 };
 
 // Define 16 bit packed field types

--- a/crates/field/src/arch/portable/packed_aes_256.rs
+++ b/crates/field/src/arch/portable/packed_aes_256.rs
@@ -2,8 +2,8 @@
 
 use super::packed_scaled::packed_scaled_field;
 use crate::{
-	PackedAESBinaryField16x8b, PackedAESBinaryField1x128b, PackedAESBinaryField2x64b,
-	PackedAESBinaryField4x32b, PackedAESBinaryField8x16b,
+	PackedAESBinaryField1x128b, PackedAESBinaryField2x64b, PackedAESBinaryField4x32b,
+	PackedAESBinaryField8x16b, PackedAESBinaryField16x8b,
 };
 
 packed_scaled_field!(PackedAESBinaryField32x8b = [PackedAESBinaryField16x8b; 2]);

--- a/crates/field/src/arch/portable/packed_aes_32.rs
+++ b/crates/field/src/arch/portable/packed_aes_32.rs
@@ -3,16 +3,16 @@
 use cfg_if::cfg_if;
 
 use super::{
-	packed::{impl_broadcast, PackedPrimitiveType},
+	packed::{PackedPrimitiveType, impl_broadcast},
 	packed_arithmetic::{alphas, impl_tower_constants},
 };
 use crate::{
+	AESTowerField8b, AESTowerField16b, AESTowerField32b,
 	arch::{PackedStrategy, PairwiseRecursiveStrategy, PairwiseStrategy, PairwiseTableStrategy},
 	arithmetic_traits::{
 		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
 		impl_transformation_with_strategy,
 	},
-	AESTowerField16b, AESTowerField32b, AESTowerField8b,
 };
 
 // Define 32 bit packed field types

--- a/crates/field/src/arch/portable/packed_aes_64.rs
+++ b/crates/field/src/arch/portable/packed_aes_64.rs
@@ -3,16 +3,16 @@
 use cfg_if::cfg_if;
 
 use super::{
-	packed::{impl_broadcast, PackedPrimitiveType},
+	packed::{PackedPrimitiveType, impl_broadcast},
 	packed_arithmetic::{alphas, impl_tower_constants},
 };
 use crate::{
+	AESTowerField8b, AESTowerField16b, AESTowerField32b, AESTowerField64b,
 	arch::{PackedStrategy, PairwiseRecursiveStrategy, PairwiseStrategy, PairwiseTableStrategy},
 	arithmetic_traits::{
 		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
 		impl_transformation_with_strategy,
 	},
-	AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField8b,
 };
 
 // Define 64 bit packed field types

--- a/crates/field/src/arch/portable/packed_aes_8.rs
+++ b/crates/field/src/arch/portable/packed_aes_8.rs
@@ -1,13 +1,13 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use super::packed::{impl_broadcast, PackedPrimitiveType};
+use super::packed::{PackedPrimitiveType, impl_broadcast};
 use crate::{
+	AESTowerField8b,
 	arch::{PairwiseStrategy, PairwiseTableStrategy},
 	arithmetic_traits::{
 		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
 		impl_transformation_with_strategy,
 	},
-	AESTowerField8b,
 };
 
 // Define 16 bit packed field types

--- a/crates/field/src/arch/portable/packed_arithmetic.rs
+++ b/crates/field/src/arch/portable/packed_arithmetic.rs
@@ -1,6 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use crate::{
+	PackedExtension, PackedField, TowerField,
 	arch::PackedStrategy,
 	arithmetic_traits::{
 		MulAlpha, TaggedInvertOrZero, TaggedMul, TaggedMulAlpha, TaggedPackedTransformationFactory,
@@ -10,7 +11,6 @@ use crate::{
 	linear_transformation::{FieldLinearTransformation, Transformation},
 	packed::PackedBinaryField,
 	underlier::{UnderlierType, UnderlierWithBitOps, WithUnderlier},
-	PackedExtension, PackedField, TowerField,
 };
 
 pub trait UnderlierWithBitConstants: UnderlierWithBitOps
@@ -409,17 +409,17 @@ mod tests {
 
 	use super::*;
 	use crate::{
+		BinaryField1b, BinaryField2b, BinaryField4b, BinaryField8b, BinaryField16b, BinaryField32b,
+		BinaryField64b,
 		arch::portable::packed_128::{
-			PackedBinaryField16x8b, PackedBinaryField1x128b, PackedBinaryField2x64b,
-			PackedBinaryField32x4b, PackedBinaryField4x32b, PackedBinaryField64x2b,
-			PackedBinaryField8x16b,
+			PackedBinaryField1x128b, PackedBinaryField2x64b, PackedBinaryField4x32b,
+			PackedBinaryField8x16b, PackedBinaryField16x8b, PackedBinaryField32x4b,
+			PackedBinaryField64x2b,
 		},
 		test_utils::{
 			define_invert_tests, define_mul_alpha_tests, define_multiply_tests,
 			define_square_tests, define_transformation_tests,
 		},
-		BinaryField16b, BinaryField1b, BinaryField2b, BinaryField32b, BinaryField4b,
-		BinaryField64b, BinaryField8b,
 	};
 
 	const NUM_TESTS: u64 = 100;

--- a/crates/field/src/arch/portable/packed_polyval_128.rs
+++ b/crates/field/src/arch/portable/packed_polyval_128.rs
@@ -13,12 +13,12 @@ use std::{
 	ops::{BitXor, Mul},
 };
 
-use super::packed::{impl_broadcast, PackedPrimitiveType};
+use super::packed::{PackedPrimitiveType, impl_broadcast};
 use crate::{
-	arch::{PairwiseStrategy, ReuseMultiplyStrategy},
-	arithmetic_traits::{impl_square_with, impl_transformation_with_strategy, InvertOrZero},
-	packed::PackedField,
 	BinaryField128bPolyval,
+	arch::{PairwiseStrategy, ReuseMultiplyStrategy},
+	arithmetic_traits::{InvertOrZero, impl_square_with, impl_transformation_with_strategy},
+	packed::PackedField,
 };
 
 pub type PackedBinaryPolyval1x128b = PackedPrimitiveType<u128, BinaryField128bPolyval>;

--- a/crates/field/src/arch/portable/packed_scaled.rs
+++ b/crates/field/src/arch/portable/packed_scaled.rs
@@ -12,6 +12,7 @@ use rand::RngCore;
 use subtle::ConstantTimeEq;
 
 use crate::{
+	Field, PackedField,
 	arithmetic_traits::MulAlpha,
 	as_packed_field::PackScalar,
 	linear_transformation::{
@@ -19,7 +20,6 @@ use crate::{
 	},
 	packed::PackedBinaryField,
 	underlier::{ScaledUnderlier, UnderlierType, WithUnderlier},
-	Field, PackedField,
 };
 
 /// Packed field that just stores smaller packed field N times and performs all operations

--- a/crates/field/src/arch/portable/pairwise_recursive_arithmetic.rs
+++ b/crates/field/src/arch/portable/pairwise_recursive_arithmetic.rs
@@ -1,12 +1,12 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use crate::{
+	TowerExtensionField,
 	arch::PairwiseRecursiveStrategy,
 	arithmetic_traits::{
 		InvertOrZero, MulAlpha, Square, TaggedInvertOrZero, TaggedMul, TaggedMulAlpha, TaggedSquare,
 	},
 	packed::PackedField,
-	TowerExtensionField,
 };
 
 impl<P> TaggedMul<PairwiseRecursiveStrategy> for P

--- a/crates/field/src/arch/portable/pairwise_table_arithmetic.rs
+++ b/crates/field/src/arch/portable/pairwise_table_arithmetic.rs
@@ -170,7 +170,7 @@ fn multiply_8b_using_log_table(
 	log_table: &[u8; 256],
 	exp_table: &[u8; 256],
 ) -> u8 {
-	let result = if lhs != 0 && rhs != 0 {
+	if lhs != 0 && rhs != 0 {
 		let log_table_index = log_table[lhs as usize] as usize + log_table[rhs as usize] as usize;
 		let log_table_index = if log_table_index > 254 {
 			log_table_index - 255
@@ -188,9 +188,7 @@ fn multiply_8b_using_log_table(
 		}
 	} else {
 		0
-	};
-
-	result
+	}
 }
 
 /// Return the result of the operation by a table search for each scalar value

--- a/crates/field/src/arch/portable/pairwise_table_arithmetic.rs
+++ b/crates/field/src/arch/portable/pairwise_table_arithmetic.rs
@@ -2,11 +2,11 @@
 
 use super::packed::PackedPrimitiveType;
 use crate::{
+	AESTowerField8b, BinaryField2b, BinaryField4b, BinaryField8b,
 	arch::PairwiseTableStrategy,
 	arithmetic_traits::{TaggedInvertOrZero, TaggedMul, TaggedMulAlpha, TaggedSquare},
 	packed::PackedField,
 	underlier::UnderlierType,
-	AESTowerField8b, BinaryField2b, BinaryField4b, BinaryField8b,
 };
 
 impl<U: UnderlierType> TaggedMul<PairwiseTableStrategy> for PackedPrimitiveType<U, BinaryField2b>

--- a/crates/field/src/arch/portable/underlier_constants.rs
+++ b/crates/field/src/arch/portable/underlier_constants.rs
@@ -1,9 +1,9 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use super::packed_arithmetic::{
-	interleave_mask_even, interleave_mask_odd, UnderlierWithBitConstants,
+	UnderlierWithBitConstants, interleave_mask_even, interleave_mask_odd,
 };
-use crate::underlier::{UnderlierType, U1, U2, U4};
+use crate::underlier::{U1, U2, U4, UnderlierType};
 
 impl UnderlierWithBitConstants for U1 {
 	const INTERLEAVE_EVEN_MASK: &'static [Self] = &[];

--- a/crates/field/src/arch/x86_64/gfni/aes_isomorphic.rs
+++ b/crates/field/src/arch/x86_64/gfni/aes_isomorphic.rs
@@ -1,13 +1,13 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use super::gfni_arithmetics::{linear_transform, GfniType, AES_TO_TOWER_MAP, TOWER_TO_AES_MAP};
+use super::gfni_arithmetics::{AES_TO_TOWER_MAP, GfniType, TOWER_TO_AES_MAP, linear_transform};
 use crate::{
-	arch::{portable::packed::PackedPrimitiveType, AESIsomorphicStrategy},
+	AESTowerField8b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField128b,
+	BinaryField8b, BinaryField16b, BinaryField32b, BinaryField64b, BinaryField128b, PackedField,
+	TowerField,
+	arch::{AESIsomorphicStrategy, portable::packed::PackedPrimitiveType},
 	arithmetic_traits::{TaggedInvertOrZero, TaggedMul, TaggedSquare},
 	underlier::UnderlierType,
-	AESTowerField128b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField8b,
-	BinaryField128b, BinaryField16b, BinaryField32b, BinaryField64b, BinaryField8b, PackedField,
-	TowerField,
 };
 
 /// Canonical field that is isomorphic to the corresponding AES field.

--- a/crates/field/src/arch/x86_64/gfni/gfni_arithmetics.rs
+++ b/crates/field/src/arch/x86_64/gfni/gfni_arithmetics.rs
@@ -5,17 +5,17 @@ use std::array;
 use binius_utils::checked_arithmetics::checked_int_div;
 
 use crate::{
+	BinaryField, PackedField, TowerField,
 	arch::{
+		GfniStrategy,
 		portable::packed::PackedPrimitiveType,
 		x86_64::{m128::m128_from_u128, simd::simd_arithmetic::TowerSimdType},
-		GfniStrategy,
 	},
 	arithmetic_traits::{TaggedInvertOrZero, TaggedMul, TaggedPackedTransformationFactory},
 	is_aes_tower, is_canonical_tower,
 	linear_transformation::{FieldLinearTransformation, Transformation},
 	packed::PackedBinaryField,
 	underlier::{Divisible, UnderlierType, WithUnderlier},
-	BinaryField, PackedField, TowerField,
 };
 
 #[rustfmt::skip]

--- a/crates/field/src/arch/x86_64/gfni/m256.rs
+++ b/crates/field/src/arch/x86_64/gfni/m256.rs
@@ -3,16 +3,16 @@
 use core::arch::x86_64::*;
 use std::array;
 
-use gfni_arithmetics::{get_8x8_matrix, GfniType};
+use gfni_arithmetics::{GfniType, get_8x8_matrix};
 use seq_macro::seq;
 
 use super::*;
 use crate::{
-	arch::{x86_64::m256::M256, GfniSpecializedStrategy256b},
+	BinaryField, PackedField,
+	arch::{GfniSpecializedStrategy256b, x86_64::m256::M256},
 	arithmetic_traits::TaggedPackedTransformationFactory,
 	linear_transformation::{FieldLinearTransformation, Transformation},
 	underlier::WithUnderlier,
-	BinaryField, PackedField,
 };
 
 impl GfniType for M256 {

--- a/crates/field/src/arch/x86_64/gfni/m512.rs
+++ b/crates/field/src/arch/x86_64/gfni/m512.rs
@@ -3,15 +3,15 @@
 use core::arch::x86_64::*;
 use std::array;
 
-use gfni_arithmetics::{get_8x8_matrix, GfniType};
+use gfni_arithmetics::{GfniType, get_8x8_matrix};
 
 use super::*;
 use crate::{
-	arch::{x86_64::m512::M512, GfniSpecializedStrategy512b},
+	BinaryField, PackedField,
+	arch::{GfniSpecializedStrategy512b, x86_64::m512::M512},
 	arithmetic_traits::TaggedPackedTransformationFactory,
 	linear_transformation::{FieldLinearTransformation, Transformation},
 	underlier::WithUnderlier,
-	BinaryField, PackedField,
 };
 
 impl GfniType for M512 {

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -288,7 +288,7 @@ impl ConditionallySelectable for M128 {
 
 impl Random for M128 {
 	fn random(mut rng: impl RngCore) -> Self {
-		let val: u128 = rng.gen();
+		let val: u128 = rng.r#gen();
 		val.into()
 	}
 }

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -6,29 +6,29 @@ use std::{
 	ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not, Shl, Shr},
 };
 
-use bytemuck::{must_cast, Pod, Zeroable};
+use bytemuck::{Pod, Zeroable, must_cast};
 use rand::{Rng, RngCore};
 use seq_macro::seq;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use crate::{
+	BinaryField,
 	arch::{
 		binary_utils::{as_array_mut, as_array_ref, make_func_to_i8},
 		portable::{
-			packed::{impl_pack_scalar, PackedPrimitiveType},
+			packed::{PackedPrimitiveType, impl_pack_scalar},
 			packed_arithmetic::{
-				interleave_mask_even, interleave_mask_odd, UnderlierWithBitConstants,
+				UnderlierWithBitConstants, interleave_mask_even, interleave_mask_odd,
 			},
 		},
 	},
 	arithmetic_traits::Broadcast,
 	tower_levels::TowerLevel,
 	underlier::{
-		impl_divisible, impl_iteration, spread_fallback, transpose_128b_values,
-		unpack_hi_128b_fallback, unpack_lo_128b_fallback, NumCast, Random, SmallU, SpreadToByte,
-		UnderlierType, UnderlierWithBitOps, WithUnderlier, U1, U2, U4,
+		NumCast, Random, SmallU, SpreadToByte, U1, U2, U4, UnderlierType, UnderlierWithBitOps,
+		WithUnderlier, impl_divisible, impl_iteration, spread_fallback, transpose_128b_values,
+		unpack_hi_128b_fallback, unpack_lo_128b_fallback,
 	},
-	BinaryField,
 };
 
 /// 128-bit value that is used for 128-bit SIMD operations
@@ -184,11 +184,7 @@ impl Not for M128 {
 
 /// `std::cmp::max` isn't const, so we need our own implementation
 pub(crate) const fn max_i32(left: i32, right: i32) -> i32 {
-	if left > right {
-		left
-	} else {
-		right
-	}
+	if left > right { left } else { right }
 }
 
 /// This solution shows 4X better performance.

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -903,47 +903,47 @@ where
 #[inline]
 unsafe fn interleave_bits(a: __m128i, b: __m128i, log_block_len: usize) -> (__m128i, __m128i) {
 	match log_block_len {
-		0 => {
+		0 => unsafe {
 			let mask = _mm_set1_epi8(0x55i8);
 			interleave_bits_imm::<1>(a, b, mask)
-		}
-		1 => {
+		},
+		1 => unsafe {
 			let mask = _mm_set1_epi8(0x33i8);
 			interleave_bits_imm::<2>(a, b, mask)
-		}
-		2 => {
+		},
+		2 => unsafe {
 			let mask = _mm_set1_epi8(0x0fi8);
 			interleave_bits_imm::<4>(a, b, mask)
-		}
-		3 => {
+		},
+		3 => unsafe {
 			let shuffle = _mm_set_epi8(15, 13, 11, 9, 7, 5, 3, 1, 14, 12, 10, 8, 6, 4, 2, 0);
 			let a = _mm_shuffle_epi8(a, shuffle);
 			let b = _mm_shuffle_epi8(b, shuffle);
 			let a_prime = _mm_unpacklo_epi8(a, b);
 			let b_prime = _mm_unpackhi_epi8(a, b);
 			(a_prime, b_prime)
-		}
-		4 => {
+		},
+		4 => unsafe {
 			let shuffle = _mm_set_epi8(15, 14, 11, 10, 7, 6, 3, 2, 13, 12, 9, 8, 5, 4, 1, 0);
 			let a = _mm_shuffle_epi8(a, shuffle);
 			let b = _mm_shuffle_epi8(b, shuffle);
 			let a_prime = _mm_unpacklo_epi16(a, b);
 			let b_prime = _mm_unpackhi_epi16(a, b);
 			(a_prime, b_prime)
-		}
-		5 => {
+		},
+		5 => unsafe {
 			let shuffle = _mm_set_epi8(15, 14, 13, 12, 7, 6, 5, 4, 11, 10, 9, 8, 3, 2, 1, 0);
 			let a = _mm_shuffle_epi8(a, shuffle);
 			let b = _mm_shuffle_epi8(b, shuffle);
 			let a_prime = _mm_unpacklo_epi32(a, b);
 			let b_prime = _mm_unpackhi_epi32(a, b);
 			(a_prime, b_prime)
-		}
-		6 => {
+		},
+		6 => unsafe {
 			let a_prime = _mm_unpacklo_epi64(a, b);
 			let b_prime = _mm_unpackhi_epi64(a, b);
 			(a_prime, b_prime)
-		}
+		},
 		_ => panic!("unsupported block length"),
 	}
 }
@@ -954,10 +954,12 @@ unsafe fn interleave_bits_imm<const BLOCK_LEN: i32>(
 	b: __m128i,
 	mask: __m128i,
 ) -> (__m128i, __m128i) {
-	let t = _mm_and_si128(_mm_xor_si128(_mm_srli_epi64::<BLOCK_LEN>(a), b), mask);
-	let a_prime = _mm_xor_si128(a, _mm_slli_epi64::<BLOCK_LEN>(t));
-	let b_prime = _mm_xor_si128(b, t);
-	(a_prime, b_prime)
+	unsafe {
+		let t = _mm_and_si128(_mm_xor_si128(_mm_srli_epi64::<BLOCK_LEN>(a), b), mask);
+		let a_prime = _mm_xor_si128(a, _mm_slli_epi64::<BLOCK_LEN>(t));
+		let b_prime = _mm_xor_si128(b, t);
+		(a_prime, b_prime)
+	}
 }
 
 impl_iteration!(M128,

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -492,7 +492,7 @@ impl UnderlierWithBitOps for M128 {
 		match T::LOG_BITS {
 			0 => match log_block_len {
 				0 => Self::fill_with_bit(((u128::from(self) >> block_idx) & 1) as _),
-				1 => {
+				1 => unsafe {
 					let bits: [u8; 2] =
 						array::from_fn(|i| ((u128::from(self) >> (block_idx * 2 + i)) & 1) as _);
 
@@ -501,8 +501,8 @@ impl UnderlierWithBitOps for M128 {
 						u64::fill_with_bit(bits[0]) as i64,
 					)
 					.into()
-				}
-				2 => {
+				},
+				2 => unsafe {
 					let bits: [u8; 4] =
 						array::from_fn(|i| ((u128::from(self) >> (block_idx * 4 + i)) & 1) as _);
 
@@ -513,8 +513,8 @@ impl UnderlierWithBitOps for M128 {
 						u32::fill_with_bit(bits[0]) as i32,
 					)
 					.into()
-				}
-				3 => {
+				},
+				3 => unsafe {
 					let bits: [u8; 8] =
 						array::from_fn(|i| ((u128::from(self) >> (block_idx * 8 + i)) & 1) as _);
 
@@ -529,8 +529,8 @@ impl UnderlierWithBitOps for M128 {
 						u16::fill_with_bit(bits[0]) as i16,
 					)
 					.into()
-				}
-				4 => {
+				},
+				4 => unsafe {
 					let bits: [u8; 16] =
 						array::from_fn(|i| ((u128::from(self) >> (block_idx * 16 + i)) & 1) as _);
 
@@ -553,16 +553,16 @@ impl UnderlierWithBitOps for M128 {
 						u8::fill_with_bit(bits[0]) as i8,
 					)
 					.into()
-				}
-				_ => spread_fallback(self, log_block_len, block_idx),
+				},
+				_ => unsafe { spread_fallback(self, log_block_len, block_idx) },
 			},
 			1 => match log_block_len {
-				0 => {
+				0 => unsafe {
 					let value =
 						U2::new((u128::from(self) >> (block_idx * 2)) as _).spread_to_byte();
 
 					_mm_set1_epi8(value as i8).into()
-				}
+				},
 				1 => {
 					let bytes: [u8; 2] = array::from_fn(|i| {
 						U2::new((u128::from(self) >> (block_idx * 4 + i * 2)) as _).spread_to_byte()
@@ -593,14 +593,14 @@ impl UnderlierWithBitOps for M128 {
 
 					Self::from_fn::<u8>(|i| bytes[i])
 				}
-				_ => spread_fallback(self, log_block_len, block_idx),
+				_ => unsafe { spread_fallback(self, log_block_len, block_idx) },
 			},
 			2 => match log_block_len {
 				0 => {
 					let value =
 						U4::new((u128::from(self) >> (block_idx * 4)) as _).spread_to_byte();
 
-					_mm_set1_epi8(value as i8).into()
+					unsafe { _mm_set1_epi8(value as i8).into() }
 				}
 				1 => {
 					let values: [u8; 2] = array::from_fn(|i| {
@@ -633,13 +633,13 @@ impl UnderlierWithBitOps for M128 {
 
 					Self::from_fn::<u8>(|i| values[i])
 				}
-				_ => spread_fallback(self, log_block_len, block_idx),
+				_ => unsafe { spread_fallback(self, log_block_len, block_idx) },
 			},
 			3 => match log_block_len {
-				0 => _mm_shuffle_epi8(self.0, LOG_B8_0[block_idx].0).into(),
-				1 => _mm_shuffle_epi8(self.0, LOG_B8_1[block_idx].0).into(),
-				2 => _mm_shuffle_epi8(self.0, LOG_B8_2[block_idx].0).into(),
-				3 => _mm_shuffle_epi8(self.0, LOG_B8_3[block_idx].0).into(),
+				0 => unsafe { _mm_shuffle_epi8(self.0, LOG_B8_0[block_idx].0).into() },
+				1 => unsafe { _mm_shuffle_epi8(self.0, LOG_B8_1[block_idx].0).into() },
+				2 => unsafe { _mm_shuffle_epi8(self.0, LOG_B8_2[block_idx].0).into() },
+				3 => unsafe { _mm_shuffle_epi8(self.0, LOG_B8_3[block_idx].0).into() },
 				4 => self,
 				_ => panic!("unsupported block length"),
 			},
@@ -647,7 +647,7 @@ impl UnderlierWithBitOps for M128 {
 				0 => {
 					let value = (u128::from(self) >> (block_idx * 16)) as u16;
 
-					_mm_set1_epi16(value as i16).into()
+					unsafe { _mm_set1_epi16(value as i16).into() }
 				}
 				1 => {
 					let values: [u16; 2] =
@@ -665,11 +665,11 @@ impl UnderlierWithBitOps for M128 {
 				_ => panic!("unsupported block length"),
 			},
 			5 => match log_block_len {
-				0 => {
+				0 => unsafe {
 					let value = (u128::from(self) >> (block_idx * 32)) as u32;
 
 					_mm_set1_epi32(value as i32).into()
-				}
+				},
 				1 => {
 					let values: [u32; 2] =
 						array::from_fn(|i| (u128::from(self) >> (block_idx * 64 + i * 32)) as u32);
@@ -680,11 +680,11 @@ impl UnderlierWithBitOps for M128 {
 				_ => panic!("unsupported block length"),
 			},
 			6 => match log_block_len {
-				0 => {
+				0 => unsafe {
 					let value = (u128::from(self) >> (block_idx * 64)) as u64;
 
 					_mm_set1_epi64x(value as i64).into()
-				}
+				},
 				1 => self,
 				_ => panic!("unsupported block length"),
 			},

--- a/crates/field/src/arch/x86_64/m256.rs
+++ b/crates/field/src/arch/x86_64/m256.rs
@@ -290,7 +290,7 @@ impl ConditionallySelectable for M256 {
 
 impl Random for M256 {
 	fn random(mut rng: impl RngCore) -> Self {
-		let val: [u128; 2] = rng.gen();
+		let val: [u128; 2] = rng.r#gen();
 		val.into()
 	}
 }

--- a/crates/field/src/arch/x86_64/m256.rs
+++ b/crates/field/src/arch/x86_64/m256.rs
@@ -6,19 +6,20 @@ use std::{
 	ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not, Shl, Shr},
 };
 
-use bytemuck::{must_cast, Pod, Zeroable};
+use bytemuck::{Pod, Zeroable, must_cast};
 use cfg_if::cfg_if;
 use rand::{Rng, RngCore};
 use seq_macro::seq;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use crate::{
+	BinaryField,
 	arch::{
 		binary_utils::{as_array_mut, as_array_ref, make_func_to_i8},
 		portable::{
-			packed::{impl_pack_scalar, PackedPrimitiveType},
+			packed::{PackedPrimitiveType, impl_pack_scalar},
 			packed_arithmetic::{
-				interleave_mask_even, interleave_mask_odd, UnderlierWithBitConstants,
+				UnderlierWithBitConstants, interleave_mask_even, interleave_mask_odd,
 			},
 		},
 		x86_64::m128::bitshift_128b,
@@ -26,12 +27,11 @@ use crate::{
 	arithmetic_traits::Broadcast,
 	tower_levels::TowerLevel,
 	underlier::{
+		NumCast, Random, SmallU, U1, U2, U4, UnderlierType, UnderlierWithBitOps, WithUnderlier,
 		get_block_values, get_spread_bytes, impl_divisible, impl_iteration,
 		pair_unpack_lo_hi_128b_lanes, spread_fallback, transpose_128b_blocks_low_to_high,
-		unpack_hi_128b_fallback, unpack_lo_128b_fallback, NumCast, Random, SmallU, UnderlierType,
-		UnderlierWithBitOps, WithUnderlier, U1, U2, U4,
+		unpack_hi_128b_fallback, unpack_lo_128b_fallback,
 	},
-	BinaryField,
 };
 
 /// 256-bit value that is used for 256-bit SIMD operations

--- a/crates/field/src/arch/x86_64/m256.rs
+++ b/crates/field/src/arch/x86_64/m256.rs
@@ -555,126 +555,126 @@ impl UnderlierWithBitOps for M256 {
 	{
 		match T::LOG_BITS {
 			0 => match log_block_len {
-				0 => {
+				0 => unsafe {
 					let bits = get_block_values::<_, U1, 1>(self, block_idx)[0];
 					Self::fill_with_bit(bits.val())
-				}
-				1 => {
+				},
+				1 => unsafe {
 					let bits = get_block_values::<_, U1, 2>(self, block_idx);
 					let values: [u64; 2] = bits.map(|b| u64::fill_with_bit(b.val()));
 					Self::from_fn::<u64>(|i| values[i / 2])
-				}
-				2 => {
+				},
+				2 => unsafe {
 					let bits = get_block_values::<_, U1, 4>(self, block_idx);
 					Self::from_fn::<u64>(|i| u64::fill_with_bit(bits[i].val()))
-				}
-				3 => {
+				},
+				3 => unsafe {
 					let bits = get_block_values::<_, U1, 8>(self, block_idx);
 					Self::from_fn::<u32>(|i| u32::fill_with_bit(bits[i].val()))
-				}
-				4 => {
+				},
+				4 => unsafe {
 					let bits = get_block_values::<_, U1, 16>(self, block_idx);
 					Self::from_fn::<u16>(|i| u16::fill_with_bit(bits[i].val()))
-				}
-				5 => {
+				},
+				5 => unsafe {
 					let bits = get_block_values::<_, U1, 32>(self, block_idx);
 					Self::from_fn::<u8>(|i| u8::fill_with_bit(bits[i].val()))
-				}
-				_ => spread_fallback(self, log_block_len, block_idx),
+				},
+				_ => unsafe { spread_fallback(self, log_block_len, block_idx) },
 			},
 			1 => match log_block_len {
-				0 => {
+				0 => unsafe {
 					let byte = get_spread_bytes::<_, U2, 1>(self, block_idx)[0];
 
 					_mm256_set1_epi8(byte as _).into()
-				}
-				1 => {
+				},
+				1 => unsafe {
 					let bytes = get_spread_bytes::<_, U2, 2>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i / 16])
-				}
-				2 => {
+				},
+				2 => unsafe {
 					let bytes = get_spread_bytes::<_, U2, 4>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i / 8])
-				}
-				3 => {
+				},
+				3 => unsafe {
 					let bytes = get_spread_bytes::<_, U2, 8>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i / 4])
-				}
-				4 => {
+				},
+				4 => unsafe {
 					let bytes = get_spread_bytes::<_, U2, 16>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i / 2])
-				}
-				5 => {
+				},
+				5 => unsafe {
 					let bytes = get_spread_bytes::<_, U2, 32>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i])
-				}
-				_ => spread_fallback(self, log_block_len, block_idx),
+				},
+				_ => unsafe { spread_fallback(self, log_block_len, block_idx) },
 			},
 			2 => match log_block_len {
-				0 => {
+				0 => unsafe {
 					let byte = get_spread_bytes::<_, U4, 1>(self, block_idx)[0];
 
 					_mm256_set1_epi8(byte as _).into()
-				}
-				1 => {
+				},
+				1 => unsafe {
 					let bytes = get_spread_bytes::<_, U4, 2>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i / 16])
-				}
-				2 => {
+				},
+				2 => unsafe {
 					let bytes = get_spread_bytes::<_, U4, 4>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i / 8])
-				}
-				3 => {
+				},
+				3 => unsafe {
 					let bytes = get_spread_bytes::<_, U4, 8>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i / 4])
-				}
-				4 => {
+				},
+				4 => unsafe {
 					let bytes = get_spread_bytes::<_, U4, 16>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i / 2])
-				}
-				5 => {
+				},
+				5 => unsafe {
 					let bytes = get_spread_bytes::<_, U4, 32>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i])
-				}
-				_ => spread_fallback(self, log_block_len, block_idx),
+				},
+				_ => unsafe { spread_fallback(self, log_block_len, block_idx) },
 			},
 			3 => {
 				cfg_if! {
 					if #[cfg(target_feature = "avx512f")] {
 						match log_block_len {
-							0 => {
+							0 => unsafe {
 								let byte = get_block_values::<_, u8, 1>(self, block_idx)[0];
 								_mm256_set1_epi8(byte as _).into()
 							}
-							1 => {
+							1 => unsafe {
 								_mm256_permutexvar_epi8(
 									LOG_B8_1[block_idx],
 									self.0,
 								).into()
 							}
-							2 => {
+							2 => unsafe {
 								_mm256_permutexvar_epi8(
 									LOG_B8_2[block_idx],
 									self.0,
 								).into()
 							}
-							3 => {
+							3 => unsafe {
 								_mm256_permutexvar_epi8(
 									LOG_B8_3[block_idx],
 									self.0,
 								).into()
 							}
-							4 => {
+							4 => unsafe {
 								_mm256_permutexvar_epi8(
 									LOG_B8_4[block_idx],
 									self.0,
@@ -685,23 +685,23 @@ impl UnderlierWithBitOps for M256 {
 						}
 					} else {
 						match log_block_len {
-							0 => {
+							0 => unsafe {
 								let byte = get_block_values::<_, u8, 1>(self, block_idx)[0];
 								_mm256_set1_epi8(byte as _).into()
 							}
-							1 => {
+							1 => unsafe {
 								let bytes = get_block_values::<_, u8, 2>(self, block_idx);
 								Self::from_fn::<u8>(|i| bytes[i / 16])
 							}
-							2 => {
+							2 => unsafe {
 								let bytes = get_block_values::<_, u8, 4>(self, block_idx);
 								Self::from_fn::<u8>(|i| bytes[i / 8])
 							}
-							3 => {
+							3 => unsafe {
 								let bytes = get_block_values::<_, u8, 8>(self, block_idx);
 								Self::from_fn::<u8>(|i| bytes[i / 4])
 							}
-							4 => {
+							4 => unsafe {
 								let bytes = get_block_values::<_, u8, 16>(self, block_idx);
 								Self::from_fn::<u8>(|i| bytes[i / 2])
 							}
@@ -715,23 +715,23 @@ impl UnderlierWithBitOps for M256 {
 				cfg_if! {
 					if #[cfg(target_feature = "avx512f")] {
 						match log_block_len {
-							0 => {
+							0 => unsafe {
 								let value = get_block_values::<_, u16, 1>(self, block_idx)[0];
 								_mm256_set1_epi16(value as _).into()
 							}
-							1 => {
+							1 => unsafe {
 								_mm256_permutexvar_epi8(
 									LOG_B16_1[block_idx],
 									self.0,
 								).into()
 							}
-							2 => {
+							2 => unsafe {
 								_mm256_permutexvar_epi8(
 									LOG_B16_2[block_idx],
 									self.0,
 								).into()
 							}
-							3 => {
+							3 => unsafe {
 								_mm256_permutexvar_epi8(
 									LOG_B16_3[block_idx],
 									self.0,
@@ -742,19 +742,19 @@ impl UnderlierWithBitOps for M256 {
 						}
 					} else {
 						match log_block_len {
-							0 => {
+							0 => unsafe {
 								let value = get_block_values::<_, u16, 1>(self, block_idx)[0];
 								_mm256_set1_epi16(value as _).into()
 							}
-							1 => {
+							1 => unsafe {
 								let values = get_block_values::<_, u16, 2>(self, block_idx);
 								Self::from_fn::<u16>(|i| values[i / 8])
 							}
-							2 => {
+							2 => unsafe {
 								let values = get_block_values::<_, u16, 4>(self, block_idx);
 								Self::from_fn::<u16>(|i| values[i / 4])
 							}
-							3 => {
+							3 => unsafe {
 								let values = get_block_values::<_, u16, 8>(self, block_idx);
 								Self::from_fn::<u16>(|i| values[i / 2])
 							}
@@ -768,17 +768,17 @@ impl UnderlierWithBitOps for M256 {
 				cfg_if! {
 					if #[cfg(target_feature = "avx512f")] {
 						match log_block_len {
-							0 => {
+							0 => unsafe {
 								let value = get_block_values::<_, u32, 1>(self, block_idx)[0];
 								_mm256_set1_epi32(value as _).into()
 							}
-							1 => {
+							1 => unsafe {
 								_mm256_permutexvar_epi8(
 									LOG_B32_1[block_idx],
 									self.0,
 								).into()
 							}
-							2 => {
+							2 => unsafe {
 								_mm256_permutexvar_epi8(
 									LOG_B32_2[block_idx],
 									self.0,
@@ -789,15 +789,15 @@ impl UnderlierWithBitOps for M256 {
 						}
 					} else {
 						match log_block_len {
-							0 => {
+							0 => unsafe {
 								let value = get_block_values::<_, u32, 1>(self, block_idx)[0];
 								_mm256_set1_epi32(value as _).into()
 							}
-							1 => {
+							1 => unsafe {
 								let values = get_block_values::<_, u32, 2>(self, block_idx);
 								Self::from_fn::<u32>(|i| values[i / 4])
 							}
-							2 => {
+							2 => unsafe {
 								let values = get_block_values::<_, u32, 4>(self, block_idx);
 								Self::from_fn::<u32>(|i| values[i / 2])
 							}
@@ -808,11 +808,11 @@ impl UnderlierWithBitOps for M256 {
 				}
 			}
 			6 => match log_block_len {
-				0 => {
+				0 => unsafe {
 					let value = get_block_values::<_, u64, 1>(self, block_idx)[0];
 					_mm256_set1_epi64x(value as _).into()
-				}
-				1 => {
+				},
+				1 => unsafe {
 					cfg_if! {
 						if #[cfg(target_feature = "avx512f")] {
 							_mm256_permutexvar_epi8(
@@ -824,19 +824,19 @@ impl UnderlierWithBitOps for M256 {
 							Self::from_fn::<u64>(|i| values[i / 2])
 						}
 					}
-				}
+				},
 				2 => self,
 				_ => panic!("unsupported block length"),
 			},
 			7 => match log_block_len {
-				0 => {
+				0 => unsafe {
 					let value = get_block_values::<_, u128, 1>(self, block_idx)[0];
 					Self::from_fn::<u128>(|_| value)
-				}
+				},
 				1 => self,
 				_ => panic!("unsupported block length"),
 			},
-			_ => spread_fallback(self, log_block_len, block_idx),
+			_ => unsafe { spread_fallback(self, log_block_len, block_idx) },
 		}
 	}
 

--- a/crates/field/src/arch/x86_64/m512.rs
+++ b/crates/field/src/arch/x86_64/m512.rs
@@ -6,34 +6,34 @@ use std::{
 	ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not, Shl, Shr},
 };
 
-use bytemuck::{must_cast, Pod, Zeroable};
+use bytemuck::{Pod, Zeroable, must_cast};
 use rand::{Rng, RngCore};
 use seq_macro::seq;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use crate::{
+	BinaryField,
 	arch::{
 		binary_utils::{as_array_mut, as_array_ref, make_func_to_i8},
 		portable::{
-			packed::{impl_pack_scalar, PackedPrimitiveType},
+			packed::{PackedPrimitiveType, impl_pack_scalar},
 			packed_arithmetic::{
-				interleave_mask_even, interleave_mask_odd, UnderlierWithBitConstants,
+				UnderlierWithBitConstants, interleave_mask_even, interleave_mask_odd,
 			},
 		},
 		x86_64::{
-			m128::{bitshift_128b, M128},
+			m128::{M128, bitshift_128b},
 			m256::M256,
 		},
 	},
 	arithmetic_traits::Broadcast,
 	tower_levels::TowerLevel,
 	underlier::{
+		NumCast, Random, SmallU, U1, U2, U4, UnderlierType, UnderlierWithBitOps, WithUnderlier,
 		get_block_values, get_spread_bytes, impl_divisible, impl_iteration,
 		pair_unpack_lo_hi_128b_lanes, spread_fallback, transpose_128b_blocks_low_to_high,
-		unpack_hi_128b_fallback, unpack_lo_128b_fallback, NumCast, Random, SmallU, UnderlierType,
-		UnderlierWithBitOps, WithUnderlier, U1, U2, U4,
+		unpack_hi_128b_fallback, unpack_lo_128b_fallback,
 	},
-	BinaryField,
 };
 
 /// 512-bit value that is used for 512-bit SIMD operations

--- a/crates/field/src/arch/x86_64/m512.rs
+++ b/crates/field/src/arch/x86_64/m512.rs
@@ -711,165 +711,165 @@ impl UnderlierWithBitOps for M512 {
 	{
 		match T::LOG_BITS {
 			0 => match log_block_len {
-				0 => {
+				0 => unsafe {
 					let bit = get_block_values::<_, U1, 1>(self, block_idx)[0];
 					Self::fill_with_bit(bit.val())
-				}
-				1 => {
+				},
+				1 => unsafe {
 					let bits = get_block_values::<_, U1, 2>(self, block_idx);
 					let values = bits.map(|b| u128::fill_with_bit(b.val()));
 
 					Self::from_fn::<u128>(|i| values[i / 2])
-				}
-				2 => {
+				},
+				2 => unsafe {
 					let bits = get_block_values::<_, U1, 4>(self, block_idx);
 					let values = bits.map(|b| u128::fill_with_bit(b.val()));
 
 					Self::from_fn::<u128>(|i| values[i])
-				}
-				3 => {
+				},
+				3 => unsafe {
 					let bits = get_block_values::<_, U1, 8>(self, block_idx);
 					let values = bits.map(|b| u64::fill_with_bit(b.val()));
 
 					Self::from_fn::<u64>(|i| values[i])
-				}
-				4 => {
+				},
+				4 => unsafe {
 					let bits = get_block_values::<_, U1, 16>(self, block_idx);
 					let values = bits.map(|b| u32::fill_with_bit(b.val()));
 
 					Self::from_fn::<u32>(|i| values[i])
-				}
-				5 => {
+				},
+				5 => unsafe {
 					let bits = get_block_values::<_, U1, 32>(self, block_idx);
 					let values = bits.map(|b| u16::fill_with_bit(b.val()));
 
 					Self::from_fn::<u16>(|i| values[i])
-				}
-				6 => {
+				},
+				6 => unsafe {
 					let bits = get_block_values::<_, U1, 64>(self, block_idx);
 					let values = bits.map(|b| u8::fill_with_bit(b.val()));
 
 					Self::from_fn::<u8>(|i| values[i])
-				}
-				_ => spread_fallback(self, log_block_len, block_idx),
+				},
+				_ => unsafe { spread_fallback(self, log_block_len, block_idx) },
 			},
 			1 => match log_block_len {
-				0 => {
+				0 => unsafe {
 					let bytes = get_spread_bytes::<_, U2, 1>(self, block_idx)[0];
 
 					_mm512_set1_epi8(bytes as _).into()
-				}
-				1 => {
+				},
+				1 => unsafe {
 					let bytes = get_spread_bytes::<_, U2, 2>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i / 32])
-				}
-				2 => {
+				},
+				2 => unsafe {
 					let bytes = get_spread_bytes::<_, U2, 4>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i / 16])
-				}
-				3 => {
+				},
+				3 => unsafe {
 					let bytes = get_spread_bytes::<_, U2, 8>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i / 8])
-				}
-				4 => {
+				},
+				4 => unsafe {
 					let bytes = get_spread_bytes::<_, U2, 16>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i / 4])
-				}
-				5 => {
+				},
+				5 => unsafe {
 					let bytes = get_spread_bytes::<_, U2, 32>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i / 2])
-				}
-				6 => {
+				},
+				6 => unsafe {
 					let bytes = get_spread_bytes::<_, U2, 64>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i])
-				}
-				_ => spread_fallback(self, log_block_len, block_idx),
+				},
+				_ => unsafe { spread_fallback(self, log_block_len, block_idx) },
 			},
 			2 => match log_block_len {
-				0 => {
+				0 => unsafe {
 					let bytes = get_spread_bytes::<_, U4, 1>(self, block_idx)[0];
 
 					_mm512_set1_epi8(bytes as _).into()
-				}
-				1 => {
+				},
+				1 => unsafe {
 					let bytes = get_spread_bytes::<_, U4, 2>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i / 32])
-				}
-				2 => {
+				},
+				2 => unsafe {
 					let bytes = get_spread_bytes::<_, U4, 4>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i / 16])
-				}
-				3 => {
+				},
+				3 => unsafe {
 					let bytes = get_spread_bytes::<_, U4, 8>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i / 8])
-				}
-				4 => {
+				},
+				4 => unsafe {
 					let bytes = get_spread_bytes::<_, U4, 16>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i / 4])
-				}
-				5 => {
+				},
+				5 => unsafe {
 					let bytes = get_spread_bytes::<_, U4, 32>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i / 2])
-				}
-				6 => {
+				},
+				6 => unsafe {
 					let bytes = get_spread_bytes::<_, U4, 64>(self, block_idx);
 
 					Self::from_fn::<u8>(|i| bytes[i])
-				}
-				_ => spread_fallback(self, log_block_len, block_idx),
+				},
+				_ => unsafe { spread_fallback(self, log_block_len, block_idx) },
 			},
 			3 => match log_block_len {
-				0 => _mm512_permutexvar_epi8(LOG_B8_0[block_idx], self.0).into(),
-				1 => _mm512_permutexvar_epi8(LOG_B8_1[block_idx], self.0).into(),
-				2 => _mm512_permutexvar_epi8(LOG_B8_2[block_idx], self.0).into(),
-				3 => _mm512_permutexvar_epi8(LOG_B8_3[block_idx], self.0).into(),
-				4 => _mm512_permutexvar_epi8(LOG_B8_4[block_idx], self.0).into(),
-				5 => _mm512_permutexvar_epi8(LOG_B8_5[block_idx], self.0).into(),
+				0 => unsafe { _mm512_permutexvar_epi8(LOG_B8_0[block_idx], self.0).into() },
+				1 => unsafe { _mm512_permutexvar_epi8(LOG_B8_1[block_idx], self.0).into() },
+				2 => unsafe { _mm512_permutexvar_epi8(LOG_B8_2[block_idx], self.0).into() },
+				3 => unsafe { _mm512_permutexvar_epi8(LOG_B8_3[block_idx], self.0).into() },
+				4 => unsafe { _mm512_permutexvar_epi8(LOG_B8_4[block_idx], self.0).into() },
+				5 => unsafe { _mm512_permutexvar_epi8(LOG_B8_5[block_idx], self.0).into() },
 				6 => self,
 				_ => panic!("unsupported block length"),
 			},
 			4 => match log_block_len {
-				0 => _mm512_permutexvar_epi8(LOG_B16_0[block_idx], self.0).into(),
-				1 => _mm512_permutexvar_epi8(LOG_B16_1[block_idx], self.0).into(),
-				2 => _mm512_permutexvar_epi8(LOG_B16_2[block_idx], self.0).into(),
-				3 => _mm512_permutexvar_epi8(LOG_B16_3[block_idx], self.0).into(),
-				4 => _mm512_permutexvar_epi8(LOG_B16_4[block_idx], self.0).into(),
+				0 => unsafe { _mm512_permutexvar_epi8(LOG_B16_0[block_idx], self.0).into() },
+				1 => unsafe { _mm512_permutexvar_epi8(LOG_B16_1[block_idx], self.0).into() },
+				2 => unsafe { _mm512_permutexvar_epi8(LOG_B16_2[block_idx], self.0).into() },
+				3 => unsafe { _mm512_permutexvar_epi8(LOG_B16_3[block_idx], self.0).into() },
+				4 => unsafe { _mm512_permutexvar_epi8(LOG_B16_4[block_idx], self.0).into() },
 				5 => self,
 				_ => panic!("unsupported block length"),
 			},
 			5 => match log_block_len {
-				0 => _mm512_permutexvar_epi8(LOG_B32_0[block_idx], self.0).into(),
-				1 => _mm512_permutexvar_epi8(LOG_B32_1[block_idx], self.0).into(),
-				2 => _mm512_permutexvar_epi8(LOG_B32_2[block_idx], self.0).into(),
-				3 => _mm512_permutexvar_epi8(LOG_B32_3[block_idx], self.0).into(),
+				0 => unsafe { _mm512_permutexvar_epi8(LOG_B32_0[block_idx], self.0).into() },
+				1 => unsafe { _mm512_permutexvar_epi8(LOG_B32_1[block_idx], self.0).into() },
+				2 => unsafe { _mm512_permutexvar_epi8(LOG_B32_2[block_idx], self.0).into() },
+				3 => unsafe { _mm512_permutexvar_epi8(LOG_B32_3[block_idx], self.0).into() },
 				4 => self,
 				_ => panic!("unsupported block length"),
 			},
 			6 => match log_block_len {
-				0 => _mm512_permutexvar_epi8(LOG_B64_0[block_idx], self.0).into(),
-				1 => _mm512_permutexvar_epi8(LOG_B64_1[block_idx], self.0).into(),
-				2 => _mm512_permutexvar_epi8(LOG_B64_2[block_idx], self.0).into(),
+				0 => unsafe { _mm512_permutexvar_epi8(LOG_B64_0[block_idx], self.0).into() },
+				1 => unsafe { _mm512_permutexvar_epi8(LOG_B64_1[block_idx], self.0).into() },
+				2 => unsafe { _mm512_permutexvar_epi8(LOG_B64_2[block_idx], self.0).into() },
 				3 => self,
 				_ => panic!("unsupported block length"),
 			},
 			7 => match log_block_len {
-				0 => _mm512_permutexvar_epi8(LOG_B128_0[block_idx], self.0).into(),
-				1 => _mm512_permutexvar_epi8(LOG_B128_1[block_idx], self.0).into(),
+				0 => unsafe { _mm512_permutexvar_epi8(LOG_B128_0[block_idx], self.0).into() },
+				1 => unsafe { _mm512_permutexvar_epi8(LOG_B128_1[block_idx], self.0).into() },
 				2 => self,
 				_ => panic!("unsupported block length"),
 			},
-			_ => spread_fallback(self, log_block_len, block_idx),
+			_ => unsafe { spread_fallback(self, log_block_len, block_idx) },
 		}
 	}
 

--- a/crates/field/src/arch/x86_64/m512.rs
+++ b/crates/field/src/arch/x86_64/m512.rs
@@ -341,7 +341,7 @@ impl ConditionallySelectable for M512 {
 
 impl Random for M512 {
 	fn random(mut rng: impl RngCore) -> Self {
-		let val: [u128; 4] = rng.gen();
+		let val: [u128; 4] = rng.r#gen();
 		val.into()
 	}
 }

--- a/crates/field/src/arch/x86_64/packed_128.rs
+++ b/crates/field/src/arch/x86_64/packed_128.rs
@@ -4,19 +4,19 @@ use cfg_if::cfg_if;
 
 use super::m128::M128;
 use crate::{
+	BinaryField1b, BinaryField2b, BinaryField4b, BinaryField8b, BinaryField16b, BinaryField32b,
+	BinaryField64b, BinaryField128b,
 	arch::{
+		PackedStrategy, SimdStrategy,
 		portable::{
-			packed::{impl_ops_for_zero_height, PackedPrimitiveType},
+			packed::{PackedPrimitiveType, impl_ops_for_zero_height},
 			packed_arithmetic::{alphas, impl_tower_constants},
 		},
-		PackedStrategy, SimdStrategy,
 	},
 	arithmetic_traits::{
 		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
 		impl_transformation_with_strategy,
 	},
-	BinaryField128b, BinaryField16b, BinaryField1b, BinaryField2b, BinaryField32b, BinaryField4b,
-	BinaryField64b, BinaryField8b,
 };
 
 // Define 128 bit packed field types

--- a/crates/field/src/arch/x86_64/packed_256.rs
+++ b/crates/field/src/arch/x86_64/packed_256.rs
@@ -4,19 +4,19 @@ use cfg_if::cfg_if;
 
 use super::m256::M256;
 use crate::{
+	BinaryField1b, BinaryField2b, BinaryField4b, BinaryField8b, BinaryField16b, BinaryField32b,
+	BinaryField64b, BinaryField128b,
 	arch::{
+		PackedStrategy, SimdStrategy,
 		portable::{
-			packed::{impl_ops_for_zero_height, PackedPrimitiveType},
+			packed::{PackedPrimitiveType, impl_ops_for_zero_height},
 			packed_arithmetic::{alphas, impl_tower_constants},
 		},
-		PackedStrategy, SimdStrategy,
 	},
 	arithmetic_traits::{
 		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
 		impl_transformation_with_strategy,
 	},
-	BinaryField128b, BinaryField16b, BinaryField1b, BinaryField2b, BinaryField32b, BinaryField4b,
-	BinaryField64b, BinaryField8b,
 };
 
 // Define 128 bit packed field types

--- a/crates/field/src/arch/x86_64/packed_512.rs
+++ b/crates/field/src/arch/x86_64/packed_512.rs
@@ -2,19 +2,19 @@
 
 use super::m512::M512;
 use crate::{
+	BinaryField1b, BinaryField2b, BinaryField4b, BinaryField8b, BinaryField16b, BinaryField32b,
+	BinaryField64b, BinaryField128b,
 	arch::{
+		PackedStrategy, SimdStrategy,
 		portable::{
-			packed::{impl_ops_for_zero_height, PackedPrimitiveType},
+			packed::{PackedPrimitiveType, impl_ops_for_zero_height},
 			packed_arithmetic::{alphas, impl_tower_constants},
 		},
-		PackedStrategy, SimdStrategy,
 	},
 	arithmetic_traits::{
 		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
 		impl_transformation_with_strategy,
 	},
-	BinaryField128b, BinaryField16b, BinaryField1b, BinaryField2b, BinaryField32b, BinaryField4b,
-	BinaryField64b, BinaryField8b,
 };
 
 // Define 128 bit packed field types

--- a/crates/field/src/arch/x86_64/packed_aes_128.rs
+++ b/crates/field/src/arch/x86_64/packed_aes_128.rs
@@ -5,9 +5,9 @@ use cfg_if::cfg_if;
 use super::m128::M128;
 use crate::{
 	aes_field::{
-		AESTowerField128b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField8b,
+		AESTowerField8b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField128b,
 	},
-	arch::{portable::packed::PackedPrimitiveType, SimdStrategy},
+	arch::{SimdStrategy, portable::packed::PackedPrimitiveType},
 	arithmetic_traits::{
 		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
 		impl_transformation_with_strategy,

--- a/crates/field/src/arch/x86_64/packed_aes_256.rs
+++ b/crates/field/src/arch/x86_64/packed_aes_256.rs
@@ -5,9 +5,9 @@ use cfg_if::cfg_if;
 use super::m256::M256;
 use crate::{
 	aes_field::{
-		AESTowerField128b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField8b,
+		AESTowerField8b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField128b,
 	},
-	arch::{portable::packed::PackedPrimitiveType, SimdStrategy},
+	arch::{SimdStrategy, portable::packed::PackedPrimitiveType},
 	arithmetic_traits::{
 		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
 		impl_transformation_with_strategy,

--- a/crates/field/src/arch/x86_64/packed_aes_512.rs
+++ b/crates/field/src/arch/x86_64/packed_aes_512.rs
@@ -5,9 +5,9 @@ use cfg_if::cfg_if;
 use super::m512::M512;
 use crate::{
 	aes_field::{
-		AESTowerField128b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField8b,
+		AESTowerField8b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField128b,
 	},
-	arch::{portable::packed::PackedPrimitiveType, ReuseMultiplyStrategy, SimdStrategy},
+	arch::{ReuseMultiplyStrategy, SimdStrategy, portable::packed::PackedPrimitiveType},
 	arithmetic_traits::{
 		impl_invert_with, impl_mul_alpha_with, impl_mul_with, impl_square_with,
 		impl_transformation_with_strategy,

--- a/crates/field/src/arch/x86_64/packed_polyval_128.rs
+++ b/crates/field/src/arch/x86_64/packed_polyval_128.rs
@@ -4,10 +4,10 @@ use std::ops::Mul;
 
 use super::{super::portable::packed::PackedPrimitiveType, m128::M128};
 use crate::{
-	arch::{cfg_if, ReuseMultiplyStrategy},
-	arithmetic_traits::{impl_square_with, InvertOrZero},
-	packed::PackedField,
 	BinaryField128bPolyval,
+	arch::{ReuseMultiplyStrategy, cfg_if},
+	arithmetic_traits::{InvertOrZero, impl_square_with},
+	packed::PackedField,
 };
 
 pub type PackedBinaryPolyval1x128b = PackedPrimitiveType<M128, BinaryField128bPolyval>;

--- a/crates/field/src/arch/x86_64/packed_polyval_256.rs
+++ b/crates/field/src/arch/x86_64/packed_polyval_256.rs
@@ -4,9 +4,9 @@ use cfg_if::cfg_if;
 
 use super::m256::M256;
 use crate::{
-	arch::{portable::packed::PackedPrimitiveType, PairwiseStrategy, ReuseMultiplyStrategy},
-	arithmetic_traits::{impl_invert_with, impl_square_with},
 	BinaryField128bPolyval,
+	arch::{PairwiseStrategy, ReuseMultiplyStrategy, portable::packed::PackedPrimitiveType},
+	arithmetic_traits::{impl_invert_with, impl_square_with},
 };
 
 /// Define packed type

--- a/crates/field/src/arch/x86_64/packed_polyval_512.rs
+++ b/crates/field/src/arch/x86_64/packed_polyval_512.rs
@@ -2,11 +2,11 @@
 
 use super::m512::M512;
 use crate::{
+	BinaryField128bPolyval,
 	arch::{
-		cfg_if, portable::packed::PackedPrimitiveType, PairwiseStrategy, ReuseMultiplyStrategy,
+		PairwiseStrategy, ReuseMultiplyStrategy, cfg_if, portable::packed::PackedPrimitiveType,
 	},
 	arithmetic_traits::{impl_invert_with, impl_square_with},
-	BinaryField128bPolyval,
 };
 
 /// Define packed type

--- a/crates/field/src/arch/x86_64/pclmul/m128.rs
+++ b/crates/field/src/arch/x86_64/pclmul/m128.rs
@@ -8,31 +8,31 @@ use crate::arch::x86_64::m128::M128;
 impl PolyvalSimdType for M128 {
 	#[inline(always)]
 	unsafe fn shuffle_epi32<const IMM8: i32>(a: Self) -> Self {
-		_mm_shuffle_epi32::<IMM8>(a.0).into()
+		unsafe { _mm_shuffle_epi32::<IMM8>(a.0).into() }
 	}
 
 	#[inline(always)]
 	unsafe fn xor(a: Self, b: Self) -> Self {
-		_mm_xor_si128(a.0, b.0).into()
+		unsafe { _mm_xor_si128(a.0, b.0).into() }
 	}
 
 	#[inline(always)]
 	unsafe fn clmul_epi64<const IMM8: i32>(a: Self, b: Self) -> Self {
-		_mm_clmulepi64_si128::<IMM8>(a.0, b.0).into()
+		unsafe { _mm_clmulepi64_si128::<IMM8>(a.0, b.0).into() }
 	}
 
 	#[inline(always)]
 	unsafe fn srli_epi64<const IMM8: i32>(a: Self) -> Self {
-		_mm_srli_epi64::<IMM8>(a.0).into()
+		unsafe { _mm_srli_epi64::<IMM8>(a.0).into() }
 	}
 
 	#[inline(always)]
 	unsafe fn slli_epi64<const IMM8: i32>(a: Self) -> Self {
-		_mm_slli_epi64::<IMM8>(a.0).into()
+		unsafe { _mm_slli_epi64::<IMM8>(a.0).into() }
 	}
 
 	#[inline(always)]
 	unsafe fn unpacklo_epi64(a: Self, b: Self) -> Self {
-		_mm_unpacklo_epi64(a.0, b.0).into()
+		unsafe { _mm_unpacklo_epi64(a.0, b.0).into() }
 	}
 }

--- a/crates/field/src/arch/x86_64/pclmul/m256.rs
+++ b/crates/field/src/arch/x86_64/pclmul/m256.rs
@@ -8,31 +8,31 @@ use crate::arch::x86_64::m256::M256;
 impl PolyvalSimdType for M256 {
 	#[inline(always)]
 	unsafe fn shuffle_epi32<const IMM8: i32>(a: Self) -> Self {
-		_mm256_shuffle_epi32::<IMM8>(a.0).into()
+		unsafe { _mm256_shuffle_epi32::<IMM8>(a.0).into() }
 	}
 
 	#[inline(always)]
 	unsafe fn xor(a: Self, b: Self) -> Self {
-		_mm256_xor_si256(a.0, b.0).into()
+		unsafe { _mm256_xor_si256(a.0, b.0).into() }
 	}
 
 	#[inline(always)]
 	unsafe fn clmul_epi64<const IMM8: i32>(a: Self, b: Self) -> Self {
-		_mm256_clmulepi64_epi128::<IMM8>(a.0, b.0).into()
+		unsafe { _mm256_clmulepi64_epi128::<IMM8>(a.0, b.0).into() }
 	}
 
 	#[inline(always)]
 	unsafe fn slli_epi64<const IMM8: i32>(a: Self) -> Self {
-		_mm256_slli_epi64::<IMM8>(a.0).into()
+		unsafe { _mm256_slli_epi64::<IMM8>(a.0).into() }
 	}
 
 	#[inline(always)]
 	unsafe fn srli_epi64<const IMM8: i32>(a: Self) -> Self {
-		_mm256_srli_epi64::<IMM8>(a.0).into()
+		unsafe { _mm256_srli_epi64::<IMM8>(a.0).into() }
 	}
 
 	#[inline(always)]
 	unsafe fn unpacklo_epi64(a: Self, b: Self) -> Self {
-		_mm256_unpacklo_epi64(a.0, b.0).into()
+		unsafe { _mm256_unpacklo_epi64(a.0, b.0).into() }
 	}
 }

--- a/crates/field/src/arch/x86_64/pclmul/m512.rs
+++ b/crates/field/src/arch/x86_64/pclmul/m512.rs
@@ -10,17 +10,17 @@ use crate::arch::x86_64::m512::M512;
 impl PolyvalSimdType for M512 {
 	#[inline(always)]
 	unsafe fn shuffle_epi32<const IMM8: i32>(a: Self) -> Self {
-		_mm512_shuffle_epi32::<IMM8>(a.0).into()
+		unsafe { _mm512_shuffle_epi32::<IMM8>(a.0).into() }
 	}
 
 	#[inline(always)]
 	unsafe fn xor(a: Self, b: Self) -> Self {
-		_mm512_xor_si512(a.0, b.0).into()
+		unsafe { _mm512_xor_si512(a.0, b.0).into() }
 	}
 
 	#[inline(always)]
 	unsafe fn clmul_epi64<const IMM8: i32>(a: Self, b: Self) -> Self {
-		_mm512_clmulepi64_epi128::<IMM8>(a.0, b.0).into()
+		unsafe { _mm512_clmulepi64_epi128::<IMM8>(a.0, b.0).into() }
 	}
 
 	#[inline(always)]
@@ -29,28 +29,32 @@ impl PolyvalSimdType for M512 {
 		// `_mm256_slli_epi64` have different generic constant type and stable Rust
 		// doesn't allow cast for const parameter.
 		// All these `if`s will be eliminated by compiler because `IMM8` is known at compile time.
-		seq!(N in 0..64 {
-			if IMM8 == N {
-				return _mm512_slli_epi64::<N>(a.0).into()
-			}
-		});
+		unsafe {
+			seq!(N in 0..64 {
+				if IMM8 == N {
+					return _mm512_slli_epi64::<N>(a.0).into()
+				}
+			});
+		}
 
 		unreachable!("bit shift count shouldn't exceed 63")
 	}
 
 	#[inline(always)]
 	unsafe fn srli_epi64<const IMM8: i32>(a: Self) -> Self {
-		seq!(N in 0..64 {
-			if IMM8 == N {
-				return _mm512_srli_epi64::<N>(a.0).into()
-			}
-		});
+		unsafe {
+			seq!(N in 0..64 {
+				if IMM8 == N {
+					return _mm512_srli_epi64::<N>(a.0).into()
+				}
+			});
+		}
 
 		unreachable!("bit shift count shouldn't exceed 63")
 	}
 
 	#[inline(always)]
 	unsafe fn unpacklo_epi64(a: Self, b: Self) -> Self {
-		_mm512_unpacklo_epi64(a.0, b.0).into()
+		unsafe { _mm512_unpacklo_epi64(a.0, b.0).into() }
 	}
 }

--- a/crates/field/src/arch/x86_64/pclmul/montgomery_mul.rs
+++ b/crates/field/src/arch/x86_64/pclmul/montgomery_mul.rs
@@ -12,41 +12,47 @@ pub trait PolyvalSimdType: Copy {
 
 #[inline]
 pub unsafe fn simd_montgomery_multiply<T: PolyvalSimdType>(h: T, y: T) -> T {
-	let h0 = h;
-	let h1 = T::shuffle_epi32::<0x0E>(h);
-	let h2 = T::xor(h0, h1);
-	let y0 = y;
+	unsafe {
+		let h0 = h;
+		let h1 = T::shuffle_epi32::<0x0E>(h);
+		let h2 = T::xor(h0, h1);
+		let y0 = y;
 
-	// Multiply values partitioned to 64-bit parts
-	let y1 = T::shuffle_epi32::<0x0E>(y);
-	let y2 = T::xor(y0, y1);
-	let t0 = T::clmul_epi64::<0x00>(y0, h0);
-	let t1 = T::clmul_epi64::<0x11>(y, h);
-	let t2 = T::clmul_epi64::<0x00>(y2, h2);
-	let t2 = T::xor(t2, T::xor(t0, t1));
-	let v0 = t0;
-	let v1 = T::xor(T::shuffle_epi32::<0x0E>(t0), t2);
-	let v2 = T::xor(t1, T::shuffle_epi32::<0x0E>(t2));
-	let v3 = T::shuffle_epi32::<0x0E>(t1);
+		// Multiply values partitioned to 64-bit parts
+		let y1 = T::shuffle_epi32::<0x0E>(y);
+		let y2 = T::xor(y0, y1);
+		let t0 = T::clmul_epi64::<0x00>(y0, h0);
+		let t1 = T::clmul_epi64::<0x11>(y, h);
+		let t2 = T::clmul_epi64::<0x00>(y2, h2);
+		let t2 = T::xor(t2, T::xor(t0, t1));
+		let v0 = t0;
+		let v1 = T::xor(T::shuffle_epi32::<0x0E>(t0), t2);
+		let v2 = T::xor(t1, T::shuffle_epi32::<0x0E>(t2));
+		let v3 = T::shuffle_epi32::<0x0E>(t1);
 
-	// Polynomial reduction
-	let v2 = xor5(v2, v0, T::srli_epi64::<1>(v0), T::srli_epi64::<2>(v0), T::srli_epi64::<7>(v0));
+		// Polynomial reduction
+		let v2 =
+			xor5(v2, v0, T::srli_epi64::<1>(v0), T::srli_epi64::<2>(v0), T::srli_epi64::<7>(v0));
 
-	let v1 = xor4(v1, T::slli_epi64::<63>(v0), T::slli_epi64::<62>(v0), T::slli_epi64::<57>(v0));
+		let v1 =
+			xor4(v1, T::slli_epi64::<63>(v0), T::slli_epi64::<62>(v0), T::slli_epi64::<57>(v0));
 
-	let v3 = xor5(v3, v1, T::srli_epi64::<1>(v1), T::srli_epi64::<2>(v1), T::srli_epi64::<7>(v1));
+		let v3 =
+			xor5(v3, v1, T::srli_epi64::<1>(v1), T::srli_epi64::<2>(v1), T::srli_epi64::<7>(v1));
 
-	let v2 = xor4(v2, T::slli_epi64::<63>(v1), T::slli_epi64::<62>(v1), T::slli_epi64::<57>(v1));
+		let v2 =
+			xor4(v2, T::slli_epi64::<63>(v1), T::slli_epi64::<62>(v1), T::slli_epi64::<57>(v1));
 
-	T::unpacklo_epi64(v2, v3)
+		T::unpacklo_epi64(v2, v3)
+	}
 }
 
 #[inline(always)]
 unsafe fn xor4<T: PolyvalSimdType>(e1: T, e2: T, e3: T, e4: T) -> T {
-	T::xor(T::xor(e1, e2), T::xor(e3, e4))
+	unsafe { T::xor(T::xor(e1, e2), T::xor(e3, e4)) }
 }
 
 #[inline(always)]
 unsafe fn xor5<T: PolyvalSimdType>(e1: T, e2: T, e3: T, e4: T, e5: T) -> T {
-	T::xor(e1, T::xor(T::xor(e2, e3), T::xor(e4, e5)))
+	unsafe { T::xor(e1, T::xor(T::xor(e2, e3), T::xor(e4, e5))) }
 }

--- a/crates/field/src/arch/x86_64/simd/m128.rs
+++ b/crates/field/src/arch/x86_64/simd/m128.rs
@@ -3,7 +3,7 @@
 use core::arch::x86_64::*;
 
 use super::simd_arithmetic::TowerSimdType;
-use crate::{arch::x86_64::m128::M128, BinaryField};
+use crate::{BinaryField, arch::x86_64::m128::M128};
 
 impl TowerSimdType for M128 {
 	#[inline(always)]

--- a/crates/field/src/arch/x86_64/simd/m256.rs
+++ b/crates/field/src/arch/x86_64/simd/m256.rs
@@ -3,7 +3,7 @@
 use core::arch::x86_64::*;
 
 use super::simd_arithmetic::TowerSimdType;
-use crate::{arch::x86_64::m256::M256, BinaryField};
+use crate::{BinaryField, arch::x86_64::m256::M256};
 
 impl TowerSimdType for M256 {
 	#[inline(always)]

--- a/crates/field/src/arch/x86_64/simd/m512.rs
+++ b/crates/field/src/arch/x86_64/simd/m512.rs
@@ -3,7 +3,7 @@
 use core::arch::x86_64::*;
 
 use super::simd_arithmetic::TowerSimdType;
-use crate::{arch::x86_64::m512::M512, BinaryField};
+use crate::{BinaryField, arch::x86_64::m512::M512};
 
 impl TowerSimdType for M512 {
 	#[inline(always)]

--- a/crates/field/src/arch/x86_64/simd/simd_arithmetic.rs
+++ b/crates/field/src/arch/x86_64/simd/simd_arithmetic.rs
@@ -91,7 +91,7 @@ pub trait TowerSimdType: Sized + Copy + UnderlierWithBitOps {
 
 	#[inline(always)]
 	fn alpha<Scalar: BinaryField>() -> Self {
-		let alpha_128 = unsafe {
+		let alpha_128 = {
 			match Scalar::N_BITS.ilog2() {
 				3 => {
 					// Compiler will optimize this if out for each instantiation
@@ -103,11 +103,11 @@ pub trait TowerSimdType: Sized + Copy + UnderlierWithBitOps {
 					} else {
 						panic!("tower field not supported")
 					};
-					_mm_set1_epi8(value)
+					unsafe { _mm_set1_epi8(value) }
 				}
-				4 => _mm_set1_epi16(0x0100),
-				5 => _mm_set1_epi32(0x00010000),
-				6 => _mm_set1_epi64x(0x0000000100000000),
+				4 => unsafe { _mm_set1_epi16(0x0100) },
+				5 => unsafe { _mm_set1_epi32(0x00010000) },
+				6 => unsafe { _mm_set1_epi64x(0x0000000100000000) },
 				_ => panic!("unsupported bit count"),
 			}
 		};
@@ -117,12 +117,12 @@ pub trait TowerSimdType: Sized + Copy + UnderlierWithBitOps {
 
 	#[inline(always)]
 	fn even_mask<Scalar: BinaryField>() -> Self {
-		let mask_128 = unsafe {
+		let mask_128 = {
 			match Scalar::N_BITS.ilog2() {
-				3 => _mm_set1_epi16(0x00FF),
-				4 => _mm_set1_epi32(0x0000FFFF),
-				5 => _mm_set1_epi64x(0x00000000FFFFFFFF),
-				6 => _mm_set_epi64x(0, -1),
+				3 => unsafe { _mm_set1_epi16(0x00FF) },
+				4 => unsafe { _mm_set1_epi32(0x0000FFFF) },
+				5 => unsafe { _mm_set1_epi64x(0x00000000FFFFFFFF) },
+				6 => unsafe { _mm_set_epi64x(0, -1) },
 				_ => panic!("unsupported bit count"),
 			}
 		};

--- a/crates/field/src/arch/x86_64/simd/simd_arithmetic.rs
+++ b/crates/field/src/arch/x86_64/simd/simd_arithmetic.rs
@@ -3,13 +3,14 @@
 use std::{any::TypeId, arch::x86_64::*};
 
 use crate::{
+	BinaryField, BinaryField8b, PackedField, TowerField,
 	aes_field::AESTowerField8b,
 	arch::{
+		SimdStrategy,
 		portable::{
 			packed::PackedPrimitiveType, packed_arithmetic::PackedTowerField,
 			reuse_multiply_arithmetic::Alpha,
 		},
-		SimdStrategy,
 	},
 	arithmetic_traits::{
 		MulAlpha, TaggedInvertOrZero, TaggedMul, TaggedMulAlpha, TaggedPackedTransformationFactory,
@@ -18,7 +19,6 @@ use crate::{
 	linear_transformation::{FieldLinearTransformation, Transformation},
 	packed::PackedBinaryField,
 	underlier::{UnderlierType, UnderlierWithBitOps, WithUnderlier},
-	BinaryField, BinaryField8b, PackedField, TowerField,
 };
 
 pub trait TowerSimdType: Sized + Copy + UnderlierWithBitOps {

--- a/crates/field/src/as_packed_field.rs
+++ b/crates/field/src/as_packed_field.rs
@@ -1,16 +1,16 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use crate::{
+	ExtensionField, Field, PackedField,
 	aes_field::*,
 	arch::{
-		packed_1::*, packed_128::*, packed_16::*, packed_2::*, packed_32::*, packed_4::*,
-		packed_64::*, packed_8::*, packed_aes_128::*, packed_aes_16::*, packed_aes_32::*,
-		packed_aes_64::*, packed_aes_8::*, packed_polyval_128::PackedBinaryPolyval1x128b,
+		packed_1::*, packed_2::*, packed_4::*, packed_8::*, packed_16::*, packed_32::*,
+		packed_64::*, packed_128::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,
+		packed_aes_64::*, packed_aes_128::*, packed_polyval_128::PackedBinaryPolyval1x128b,
 	},
 	binary_field::*,
 	polyval::BinaryField128bPolyval,
 	underlier::{UnderlierType, WithUnderlier},
-	ExtensionField, Field, PackedField,
 };
 
 /// Trait that establishes correspondence between the scalar field and a packed field of the same

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -8,8 +8,8 @@ use std::{
 };
 
 use binius_utils::{
-	bytes::{Buf, BufMut},
 	DeserializeBytes, SerializationError, SerializationMode, SerializeBytes,
+	bytes::{Buf, BufMut},
 };
 use bytemuck::{Pod, Zeroable};
 use rand::RngCore;
@@ -19,8 +19,8 @@ use super::{
 	binary_field_arithmetic::TowerFieldArithmetic, error::Error, extension::ExtensionField,
 };
 use crate::{
-	underlier::{U1, U2, U4},
 	Field,
+	underlier::{U1, U2, U4},
 };
 
 /// A finite field with characteristic 2.
@@ -895,12 +895,12 @@ impl From<BinaryField4b> for u8 {
 
 #[cfg(test)]
 pub(crate) mod tests {
-	use binius_utils::{bytes::BytesMut, SerializationMode};
+	use binius_utils::{SerializationMode, bytes::BytesMut};
 	use proptest::prelude::*;
 
 	use super::{
-		BinaryField16b as BF16, BinaryField1b as BF1, BinaryField2b as BF2, BinaryField4b as BF4,
-		BinaryField64b as BF64, BinaryField8b as BF8, *,
+		BinaryField1b as BF1, BinaryField2b as BF2, BinaryField4b as BF4, BinaryField8b as BF8,
+		BinaryField16b as BF16, BinaryField64b as BF64, *,
 	};
 
 	#[test]

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -650,8 +650,9 @@ macro_rules! impl_field_extension {
 			#[inline]
 			unsafe fn get_base_unchecked(&self, i: usize) -> $subfield_name {
 				use $crate::underlier::{WithUnderlier, UnderlierWithBitOps};
-
-				$subfield_name::from_underlier(self.to_underlier().get_subvalue(i))
+				unsafe {
+					$subfield_name::from_underlier(self.to_underlier().get_subvalue(i))
+				}
 			}
 		}
 	};

--- a/crates/field/src/binary_field_arithmetic.rs
+++ b/crates/field/src/binary_field_arithmetic.rs
@@ -1,7 +1,7 @@
 // Copyright 2023-2025 Irreducible Inc.
 
 use super::{arithmetic_traits::InvertOrZero, binary_field::*};
-use crate::{arithmetic_traits::MulAlpha, PackedField};
+use crate::{PackedField, arithmetic_traits::MulAlpha};
 
 pub(crate) trait TowerFieldArithmetic: TowerField {
 	fn multiply(self, rhs: Self) -> Self;

--- a/crates/field/src/byte_iteration.rs
+++ b/crates/field/src/byte_iteration.rs
@@ -3,18 +3,18 @@
 use std::any::TypeId;
 
 use binius_utils::random_access_sequence::RandomAccessSequence;
-use bytemuck::{zeroed_vec, Pod};
+use bytemuck::{Pod, zeroed_vec};
 
 use crate::{
+	AESTowerField8b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField128b,
+	BinaryField8b, BinaryField16b, BinaryField32b, BinaryField64b, BinaryField128b,
+	BinaryField128bPolyval, PackedField,
 	arch::{
-		byte_sliced::*, packed_128::*, packed_16::*, packed_256::*, packed_32::*, packed_512::*,
-		packed_64::*, packed_8::*, packed_aes_128::*, packed_aes_16::*, packed_aes_256::*,
-		packed_aes_32::*, packed_aes_512::*, packed_aes_64::*, packed_aes_8::*,
+		byte_sliced::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*,
+		packed_256::*, packed_512::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,
+		packed_aes_64::*, packed_aes_128::*, packed_aes_256::*, packed_aes_512::*,
 		packed_polyval_128::*, packed_polyval_256::*, packed_polyval_512::*,
 	},
-	AESTowerField128b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField8b,
-	BinaryField128b, BinaryField128bPolyval, BinaryField16b, BinaryField32b, BinaryField64b,
-	BinaryField8b, PackedField,
 };
 
 /// A marker trait that the slice of packed values can be iterated as a sequence of bytes.

--- a/crates/field/src/error.rs
+++ b/crates/field/src/error.rs
@@ -5,7 +5,9 @@
 pub enum Error {
 	#[error("the argument does not match the field extension degree")]
 	ExtensionDegreeMismatch,
-	#[error("the amount of scalars in the first array is not the same as the amount of scalars in the second")]
+	#[error(
+		"the amount of scalars in the first array is not the same as the amount of scalars in the second"
+	)]
 	MismatchedLengths,
 	#[error("the argument has too large a field extension degree")]
 	ExtensionDegreeTooHigh,

--- a/crates/field/src/extension.rs
+++ b/crates/field/src/extension.rs
@@ -5,7 +5,7 @@ use std::{
 	ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
 };
 
-use super::{error::Error, Field};
+use super::{Field, error::Error};
 
 pub trait ExtensionField<F: Field>:
 	Field

--- a/crates/field/src/lib.rs
+++ b/crates/field/src/lib.rs
@@ -55,4 +55,4 @@ pub use packed_extension::*;
 pub use packed_extension_ops::*;
 pub use packed_polyval::*;
 pub use polyval::*;
-pub use transpose::{square_transpose, Error as TransposeError};
+pub use transpose::{Error as TransposeError, square_transpose};

--- a/crates/field/src/linear_transformation.rs
+++ b/crates/field/src/linear_transformation.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use rand::RngCore;
 
-use crate::{packed::PackedBinaryField, BinaryField, BinaryField1b, ExtensionField};
+use crate::{BinaryField, BinaryField1b, ExtensionField, packed::PackedBinaryField};
 
 /// Generic transformation trait that is used both for scalars and packed fields
 pub trait Transformation<Input, Output>: Sync {

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -18,13 +18,13 @@ use bytemuck::Zeroable;
 use rand::RngCore;
 
 use super::{
+	Error,
 	arithmetic_traits::{Broadcast, MulAlpha, Square},
 	binary_field_arithmetic::TowerFieldArithmetic,
-	Error,
 };
 use crate::{
-	arithmetic_traits::InvertOrZero, is_packed_field_indexable, underlier::WithUnderlier,
-	unpack_if_possible_mut, BinaryField, Field, PackedExtension,
+	BinaryField, Field, PackedExtension, arithmetic_traits::InvertOrZero,
+	is_packed_field_indexable, underlier::WithUnderlier, unpack_if_possible_mut,
 };
 
 /// A packed field represents a vector of underlying field elements.
@@ -635,23 +635,23 @@ impl<PT> PackedBinaryField for PT where PT: PackedField<Scalar: BinaryField> {}
 mod tests {
 	use itertools::Itertools;
 	use rand::{
+		SeedableRng,
 		distributions::{Distribution, Uniform},
 		rngs::StdRng,
-		SeedableRng,
 	};
 
 	use super::*;
 	use crate::{
+		AESTowerField8b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField128b,
+		BinaryField1b, BinaryField2b, BinaryField4b, BinaryField8b, BinaryField16b, BinaryField32b,
+		BinaryField64b, BinaryField128b, BinaryField128bPolyval, PackedField,
 		arch::{
-			byte_sliced::*, packed_1::*, packed_128::*, packed_16::*, packed_2::*, packed_256::*,
-			packed_32::*, packed_4::*, packed_512::*, packed_64::*, packed_8::*, packed_aes_128::*,
-			packed_aes_16::*, packed_aes_256::*, packed_aes_32::*, packed_aes_512::*,
-			packed_aes_64::*, packed_aes_8::*, packed_polyval_128::*, packed_polyval_256::*,
-			packed_polyval_512::*,
+			byte_sliced::*, packed_1::*, packed_2::*, packed_4::*, packed_8::*, packed_16::*,
+			packed_32::*, packed_64::*, packed_128::*, packed_256::*, packed_512::*,
+			packed_aes_8::*, packed_aes_16::*, packed_aes_32::*, packed_aes_64::*,
+			packed_aes_128::*, packed_aes_256::*, packed_aes_512::*, packed_polyval_128::*,
+			packed_polyval_256::*, packed_polyval_512::*,
 		},
-		AESTowerField128b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField8b,
-		BinaryField128b, BinaryField128bPolyval, BinaryField16b, BinaryField1b, BinaryField2b,
-		BinaryField32b, BinaryField4b, BinaryField64b, BinaryField8b, PackedField,
 	};
 
 	trait PackedFieldTest {

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -505,7 +505,7 @@ impl<P: PackedField> RandomAccessSequence<P::Scalar> for PackedSlice<'_, P> {
 
 	#[inline(always)]
 	unsafe fn get_unchecked(&self, index: usize) -> P::Scalar {
-		get_packed_slice_unchecked(self.slice, index)
+		unsafe { get_packed_slice_unchecked(self.slice, index) }
 	}
 }
 
@@ -538,13 +538,13 @@ impl<P: PackedField> RandomAccessSequence<P::Scalar> for PackedSliceMut<'_, P> {
 
 	#[inline(always)]
 	unsafe fn get_unchecked(&self, index: usize) -> P::Scalar {
-		get_packed_slice_unchecked(self.slice, index)
+		unsafe { get_packed_slice_unchecked(self.slice, index) }
 	}
 }
 impl<P: PackedField> RandomAccessSequenceMut<P::Scalar> for PackedSliceMut<'_, P> {
 	#[inline(always)]
 	unsafe fn set_unchecked(&mut self, index: usize, value: P::Scalar) {
-		set_packed_slice_unchecked(self.slice, index, value);
+		unsafe { set_packed_slice_unchecked(self.slice, index, value) }
 	}
 }
 

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -913,10 +913,10 @@ mod tests {
 
 	fn check_collection_get_set<F: Field>(
 		collection: &mut impl RandomAccessSequenceMut<F>,
-		gen: &mut impl FnMut() -> F,
+		r#gen: &mut impl FnMut() -> F,
 	) {
 		for i in 0..collection.len() {
-			let value = gen();
+			let value = r#gen();
 			collection.set(i, value);
 			assert_eq!(collection.get(i), value);
 			assert_eq!(unsafe { collection.get_unchecked(i) }, value);
@@ -946,7 +946,7 @@ mod tests {
 	#[test]
 	fn check_packed_slice_mut() {
 		let mut rng = StdRng::seed_from_u64(0);
-		let mut gen = || <BinaryField8b as Field>::random(&mut rng);
+		let mut r#gen = || <BinaryField8b as Field>::random(&mut rng);
 
 		let slice: &mut [PackedBinaryField16x8b] = &mut [];
 		let packed_slice = PackedSliceMut::new(slice);
@@ -962,11 +962,11 @@ mod tests {
 		let values = PackedField::iter_slice(slice).collect_vec();
 		let mut packed_slice = PackedSliceMut::new(slice);
 		check_collection(&packed_slice, &values);
-		check_collection_get_set(&mut packed_slice, &mut gen);
+		check_collection_get_set(&mut packed_slice, &mut r#gen);
 
 		let values = PackedField::iter_slice(slice).collect_vec();
 		let mut packed_slice = PackedSliceMut::new_with_len(slice, 3);
 		check_collection(&packed_slice, &values[..3]);
-		check_collection_get_set(&mut packed_slice, &mut gen);
+		check_collection_get_set(&mut packed_slice, &mut r#gen);
 	}
 }

--- a/crates/field/src/packed_aes_field.rs
+++ b/crates/field/src/packed_aes_field.rs
@@ -1,8 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 pub use crate::arch::{
-	packed_aes_128::*, packed_aes_16::*, packed_aes_256::*, packed_aes_32::*, packed_aes_512::*,
-	packed_aes_64::*, packed_aes_8::*,
+	packed_aes_8::*, packed_aes_16::*, packed_aes_32::*, packed_aes_64::*, packed_aes_128::*,
+	packed_aes_256::*, packed_aes_512::*,
 };
 
 #[cfg(test)]
@@ -419,13 +419,13 @@ mod tests {
 		*,
 	};
 	use crate::{
+		PackedField,
 		arch::{
-			packed_128::*, packed_16::*, packed_256::*, packed_32::*, packed_512::*, packed_64::*,
-			packed_8::*,
+			packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*, packed_256::*,
+			packed_512::*,
 		},
 		linear_transformation::PackedTransformationFactory,
 		test_utils::implements_transformation_factory,
-		PackedField,
 	};
 
 	define_multiply_tests!(Mul::mul, PackedField);

--- a/crates/field/src/packed_binary_field.rs
+++ b/crates/field/src/packed_binary_field.rs
@@ -1,17 +1,17 @@
 // Copyright 2023-2025 Irreducible Inc.
 
 pub use crate::arch::{
-	packed_1::*, packed_128::*, packed_16::*, packed_2::*, packed_256::*, packed_32::*,
-	packed_4::*, packed_512::*, packed_64::*, packed_8::*,
+	packed_1::*, packed_2::*, packed_4::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*,
+	packed_128::*, packed_256::*, packed_512::*,
 };
 
 /// Common code to test different multiply, square and invert implementations
 #[cfg(test)]
 pub mod test_utils {
 	use crate::{
-		linear_transformation::PackedTransformationFactory,
-		underlier::{WithUnderlier, U1, U2, U4},
 		BinaryField, PackedField,
+		linear_transformation::PackedTransformationFactory,
+		underlier::{U1, U2, U4, WithUnderlier},
 	};
 
 	pub struct Unit;
@@ -872,7 +872,7 @@ mod tests {
 	use std::{iter::repeat_with, ops::Mul, slice};
 
 	use proptest::prelude::*;
-	use rand::{rngs::StdRng, thread_rng, SeedableRng};
+	use rand::{SeedableRng, rngs::StdRng, thread_rng};
 	use test_utils::{check_interleave_all_heights, implements_transformation_factory};
 
 	use super::{
@@ -883,15 +883,15 @@ mod tests {
 		*,
 	};
 	use crate::{
+		Field, PackedField, PackedFieldIndexable,
 		arch::{
-			packed_aes_128::*, packed_aes_16::*, packed_aes_256::*, packed_aes_32::*,
-			packed_aes_512::*, packed_aes_64::*,
+			packed_aes_16::*, packed_aes_32::*, packed_aes_64::*, packed_aes_128::*,
+			packed_aes_256::*, packed_aes_512::*,
 		},
 		arithmetic_traits::MulAlpha,
 		linear_transformation::PackedTransformationFactory,
 		test_utils::check_transpose_all_heights,
 		underlier::{U2, U4},
-		Field, PackedField, PackedFieldIndexable,
 	};
 
 	fn test_add_packed<P: PackedField + From<u128>>(a_val: u128, b_val: u128) {

--- a/crates/field/src/packed_extension.rs
+++ b/crates/field/src/packed_extension.rs
@@ -1,9 +1,9 @@
 // Copyright 2023-2025 Irreducible Inc.
 
 use crate::{
+	ExtensionField, Field, PackedField,
 	as_packed_field::PackScalar,
 	underlier::{Divisible, WithUnderlier},
-	ExtensionField, Field, PackedField,
 };
 
 /// A [`PackedField`] that can be safely cast to indexable slices of scalars.

--- a/crates/field/src/packed_extension_ops.rs
+++ b/crates/field/src/packed_extension_ops.rs
@@ -35,9 +35,11 @@ pub unsafe fn get_packed_subfields_at_pe_idx<PE: PackedExtension<F>, F: Field>(
 		bottom_most_scalar_idx % PE::PackedSubfield::WIDTH;
 	let block_idx = bottom_most_scalar_idx_within_packed_subfield / PE::WIDTH;
 
-	packed_subfields
-		.get_unchecked(bottom_most_scalar_idx_in_subfield_arr)
-		.spread_unchecked(PE::LOG_WIDTH, block_idx)
+	unsafe {
+		packed_subfields
+			.get_unchecked(bottom_most_scalar_idx_in_subfield_arr)
+			.spread_unchecked(PE::LOG_WIDTH, block_idx)
+	}
 }
 
 /// Refer to the functions above for examples of closures to pass

--- a/crates/field/src/packed_extension_ops.rs
+++ b/crates/field/src/packed_extension_ops.rs
@@ -107,11 +107,10 @@ mod tests {
 	use proptest::prelude::*;
 
 	use crate::{
-		ext_base_mul, ext_base_mul_par,
+		BinaryField8b, BinaryField16b, BinaryField128b, PackedBinaryField2x128b,
+		PackedBinaryField16x16b, PackedBinaryField32x8b, ext_base_mul, ext_base_mul_par,
 		packed::{get_packed_slice, pack_slice},
 		underlier::WithUnderlier,
-		BinaryField128b, BinaryField16b, BinaryField8b, PackedBinaryField16x16b,
-		PackedBinaryField2x128b, PackedBinaryField32x8b,
 	};
 
 	fn strategy_8b_scalars() -> impl Strategy<Value = [BinaryField8b; 32]> {

--- a/crates/field/src/packed_polyval.rs
+++ b/crates/field/src/packed_polyval.rs
@@ -142,6 +142,8 @@ mod tests {
 		define_transformation_tests,
 	};
 	use crate::{
+		BinaryField128bPolyval, PackedBinaryField1x128b, PackedBinaryField2x128b,
+		PackedBinaryField4x128b, PackedField,
 		arch::{
 			packed_polyval_128::PackedBinaryPolyval1x128b,
 			packed_polyval_256::PackedBinaryPolyval2x128b,
@@ -150,8 +152,6 @@ mod tests {
 		linear_transformation::PackedTransformationFactory,
 		test_utils::implements_transformation_factory,
 		underlier::WithUnderlier,
-		BinaryField128bPolyval, PackedBinaryField1x128b, PackedBinaryField2x128b,
-		PackedBinaryField4x128b, PackedField,
 	};
 
 	fn check_get_set<const WIDTH: usize, PT>(a: [u128; WIDTH], b: [u128; WIDTH])

--- a/crates/field/src/polyval.rs
+++ b/crates/field/src/polyval.rs
@@ -263,7 +263,7 @@ impl Field for BinaryField128bPolyval {
 	const CHARACTERISTIC: usize = 2;
 
 	fn random(mut rng: impl RngCore) -> Self {
-		Self(rng.gen())
+		Self(rng.r#gen())
 	}
 
 	fn double(&self) -> Self {

--- a/crates/field/src/polyval.rs
+++ b/crates/field/src/polyval.rs
@@ -10,9 +10,9 @@ use std::{
 };
 
 use binius_utils::{
+	DeserializeBytes, SerializationError, SerializationMode, SerializeBytes,
 	bytes::{Buf, BufMut},
 	iter::IterExtensions,
-	DeserializeBytes, SerializationError, SerializationMode, SerializeBytes,
 };
 use bytemuck::{Pod, TransparentWrapper, Zeroable};
 use rand::{Rng, RngCore};
@@ -21,20 +21,20 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use super::{
 	aes_field::AESTowerField128b,
 	arithmetic_traits::InvertOrZero,
-	binary_field::{BinaryField, BinaryField128b, BinaryField1b, TowerField},
+	binary_field::{BinaryField, BinaryField1b, BinaryField128b, TowerField},
 	error::Error,
 	extension::ExtensionField,
 	underlier::WithUnderlier,
 };
 use crate::{
+	Field,
 	arch::packed_polyval_128::PackedBinaryPolyval1x128b,
 	arithmetic_traits::Square,
 	binary_field_arithmetic::{
 		invert_or_zero_using_packed, multiple_using_packed, square_using_packed,
 	},
 	linear_transformation::{FieldLinearTransformation, Transformation},
-	underlier::{IterationMethods, IterationStrategy, NumCast, UnderlierWithBitOps, U1},
-	Field,
+	underlier::{IterationMethods, IterationStrategy, NumCast, U1, UnderlierWithBitOps},
 };
 
 #[derive(
@@ -1073,21 +1073,21 @@ pub fn is_polyval_tower<F: TowerField>() -> bool {
 
 #[cfg(test)]
 mod tests {
-	use binius_utils::{bytes::BytesMut, SerializationMode, SerializeBytes};
+	use binius_utils::{SerializationMode, SerializeBytes, bytes::BytesMut};
 	use proptest::prelude::*;
 	use rand::thread_rng;
 
 	use super::*;
 	use crate::{
+		AESTowerField128b, PackedAESBinaryField1x128b, PackedAESBinaryField2x128b,
+		PackedAESBinaryField4x128b, PackedBinaryField1x128b, PackedBinaryField2x128b,
+		PackedBinaryField4x128b, PackedField,
 		arch::{
 			packed_polyval_256::PackedBinaryPolyval2x128b,
 			packed_polyval_512::PackedBinaryPolyval4x128b,
 		},
 		binary_field::tests::is_binary_field_valid_generator,
 		linear_transformation::PackedTransformationFactory,
-		AESTowerField128b, PackedAESBinaryField1x128b, PackedAESBinaryField2x128b,
-		PackedAESBinaryField4x128b, PackedBinaryField1x128b, PackedBinaryField2x128b,
-		PackedBinaryField4x128b, PackedField,
 	};
 
 	#[test]

--- a/crates/field/src/tests.rs
+++ b/crates/field/src/tests.rs
@@ -5,19 +5,19 @@ use std::iter;
 use proptest::prelude::*;
 
 use crate::{
-	underlier::{SmallU, WithUnderlier},
-	AESTowerField8b, BinaryField128b, BinaryField128bPolyval, BinaryField16b, BinaryField1b,
-	BinaryField2b, BinaryField32b, BinaryField4b, BinaryField64b, BinaryField8b, Field,
-	PackedBinaryField128x1b, PackedBinaryField128x2b, PackedBinaryField128x4b,
-	PackedBinaryField16x16b, PackedBinaryField16x32b, PackedBinaryField16x4b,
-	PackedBinaryField16x8b, PackedBinaryField1x128b, PackedBinaryField1x64b,
-	PackedBinaryField256x1b, PackedBinaryField256x2b, PackedBinaryField2x128b,
-	PackedBinaryField2x32b, PackedBinaryField2x64b, PackedBinaryField32x16b,
+	AESTowerField8b, BinaryField1b, BinaryField2b, BinaryField4b, BinaryField8b, BinaryField16b,
+	BinaryField32b, BinaryField64b, BinaryField128b, BinaryField128bPolyval, Field,
+	PackedBinaryField1x64b, PackedBinaryField1x128b, PackedBinaryField2x32b,
+	PackedBinaryField2x64b, PackedBinaryField2x128b, PackedBinaryField4x16b,
+	PackedBinaryField4x32b, PackedBinaryField4x64b, PackedBinaryField4x128b, PackedBinaryField8x8b,
+	PackedBinaryField8x16b, PackedBinaryField8x32b, PackedBinaryField8x64b, PackedBinaryField16x4b,
+	PackedBinaryField16x8b, PackedBinaryField16x16b, PackedBinaryField16x32b,
 	PackedBinaryField32x2b, PackedBinaryField32x4b, PackedBinaryField32x8b,
-	PackedBinaryField4x128b, PackedBinaryField4x16b, PackedBinaryField4x32b,
-	PackedBinaryField4x64b, PackedBinaryField512x1b, PackedBinaryField64x1b,
-	PackedBinaryField64x2b, PackedBinaryField64x4b, PackedBinaryField64x8b, PackedBinaryField8x16b,
-	PackedBinaryField8x32b, PackedBinaryField8x64b, PackedBinaryField8x8b, PackedField,
+	PackedBinaryField32x16b, PackedBinaryField64x1b, PackedBinaryField64x2b,
+	PackedBinaryField64x4b, PackedBinaryField64x8b, PackedBinaryField128x1b,
+	PackedBinaryField128x2b, PackedBinaryField128x4b, PackedBinaryField256x1b,
+	PackedBinaryField256x2b, PackedBinaryField512x1b, PackedField,
+	underlier::{SmallU, WithUnderlier},
 };
 
 #[test]

--- a/crates/field/src/tower.rs
+++ b/crates/field/src/tower.rs
@@ -5,6 +5,9 @@
 use trait_set::trait_set;
 
 use crate::{
+	AESTowerField8b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField128b,
+	BinaryField1b, BinaryField8b, BinaryField16b, BinaryField32b, BinaryField64b, BinaryField128b,
+	BinaryField128bPolyval, ExtensionField, PackedExtension, PackedField, TowerField,
 	as_packed_field::PackScalar,
 	linear_transformation::{PackedTransformationFactory, Transformation},
 	polyval::{
@@ -12,9 +15,6 @@ use crate::{
 		POLYVAL_TO_AES_TRANSFORMARION, POLYVAL_TO_BINARY_TRANSFORMATION,
 	},
 	underlier::UnderlierType,
-	AESTowerField128b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField8b,
-	BinaryField128b, BinaryField128bPolyval, BinaryField16b, BinaryField1b, BinaryField32b,
-	BinaryField64b, BinaryField8b, ExtensionField, PackedExtension, PackedField, TowerField,
 };
 
 /// A trait that groups a family of related [`TowerField`]s as associated types.

--- a/crates/field/src/transpose.rs
+++ b/crates/field/src/transpose.rs
@@ -71,7 +71,7 @@ pub fn square_transpose<P: PackedField>(log_n: usize, elems: &mut [P]) -> Result
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::{PackedBinaryField128x1b, PackedBinaryField64x2b};
+	use crate::{PackedBinaryField64x2b, PackedBinaryField128x1b};
 
 	#[test]
 	fn test_square_transpose_128x1b() {

--- a/crates/field/src/underlier/iteration.rs
+++ b/crates/field/src/underlier/iteration.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use binius_utils::{checked_arithmetics::checked_int_div, iter::IterExtensions};
 
-use super::{Divisible, NumCast, UnderlierType, UnderlierWithBitOps, U1, U2, U4};
+use super::{Divisible, NumCast, U1, U2, U4, UnderlierType, UnderlierWithBitOps};
 
 /// The iteration strategy for the given underlier type 'U' that is treated as a packed collection
 /// of 'T's.

--- a/crates/field/src/underlier/scaled.rs
+++ b/crates/field/src/underlier/scaled.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use binius_utils::checked_arithmetics::checked_log_2;
-use bytemuck::{must_cast_mut, must_cast_ref, NoUninit, Pod, Zeroable};
+use bytemuck::{NoUninit, Pod, Zeroable, must_cast_mut, must_cast_ref};
 use rand::RngCore;
 use subtle::{Choice, ConstantTimeEq};
 

--- a/crates/field/src/underlier/small_uint.rs
+++ b/crates/field/src/underlier/small_uint.rs
@@ -7,20 +7,20 @@ use std::{
 };
 
 use binius_utils::{
+	SerializationError, SerializationMode, SerializeBytes,
 	bytes::{Buf, BufMut},
 	checked_arithmetics::checked_log_2,
 	serialization::DeserializeBytes,
-	SerializationError, SerializationMode, SerializeBytes,
 };
 use bytemuck::{NoUninit, Zeroable};
 use derive_more::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign};
 use rand::{
-	distributions::{Distribution, Uniform},
 	RngCore,
+	distributions::{Distribution, Uniform},
 };
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 
-use super::{underlier_with_bit_ops::UnderlierWithBitOps, Random, UnderlierType};
+use super::{Random, UnderlierType, underlier_with_bit_ops::UnderlierWithBitOps};
 
 /// Unsigned type with a size strictly less than 8 bits.
 #[derive(

--- a/crates/field/src/underlier/underlier_type.rs
+++ b/crates/field/src/underlier/underlier_type.rs
@@ -4,8 +4,8 @@ use std::fmt::Debug;
 
 use bytemuck::{NoUninit, Zeroable};
 use rand::{
-	distributions::{Distribution, Standard},
 	Rng, RngCore,
+	distributions::{Distribution, Standard},
 };
 use subtle::ConstantTimeEq;
 

--- a/crates/field/src/underlier/underlier_type.rs
+++ b/crates/field/src/underlier/underlier_type.rs
@@ -175,7 +175,7 @@ where
 	Standard: Distribution<T>,
 {
 	fn random(mut rng: impl RngCore) -> Self {
-		rng.gen()
+		rng.r#gen()
 	}
 }
 

--- a/crates/field/src/underlier/underlier_with_bit_ops.rs
+++ b/crates/field/src/underlier/underlier_with_bit_ops.rs
@@ -5,8 +5,8 @@ use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, N
 use binius_utils::checked_arithmetics::{checked_int_div, checked_log_2};
 
 use super::{
-	underlier_type::{NumCast, UnderlierType},
 	U1, U2, U4,
+	underlier_type::{NumCast, UnderlierType},
 };
 use crate::tower_levels::TowerLevel;
 

--- a/crates/field/src/underlier/underlier_with_bit_ops.rs
+++ b/crates/field/src/underlier/underlier_with_bit_ops.rs
@@ -117,7 +117,7 @@ pub trait UnderlierWithBitOps:
 		T: UnderlierWithBitOps + NumCast<Self>,
 		Self: From<T>,
 	{
-		spread_fallback(self, log_block_len, block_idx)
+		unsafe { spread_fallback(self, log_block_len, block_idx) }
 	}
 
 	/// Left shift within 128-bit lanes.
@@ -447,7 +447,7 @@ where
 	U: UnderlierWithBitOps + From<T>,
 	T: UnderlierType + NumCast<U>,
 {
-	std::array::from_fn(|i| value.get_subvalue::<T>(block_idx * BLOCK_LEN + i))
+	std::array::from_fn(|i| unsafe { value.get_subvalue::<T>(block_idx * BLOCK_LEN + i) })
 }
 
 /// A helper functions for implementing `UnderlierWithBitOps::spread_unchecked` for SIMD types.
@@ -464,7 +464,8 @@ where
 	U: UnderlierWithBitOps + From<T>,
 	T: UnderlierType + SpreadToByte + NumCast<U>,
 {
-	get_block_values::<U, T, BLOCK_LEN>(value, block_idx).map(SpreadToByte::spread_to_byte)
+	unsafe { get_block_values::<U, T, BLOCK_LEN>(value, block_idx) }
+		.map(SpreadToByte::spread_to_byte)
 }
 
 #[cfg(test)]

--- a/crates/field/src/util.rs
+++ b/crates/field/src/util.rs
@@ -5,7 +5,7 @@ use std::iter;
 use binius_maybe_rayon::prelude::*;
 use binius_utils::checked_arithmetics::checked_int_div;
 
-use crate::{packed::get_packed_slice_unchecked, ExtensionField, Field, PackedField};
+use crate::{ExtensionField, Field, PackedField, packed::get_packed_slice_unchecked};
 
 /// Computes the inner product of two vectors without checking that the lengths are equal
 pub fn inner_product_unchecked<F, FE>(

--- a/crates/hal/src/common.rs
+++ b/crates/hal/src/common.rs
@@ -1,8 +1,8 @@
 // Copyright 2025 Irreducible Inc.
 
 use binius_field::{
-	underlier::{UnderlierType, WithUnderlier},
 	PackedField,
+	underlier::{UnderlierType, WithUnderlier},
 };
 
 // A kibibyte per multilinear seems like a reasonable compromise.

--- a/crates/hal/src/cpu.rs
+++ b/crates/hal/src/cpu.rs
@@ -4,14 +4,14 @@ use std::fmt::Debug;
 
 use binius_field::{Field, PackedExtension, PackedField};
 use binius_math::{
-	eq_ind_partial_eval, CompositionPoly, EvaluationOrder, MultilinearExtension, MultilinearPoly,
-	MultilinearQueryRef,
+	CompositionPoly, EvaluationOrder, MultilinearExtension, MultilinearPoly, MultilinearQueryRef,
+	eq_ind_partial_eval,
 };
 use tracing::instrument;
 
 use crate::{
-	sumcheck_folding::fold_multilinears, sumcheck_round_calculation::calculate_round_evals,
 	ComputationBackend, Error, RoundEvals, SumcheckEvaluator, SumcheckMultilinear,
+	sumcheck_folding::fold_multilinears, sumcheck_round_calculation::calculate_round_evals,
 };
 
 /// Implementation of ComputationBackend for the default Backend that uses the CPU for all

--- a/crates/hal/src/sumcheck_folding.rs
+++ b/crates/hal/src/sumcheck_folding.rs
@@ -2,15 +2,15 @@
 
 use binius_field::PackedField;
 use binius_math::{
-	fold_left_lerp_inplace, fold_right_lerp, EvaluationOrder, MultilinearPoly, MultilinearQueryRef,
+	EvaluationOrder, MultilinearPoly, MultilinearQueryRef, fold_left_lerp_inplace, fold_right_lerp,
 };
 use binius_maybe_rayon::prelude::*;
 use binius_utils::checked_arithmetics::log2_ceil_usize;
 use bytemuck::zeroed_vec;
 
 use crate::{
-	common::{subcube_vars_for_bits, MAX_SRC_SUBCUBE_LOG_BITS},
 	Error, SumcheckMultilinear,
+	common::{MAX_SRC_SUBCUBE_LOG_BITS, subcube_vars_for_bits},
 };
 
 pub(crate) fn fold_multilinears<P, M>(

--- a/crates/hal/src/sumcheck_round_calculation.rs
+++ b/crates/hal/src/sumcheck_round_calculation.rs
@@ -7,21 +7,21 @@
 use std::iter;
 
 use binius_field::{
-	packed::get_packed_slice_checked, Field, PackedExtension, PackedField, PackedSubfield,
+	Field, PackedExtension, PackedField, PackedSubfield, packed::get_packed_slice_checked,
 };
 use binius_math::{
-	extrapolate_lines, CompositionPoly, EvaluationOrder, MultilinearPoly, MultilinearQuery,
-	MultilinearQueryRef, RowsBatchRef,
+	CompositionPoly, EvaluationOrder, MultilinearPoly, MultilinearQuery, MultilinearQueryRef,
+	RowsBatchRef, extrapolate_lines,
 };
 use binius_maybe_rayon::prelude::*;
 use binius_utils::bail;
 use bytemuck::zeroed_vec;
-use itertools::{izip, Either, Itertools};
+use itertools::{Either, Itertools, izip};
 use stackalloc::stackalloc_with_iter;
 
 use crate::{
-	common::{subcube_vars_for_bits, MAX_SRC_SUBCUBE_LOG_BITS},
 	Error, RoundEvals, SumcheckEvaluator, SumcheckMultilinear,
+	common::{MAX_SRC_SUBCUBE_LOG_BITS, subcube_vars_for_bits},
 };
 
 trait SumcheckMultilinearAccess<P: PackedField> {

--- a/crates/hash/benches/hash.rs
+++ b/crates/hash/benches/hash.rs
@@ -3,12 +3,12 @@
 use std::{array, mem::MaybeUninit};
 
 use binius_hash::{
-	groestl::Groestl256, multi_digest::MultiDigest, VisionHasherDigest,
-	VisionHasherDigestByteSliced,
+	VisionHasherDigest, VisionHasherDigestByteSliced, groestl::Groestl256,
+	multi_digest::MultiDigest,
 };
-use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use digest::Digest;
-use rand::{thread_rng, RngCore};
+use rand::{RngCore, thread_rng};
 
 fn bench_groestl(c: &mut Criterion) {
 	let mut group = c.benchmark_group("Grøstl");

--- a/crates/hash/src/groestl/compression.rs
+++ b/crates/hash/src/groestl/compression.rs
@@ -4,8 +4,8 @@ use digest::Output;
 
 use super::digest::Groestl256;
 use crate::{
-	groestl::{GroestlShortImpl, GroestlShortInternal},
 	PseudoCompressionFunction,
+	groestl::{GroestlShortImpl, GroestlShortInternal},
 };
 
 /// One-way compression function that compresses two 32-byte strings into a single 32-byte string.

--- a/crates/hash/src/groestl/digest.rs
+++ b/crates/hash/src/groestl/digest.rs
@@ -7,13 +7,13 @@ use core::fmt;
 
 pub use digest;
 use digest::{
+	HashMarker, InvalidOutputSize, Output,
 	block_buffer::Eager,
 	core_api::{
 		AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, CoreWrapper,
 		CtVariableCoreWrapper, OutputSizeUser, TruncSide, UpdateCore, VariableOutputCore,
 	},
-	typenum::{Unsigned, U32, U64},
-	HashMarker, InvalidOutputSize, Output,
+	typenum::{U32, U64, Unsigned},
 };
 
 use super::{GroestlShortImpl, GroestlShortInternal};

--- a/crates/hash/src/multi_digest.rs
+++ b/crates/hash/src/multi_digest.rs
@@ -177,9 +177,9 @@ mod tests {
 	use std::iter::repeat_with;
 
 	use binius_maybe_rayon::iter::IntoParallelRefIterator;
-	use digest::{consts::U32, Digest, FixedOutput, HashMarker, OutputSizeUser, Update};
+	use digest::{Digest, FixedOutput, HashMarker, OutputSizeUser, Update, consts::U32};
 	use itertools::izip;
-	use rand::{rngs::StdRng, RngCore, SeedableRng};
+	use rand::{RngCore, SeedableRng, rngs::StdRng};
 
 	use super::*;
 

--- a/crates/hash/src/serialization.rs
+++ b/crates/hash/src/serialization.rs
@@ -3,10 +3,10 @@
 use std::{borrow::Borrow, cmp::min};
 
 use binius_utils::{SerializationMode, SerializeBytes};
-use bytes::{buf::UninitSlice, BufMut};
+use bytes::{BufMut, buf::UninitSlice};
 use digest::{
-	core_api::{Block, BlockSizeUser},
 	Digest, Output,
+	core_api::{Block, BlockSizeUser},
 };
 
 /// Adapter that wraps a [`Digest`] references and exposes the [`BufMut`] interface.

--- a/crates/hash/src/sha2.rs
+++ b/crates/hash/src/sha2.rs
@@ -1,8 +1,8 @@
 // Copyright 2023-2025 Irreducible Inc.
 
 use bytemuck::{bytes_of_mut, must_cast};
-use digest::{core_api::Block, Digest};
-use sha2::{compress256, digest::Output, Sha256};
+use digest::{Digest, core_api::Block};
+use sha2::{Sha256, compress256, digest::Output};
 
 use crate::{CompressionFunction, PseudoCompressionFunction};
 

--- a/crates/hash/src/vision/digest.rs
+++ b/crates/hash/src/vision/digest.rs
@@ -3,15 +3,16 @@
 use std::{array, mem::MaybeUninit};
 
 use binius_field::{
-	linear_transformation::Transformation, make_aes_to_binary_packed_transformer,
-	make_binary_to_aes_packed_transformer, underlier::WithUnderlier, AesToBinaryTransformation,
-	BinaryField8b, BinaryToAesTransformation, ByteSlicedAES32x32b, PackedAESBinaryField8x32b,
-	PackedBinaryField8x32b, PackedExtensionIndexable, PackedField, PackedFieldIndexable,
+	AesToBinaryTransformation, BinaryField8b, BinaryToAesTransformation, ByteSlicedAES32x32b,
+	PackedAESBinaryField8x32b, PackedBinaryField8x32b, PackedExtensionIndexable, PackedField,
+	PackedFieldIndexable, linear_transformation::Transformation,
+	make_aes_to_binary_packed_transformer, make_binary_to_aes_packed_transformer,
+	underlier::WithUnderlier,
 };
 use digest::{
+	FixedOutput, FixedOutputReset, HashMarker, OutputSizeUser, Reset, Update,
 	consts::{U32, U96},
 	core_api::BlockSizeUser,
-	FixedOutput, FixedOutputReset, HashMarker, OutputSizeUser, Reset, Update,
 };
 use lazy_static::lazy_static;
 use stackalloc::helpers::slice_assume_init_mut;
@@ -359,8 +360,8 @@ mod tests {
 	use hex_literal::hex;
 
 	use super::{
-		MultiDigest, VisionHasherDigest, VisionHasherDigestByteSliced,
-		HASHES_PER_BYTE_SLICED_PERMUTATION,
+		HASHES_PER_BYTE_SLICED_PERMUTATION, MultiDigest, VisionHasherDigest,
+		VisionHasherDigestByteSliced,
 	};
 
 	#[test]

--- a/crates/hash/src/vision/mod.rs
+++ b/crates/hash/src/vision/mod.rs
@@ -8,4 +8,4 @@ pub mod permutation;
 pub use compression::*;
 pub use constants::*;
 pub use digest::*;
-pub use permutation::{Vision32MDSTransform, Vision32bPermutation, INV_PACKED_TRANS_AES};
+pub use permutation::{INV_PACKED_TRANS_AES, Vision32MDSTransform, Vision32bPermutation};

--- a/crates/hash/src/vision/permutation.rs
+++ b/crates/hash/src/vision/permutation.rs
@@ -3,16 +3,16 @@
 use std::array;
 
 use binius_field::{
+	AESTowerField8b, AESTowerField32b, BinaryField8b, ByteSlicedAES32x32b,
+	PackedAESBinaryField8x32b, PackedAESBinaryField32x8b, PackedExtension, PackedField,
 	linear_transformation::{
 		FieldLinearTransformation, PackedTransformationFactory, Transformation,
 	},
 	packed::packed_from_fn_with_offset,
-	AESTowerField32b, AESTowerField8b, BinaryField8b, ByteSlicedAES32x32b,
-	PackedAESBinaryField32x8b, PackedAESBinaryField8x32b, PackedExtension, PackedField,
 };
 use binius_ntt::{
-	twiddle::{OnTheFlyTwiddleAccess, TwiddleAccess},
 	AdditiveNTT, SingleThreadedNTT,
+	twiddle::{OnTheFlyTwiddleAccess, TwiddleAccess},
 };
 use lazy_static::lazy_static;
 
@@ -522,8 +522,8 @@ impl FastNttByteSliced {
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{packed::set_packed_slice, BinaryField32b, PackedExtension};
-	use rand::{rngs::StdRng, SeedableRng};
+	use binius_field::{BinaryField32b, PackedExtension, packed::set_packed_slice};
+	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 

--- a/crates/m3/src/builder/channel.rs
+++ b/crates/m3/src/builder/channel.rs
@@ -3,7 +3,7 @@
 use binius_core::constraint_system::channel::{ChannelId, FlushDirection};
 
 use super::column::ColumnIndex;
-use crate::builder::{Col, B1};
+use crate::builder::{B1, Col};
 
 /// A flushing rule within a table.
 #[derive(Debug)]

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -5,9 +5,9 @@ pub use binius_core::constraint_system::channel::{
 };
 use binius_core::{
 	constraint_system::{
+		ConstraintSystem as CompiledConstraintSystem,
 		channel::{ChannelId, OracleOrConst},
 		exp::Exp,
-		ConstraintSystem as CompiledConstraintSystem,
 	},
 	oracle::{Constraint, ConstraintPredicate, ConstraintSet, MultilinearOracleSet, OracleId},
 	transparent::step_down::StepDown,
@@ -19,6 +19,7 @@ use bumpalo::Bump;
 use itertools::chain;
 
 use super::{
+	Table, TableBuilder, TableSizeSpec, ZeroConstraint,
 	channel::{Channel, Flush},
 	column::{ColumnDef, ColumnInfo},
 	error::Error,
@@ -26,7 +27,6 @@ use super::{
 	table::{self, TablePartition},
 	types::B128,
 	witness::WitnessIndex,
-	Table, TableBuilder, TableSizeSpec, ZeroConstraint,
 };
 use crate::builder::expr::ArithExprNamedVars;
 
@@ -192,10 +192,10 @@ impl<F: TowerField> ConstraintSystem<F> {
 					}
 					if count != 1 << table::log_capacity(count) {
 						panic!(
-						    "Tables with required power-of-two size currently cannot have capacity \
+							"Tables with required power-of-two size currently cannot have capacity \
 						exceeding their count. This is because the flushes do not have automatic \
 						selectors applied, and so the table would flush invalid events"
-					    );
+						);
 					}
 				}
 				TableSizeSpec::Fixed { log_size } => {

--- a/crates/m3/src/builder/error.rs
+++ b/crates/m3/src/builder/error.rs
@@ -9,7 +9,9 @@ use super::{column::ColumnId, structured::Error as StructuredError, table::Table
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-	#[error("statement table sizes does not match the number of tables; expected {expected}, got {actual}")]
+	#[error(
+		"statement table sizes does not match the number of tables; expected {expected}, got {actual}"
+	)]
 	StatementMissingTableSize { expected: usize, actual: usize },
 	#[error("missing table with ID: {table_id}")]
 	MissingTable { table_id: TableId },
@@ -28,7 +30,9 @@ pub enum Error {
 	Structured(#[from] StructuredError),
 	#[error("table {table_id} index has already been initialized")]
 	TableIndexAlreadyInitialized { table_id: TableId },
-	#[error("column is not in table; column table ID: {column_table_id}, witness table ID: {witness_table_id}")]
+	#[error(
+		"column is not in table; column table ID: {column_table_id}, witness table ID: {witness_table_id}"
+	)]
 	TableMismatch {
 		column_table_id: TableId,
 		witness_table_id: TableId,
@@ -38,9 +42,13 @@ pub enum Error {
 	#[error("table {table_id} is required to have a fixed power-of-two size, instead got {size}")]
 	TableSizeFixedRequired { table_id: TableId, size: usize },
 	// TODO: These should have column IDs
-	#[error("witness borrow error: {0}. Note that packed columns are aliases for the unpacked column when accessing witness data")]
+	#[error(
+		"witness borrow error: {0}. Note that packed columns are aliases for the unpacked column when accessing witness data"
+	)]
 	WitnessBorrow(#[source] BorrowError),
-	#[error("witness borrow error: {0}. Note that packed columns are aliases for the unpacked column when accessing witness data")]
+	#[error(
+		"witness borrow error: {0}. Note that packed columns are aliases for the unpacked column when accessing witness data"
+	)]
 	WitnessBorrowMut(#[source] BorrowMutError),
 	#[error(
 		"the table index was initialized for {expected} events; attempted to fill with {actual}"

--- a/crates/m3/src/builder/indexed_lookup.rs
+++ b/crates/m3/src/builder/indexed_lookup.rs
@@ -163,7 +163,7 @@ mod tests {
 
 		let mut rng = StdRng::seed_from_u64(0);
 		let inputs_1 = repeat_with(|| {
-			let input = rng.gen::<u8>();
+			let input = rng.r#gen::<u8>();
 			let carry_in_bit = rng.gen_bool(0.5);
 			(input, carry_in_bit)
 		})
@@ -180,7 +180,7 @@ mod tests {
 			.unwrap();
 
 		let inputs_2 = repeat_with(|| {
-			let input = rng.gen::<u8>();
+			let input = rng.r#gen::<u8>();
 			let carry_in_bit = rng.gen_bool(0.5);
 			(input, carry_in_bit)
 		})

--- a/crates/m3/src/builder/indexed_lookup.rs
+++ b/crates/m3/src/builder/indexed_lookup.rs
@@ -6,8 +6,8 @@ use binius_core::constraint_system::channel::{Boundary, ChannelId, FlushDirectio
 use binius_field::{Field, PackedExtension, PackedField, TowerField};
 
 use super::{
-	constraint_system::ConstraintSystem, error::Error, witness::WitnessIndex, B1, B128, B16, B32,
-	B64, B8,
+	B1, B8, B16, B32, B64, B128, constraint_system::ConstraintSystem, error::Error,
+	witness::WitnessIndex,
 };
 
 /// Indexed lookup tables are fixed-size tables where every entry is easily determined by its
@@ -117,10 +117,10 @@ mod tests {
 	use std::{cmp::Reverse, iter::repeat_with};
 
 	use binius_field::{
+		PackedFieldIndexable,
 		arch::OptimalUnderlier,
 		ext_basis,
 		packed::{get_packed_slice, set_packed_slice},
-		PackedFieldIndexable,
 	};
 	use bumpalo::Bump;
 	use itertools::Itertools;
@@ -129,8 +129,9 @@ mod tests {
 	use super::*;
 	use crate::{
 		builder::{
-			test_utils::{validate_system_witness, ClosureFiller},
-			upcast_col, Col, TableBuilder, TableFiller, TableId, TableWitnessSegment,
+			Col, TableBuilder, TableFiller, TableId, TableWitnessSegment,
+			test_utils::{ClosureFiller, validate_system_witness},
+			upcast_col,
 		},
 		gadgets::lookup::LookupProducer,
 	};

--- a/crates/m3/src/builder/structured.rs
+++ b/crates/m3/src/builder/structured.rs
@@ -59,9 +59,9 @@ mod tests {
 	use std::iter::{self};
 
 	use binius_core::polynomial::{
-		test_utils::decompose_index_to_hypercube_point, ArithCircuitPoly,
+		ArithCircuitPoly, test_utils::decompose_index_to_hypercube_point,
 	};
-	use binius_field::{arch::OptimalUnderlier128b, as_packed_field::PackedType, BinaryField32b};
+	use binius_field::{BinaryField32b, arch::OptimalUnderlier128b, as_packed_field::PackedType};
 	use binius_math::{ArithCircuit, CompositionPoly};
 	use bumpalo::Bump;
 	use itertools::izip;
@@ -69,8 +69,8 @@ mod tests {
 	use super::*;
 	use crate::{
 		builder::{
-			test_utils::{validate_system_witness, ClosureFiller},
-			ConstraintSystem, WitnessIndex, B128, B16, B32,
+			B16, B32, B128, ConstraintSystem, WitnessIndex,
+			test_utils::{ClosureFiller, validate_system_witness},
 		},
 		gadgets::structured::fill_incrementing_b32,
 	};

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -8,10 +8,10 @@ use binius_core::{
 	transparent::MultilinearExtensionTransparent,
 };
 use binius_field::{
+	ExtensionField, TowerField,
 	arch::OptimalUnderlier,
 	as_packed_field::{PackScalar, PackedType},
 	packed::pack_slice,
-	ExtensionField, TowerField,
 };
 use binius_math::ArithCircuit;
 use binius_utils::{
@@ -20,13 +20,14 @@ use binius_utils::{
 };
 
 use super::{
+	B1, ColumnIndex, FlushOpts,
 	channel::Flush,
 	column::{Col, ColumnDef, ColumnId, ColumnInfo, ColumnShape},
 	expr::{Expr, ZeroConstraint},
 	stat::TableStat,
 	structured::StructuredDynSize,
 	types::B128,
-	upcast_col, ColumnIndex, FlushOpts, B1,
+	upcast_col,
 };
 
 pub type TableId = usize;

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -186,7 +186,7 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 			.vars_usage()
 			.iter()
 			.enumerate()
-			.filter(|(_, &used)| used)
+			.filter(|(_, used)| **used)
 			.map(|(i, _)| i)
 			.collect::<Vec<_>>();
 		let cols = partition_indexes

--- a/crates/m3/src/builder/test_utils.rs
+++ b/crates/m3/src/builder/test_utils.rs
@@ -5,22 +5,22 @@
 use anyhow::Result;
 use binius_core::{constraint_system::channel::Boundary, fiat_shamir::HasherChallenger};
 use binius_field::{
+	BinaryField128bPolyval, PackedField, PackedFieldIndexable, TowerField,
 	as_packed_field::{PackScalar, PackedType},
 	linear_transformation::PackedTransformationFactory,
 	tower::CanonicalTowerFamily,
 	underlier::UnderlierType,
-	BinaryField128bPolyval, PackedField, PackedFieldIndexable, TowerField,
 };
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_utils::env::boolean_env_flag_set;
 
 use super::{
+	B1, B8, B16, B32, B64,
 	constraint_system::ConstraintSystem,
 	table::TableId,
 	witness::{TableFiller, TableWitnessSegment},
-	B1, B16, B32, B64, B8,
 };
-use crate::builder::{Statement, WitnessIndex, B128};
+use crate::builder::{B128, Statement, WitnessIndex};
 
 /// An easy-to-use implementation of [`TableFiller`] that is constructed with a closure.
 ///

--- a/crates/m3/src/builder/types.rs
+++ b/crates/m3/src/builder/types.rs
@@ -5,7 +5,7 @@
 //! The primitive data types are fields in the canonical tower.
 
 use binius_field::{
-	BinaryField128b, BinaryField16b, BinaryField1b, BinaryField32b, BinaryField64b, BinaryField8b,
+	BinaryField1b, BinaryField8b, BinaryField16b, BinaryField32b, BinaryField64b, BinaryField128b,
 };
 
 pub type B1 = BinaryField1b;

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -869,9 +869,7 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegmentedView<'a
 		// TODO: clippy error (clippy::mut_from_ref): mutable borrow from immutable input(s)
 		#[allow(clippy::mut_from_ref)]
 		unsafe fn cast_slice_ref_to_mut<T>(slice: &[T]) -> &mut [T] {
-			unsafe {
-				slice::from_raw_parts_mut(slice.as_ptr() as *mut T, slice.len())
-			}
+			unsafe { slice::from_raw_parts_mut(slice.as_ptr() as *mut T, slice.len()) }
 		}
 
 		// Convert cols with mutable references into cols with const refs so that they can be

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -13,10 +13,10 @@ use binius_core::{
 	witness::MultilinearExtensionIndex,
 };
 use binius_field::{
+	ExtensionField, PackedExtension, PackedField, PackedFieldIndexable, PackedSubfield, TowerField,
 	arch::OptimalUnderlier,
 	as_packed_field::PackedType,
 	packed::{get_packed_slice, set_packed_slice},
-	ExtensionField, PackedExtension, PackedField, PackedFieldIndexable, PackedSubfield, TowerField,
 };
 use binius_math::{
 	ArithCircuit, CompositionPoly, MultilinearExtension, MultilinearPoly, RowsBatchRef,
@@ -24,17 +24,17 @@ use binius_math::{
 use binius_maybe_rayon::prelude::*;
 use binius_utils::checked_arithmetics::checked_log_2;
 use bumpalo::Bump;
-use bytemuck::{must_cast_slice, must_cast_slice_mut, zeroed_vec, Pod};
+use bytemuck::{Pod, must_cast_slice, must_cast_slice_mut, zeroed_vec};
 use either::Either;
 use getset::CopyGetters;
 use itertools::Itertools;
 
 use super::{
+	ColumnDef, ColumnId, ColumnIndex, ConstraintSystem, Expr,
 	column::{Col, ColumnShape},
 	error::Error,
 	table::{self, Table, TableId},
-	types::{B1, B128, B16, B32, B64, B8},
-	ColumnDef, ColumnId, ColumnIndex, ConstraintSystem, Expr,
+	types::{B1, B8, B16, B32, B64, B128},
 };
 use crate::builder::multi_iter::MultiIterator;
 
@@ -1288,12 +1288,12 @@ mod tests {
 		arch::{OptimalUnderlier128b, OptimalUnderlier256b},
 		packed::{len_packed_slice, set_packed_slice},
 	};
-	use rand::{rngs::StdRng, Rng, SeedableRng};
+	use rand::{Rng, SeedableRng, rngs::StdRng};
 
 	use super::*;
 	use crate::builder::{
-		types::{B1, B32, B8},
 		ConstraintSystem, Statement, TableBuilder,
+		types::{B1, B8, B32},
 	};
 
 	#[test]

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -1560,7 +1560,7 @@ mod tests {
 		let table_index = index.init_table(test_table.id(), table_size).unwrap();
 
 		let mut rng = StdRng::seed_from_u64(0);
-		let rows = repeat_with(|| rng.gen())
+		let rows = repeat_with(|| rng.r#gen())
 			.take(table_size)
 			.collect::<Vec<_>>();
 
@@ -1604,7 +1604,7 @@ mod tests {
 		let table_index = index.init_table(test_table.id(), table_size).unwrap();
 
 		let mut rng = StdRng::seed_from_u64(0);
-		let rows = repeat_with(|| rng.gen())
+		let rows = repeat_with(|| rng.r#gen())
 			.take(table_size)
 			.collect::<Vec<_>>();
 

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -1051,7 +1051,7 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegment<'a, P> {
 	pub fn eval_expr<FSub: TowerField, const V: usize>(
 		&self,
 		expr: &Expr<FSub, V>,
-	) -> Result<impl Iterator<Item = PackedSubfield<P, FSub>>, Error>
+	) -> Result<impl Iterator<Item = PackedSubfield<P, FSub>> + use<FSub, V, F, P>, Error>
 	where
 		P: PackedExtension<FSub>,
 	{

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -869,7 +869,9 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegmentedView<'a
 		// TODO: clippy error (clippy::mut_from_ref): mutable borrow from immutable input(s)
 		#[allow(clippy::mut_from_ref)]
 		unsafe fn cast_slice_ref_to_mut<T>(slice: &[T]) -> &mut [T] {
-			slice::from_raw_parts_mut(slice.as_ptr() as *mut T, slice.len())
+			unsafe {
+				slice::from_raw_parts_mut(slice.as_ptr() as *mut T, slice.len())
+			}
 		}
 
 		// Convert cols with mutable references into cols with const refs so that they can be

--- a/crates/m3/src/gadgets/add.rs
+++ b/crates/m3/src/gadgets/add.rs
@@ -4,13 +4,13 @@ use std::{array, marker::PhantomData, ops::Deref};
 
 use binius_core::oracle::ShiftVariant;
 use binius_field::{
-	packed::set_packed_slice, Field, PackedExtension, PackedField, PackedFieldIndexable,
-	PackedSubfield, TowerField,
+	Field, PackedExtension, PackedField, PackedFieldIndexable, PackedSubfield, TowerField,
+	packed::set_packed_slice,
 };
 use itertools::izip;
 
 use crate::builder::{
-	column::Col, types::B1, witness::TableWitnessSegment, TableBuilder, B128, B32, B64,
+	B32, B64, B128, TableBuilder, column::Col, types::B1, witness::TableWitnessSegment,
 };
 
 /// A gadget for performing 32-bit integer addition on vertically-packed bit columns.
@@ -370,11 +370,11 @@ mod tests {
 		arch::OptimalUnderlier128b, as_packed_field::PackedType, packed::get_packed_slice,
 	};
 	use bumpalo::Bump;
-	use rand::{prelude::StdRng, Rng as _, SeedableRng};
+	use rand::{Rng as _, SeedableRng, prelude::StdRng};
 
 	use super::*;
 	use crate::builder::{
-		test_utils::validate_system_witness, ConstraintSystem, Statement, WitnessIndex,
+		ConstraintSystem, Statement, WitnessIndex, test_utils::validate_system_witness,
 	};
 
 	#[test]

--- a/crates/m3/src/gadgets/add.rs
+++ b/crates/m3/src/gadgets/add.rs
@@ -384,8 +384,8 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let test_vector: Vec<(u32, u32, u32, u32, bool)> = (0..N_ITER)
 			.map(|_| {
-				let x: u32 = rng.gen();
-				let y: u32 = rng.gen();
+				let x: u32 = rng.r#gen();
+				let y: u32 = rng.r#gen();
 				let (z, carry) = x.overflowing_add(y);
 				// (x, y, carry_in, zout, final_carry)
 				(x, y, 0x00000000, z, carry)
@@ -408,9 +408,9 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let test_vector: Vec<(u32, u32, u32, u32, bool)> = (0..N_ITER)
 			.map(|_| {
-				let x: u32 = rng.gen();
-				let y: u32 = rng.gen();
-				let carry_in = rng.gen::<bool>() as u32;
+				let x: u32 = rng.r#gen();
+				let y: u32 = rng.r#gen();
+				let carry_in = rng.r#gen::<bool>() as u32;
 				let (x_plus_y, carry1) = x.overflowing_add(y);
 				let (z, carry2) = x_plus_y.overflowing_add(carry_in);
 				let final_carry = carry1 | carry2;
@@ -537,7 +537,7 @@ mod tests {
 
 		let table_id = table.id();
 		let mut rng = StdRng::seed_from_u64(0);
-		let test_values = repeat_with(|| B32::new(rng.gen::<u32>()))
+		let test_values = repeat_with(|| B32::new(rng.r#gen::<u32>()))
 			.take(TABLE_SIZE)
 			.collect::<Vec<_>>();
 

--- a/crates/m3/src/gadgets/barrel_shifter.rs
+++ b/crates/m3/src/gadgets/barrel_shifter.rs
@@ -3,9 +3,9 @@
 use std::cell::RefMut;
 
 use binius_core::oracle::ShiftVariant;
-use binius_field::{packed::set_packed_slice, Field, PackedExtension, PackedFieldIndexable};
+use binius_field::{Field, PackedExtension, PackedFieldIndexable, packed::set_packed_slice};
 
-use crate::builder::{upcast_col, Col, Expr, TableBuilder, TableWitnessSegment, B1, B128, B32};
+use crate::builder::{B1, B32, B128, Col, Expr, TableBuilder, TableWitnessSegment, upcast_col};
 
 /// Maximum number of bits of the shift amount, i.e. 0 < shift_amount < 1 <<
 /// SHIFT_MAX_BITS - 1 = 31 where dst_val = src_val >> shift_amount or dst_val =
@@ -152,7 +152,7 @@ mod tests {
 
 	use binius_field::{arch::OptimalUnderlier128b, as_packed_field::PackedType};
 	use bumpalo::Bump;
-	use rand::{rngs::StdRng, Rng, SeedableRng};
+	use rand::{Rng, SeedableRng, rngs::StdRng};
 
 	use super::*;
 	use crate::builder::{ConstraintSystem, Statement, WitnessIndex};
@@ -178,7 +178,9 @@ mod tests {
 		let mut segment = table_witness.full_segment();
 
 		let mut rng = StdRng::seed_from_u64(0x1234);
-		let test_inputs = repeat_with(|| rng.r#gen()).take(1 << 8).collect::<Vec<u32>>();
+		let test_inputs = repeat_with(|| rng.r#gen())
+			.take(1 << 8)
+			.collect::<Vec<u32>>();
 
 		for (i, (input, shift_amount)) in (*segment.get_mut_as(input).unwrap())
 			.iter_mut()

--- a/crates/m3/src/gadgets/barrel_shifter.rs
+++ b/crates/m3/src/gadgets/barrel_shifter.rs
@@ -178,7 +178,7 @@ mod tests {
 		let mut segment = table_witness.full_segment();
 
 		let mut rng = StdRng::seed_from_u64(0x1234);
-		let test_inputs = repeat_with(|| rng.gen()).take(1 << 8).collect::<Vec<u32>>();
+		let test_inputs = repeat_with(|| rng.r#gen()).take(1 << 8).collect::<Vec<u32>>();
 
 		for (i, (input, shift_amount)) in (*segment.get_mut_as(input).unwrap())
 			.iter_mut()

--- a/crates/m3/src/gadgets/div.rs
+++ b/crates/m3/src/gadgets/div.rs
@@ -2,11 +2,11 @@
 
 use std::array;
 
-use binius_field::{packed::set_packed_slice, Field, PackedExtension, PackedField};
+use binius_field::{Field, PackedExtension, PackedField, packed::set_packed_slice};
 use itertools::izip;
 
 use crate::{
-	builder::{Col, TableBuilder, TableWitnessSegment, B1, B128, B32, B64},
+	builder::{B1, B32, B64, B128, Col, TableBuilder, TableWitnessSegment},
 	gadgets::{
 		add::{U32AddFlags, WideAdd},
 		mul::{MulSS32, MulUU32, SignConverter, UnsignedMulPrimitives},

--- a/crates/m3/src/gadgets/hash/groestl.rs
+++ b/crates/m3/src/gadgets/hash/groestl.rs
@@ -10,16 +10,15 @@ use anyhow::Result;
 use array_util::ArrayExt;
 use binius_core::oracle::ShiftVariant;
 use binius_field::{
-	ext_basis,
+	AESTowerField8b, ExtensionField, PackedExtension, PackedField, PackedFieldIndexable,
+	PackedSubfield, TowerField, ext_basis,
 	linear_transformation::{
 		FieldLinearTransformation, PackedTransformationFactory, Transformation,
 	},
 	packed::{get_packed_slice, len_packed_slice, set_packed_slice},
-	AESTowerField8b, ExtensionField, PackedExtension, PackedField, PackedFieldIndexable,
-	PackedSubfield, TowerField,
 };
 
-use crate::builder::{upcast_col, Col, Expr, TableBuilder, TableWitnessSegment, B1, B128, B8};
+use crate::builder::{B1, B8, B128, Col, Expr, TableBuilder, TableWitnessSegment, upcast_col};
 
 /// The first row of the circulant matrix defining the MixBytes step in Grøstl.
 const MIX_BYTES_VEC: [u8; 8] = [0x02, 0x02, 0x03, 0x04, 0x05, 0x03, 0x05, 0x07];
@@ -405,7 +404,7 @@ mod tests {
 	};
 	use binius_hash::groestl::{GroestlShortImpl, GroestlShortInternal};
 	use bumpalo::Bump;
-	use rand::{prelude::StdRng, SeedableRng};
+	use rand::{SeedableRng, prelude::StdRng};
 
 	use super::*;
 	use crate::builder::{ConstraintSystem, Statement, WitnessIndex};

--- a/crates/m3/src/gadgets/hash/keccak/mod.rs
+++ b/crates/m3/src/gadgets/hash/keccak/mod.rs
@@ -8,13 +8,13 @@ use anyhow::Result;
 use array_util::ArrayExt as _;
 use binius_core::oracle::ShiftVariant;
 use binius_field::{
-	linear_transformation::PackedTransformationFactory, Field, PackedExtension,
-	PackedFieldIndexable, PackedSubfield, TowerField,
+	Field, PackedExtension, PackedFieldIndexable, PackedSubfield, TowerField,
+	linear_transformation::PackedTransformationFactory,
 };
 pub use state::{StateMatrix, StateRow};
 use trace::PermutationTrace;
 
-use crate::builder::{Col, Expr, TableBuilder, TableWitnessSegment, B1, B128, B64, B8};
+use crate::builder::{B1, B8, B64, B128, Col, Expr, TableBuilder, TableWitnessSegment};
 
 mod state;
 mod test_vector;

--- a/crates/m3/src/gadgets/hash/keccak/trace.rs
+++ b/crates/m3/src/gadgets/hash/keccak/trace.rs
@@ -3,8 +3,8 @@
 use std::array;
 
 use super::{
-	state::{StateMatrix, StateRow},
 	RC, RHO, ROUNDS_PER_PERMUTATION,
+	state::{StateMatrix, StateRow},
 };
 
 /// Trace of a keccak-f round.
@@ -59,11 +59,7 @@ impl RoundTrace {
 			let a_chi = b[(x, y)] ^ (!b[(x + 1, y)] & b[(x + 2, y)]);
 
 			// # ι step
-			if (x, y) == (0, 0) {
-				a_chi ^ rc
-			} else {
-				a_chi
-			}
+			if (x, y) == (0, 0) { a_chi ^ rc } else { a_chi }
 		});
 
 		RoundTrace {
@@ -129,7 +125,7 @@ pub fn keccakf_trace(state_in: StateMatrix<u64>) -> PermutationTrace {
 #[cfg(test)]
 mod tests {
 	use super::{
-		super::{test_vector, StateMatrix},
+		super::{StateMatrix, test_vector},
 		RoundTrace,
 	};
 

--- a/crates/m3/src/gadgets/lookup.rs
+++ b/crates/m3/src/gadgets/lookup.rs
@@ -1,11 +1,11 @@
 // Copyright 2025 Irreducible Inc.
 
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 use binius_core::constraint_system::channel::ChannelId;
 use binius_field::{ExtensionField, PackedExtension, PackedField, PackedSubfield, TowerField};
 use itertools::Itertools;
 
-use crate::builder::{Col, FlushOpts, TableBuilder, TableWitnessSegment, B1, B128};
+use crate::builder::{B1, B128, Col, FlushOpts, TableBuilder, TableWitnessSegment};
 
 /// A lookup producer gadget is used to create a lookup table.
 ///
@@ -92,12 +92,12 @@ mod tests {
 
 	use binius_field::{arch::OptimalUnderlier128b, as_packed_field::PackedType};
 	use bumpalo::Bump;
-	use rand::{rngs::StdRng, Rng, SeedableRng};
+	use rand::{Rng, SeedableRng, rngs::StdRng};
 
 	use super::*;
 	use crate::builder::{
-		test_utils::{validate_system_witness, ClosureFiller},
 		ConstraintSystem, WitnessIndex,
+		test_utils::{ClosureFiller, validate_system_witness},
 	};
 
 	fn with_lookup_test_instance(

--- a/crates/m3/src/gadgets/mul.rs
+++ b/crates/m3/src/gadgets/mul.rs
@@ -4,13 +4,13 @@ use std::{array, marker::PhantomData};
 
 use anyhow::Result;
 use binius_field::{
-	packed::set_packed_slice, BinaryField, ExtensionField, Field, PackedExtension, PackedField,
-	PackedSubfield, TowerField,
+	BinaryField, ExtensionField, Field, PackedExtension, PackedField, PackedSubfield, TowerField,
+	packed::set_packed_slice,
 };
 use itertools::izip;
 
 use crate::{
-	builder::{Col, Expr, TableBuilder, TableWitnessSegment, B1, B128, B32, B64},
+	builder::{B1, B32, B64, B128, Col, Expr, TableBuilder, TableWitnessSegment},
 	gadgets::{
 		add::{Incr, UnsignedAddPrimitives},
 		sub::{U32SubFlags, WideU32Sub},
@@ -108,11 +108,11 @@ struct Mul<UX: UnsignedMulPrimitives, const BIT_LENGTH: usize> {
 }
 
 impl<
-		FExpBase: TowerField,
-		FP: TowerField,
-		UX: UnsignedMulPrimitives<FP = FP, FExpBase = FExpBase>,
-		const BIT_LENGTH: usize,
-	> Mul<UX, BIT_LENGTH>
+	FExpBase: TowerField,
+	FP: TowerField,
+	UX: UnsignedMulPrimitives<FP = FP, FExpBase = FExpBase>,
+	const BIT_LENGTH: usize,
+> Mul<UX, BIT_LENGTH>
 where
 	FExpBase: ExtensionField<FP> + ExtensionField<B1>,
 	B128: ExtensionField<FExpBase> + ExtensionField<FP> + ExtensionField<B1>,

--- a/crates/m3/src/gadgets/structured.rs
+++ b/crates/m3/src/gadgets/structured.rs
@@ -2,7 +2,7 @@
 
 use binius_field::{PackedExtension, PackedField, PackedFieldIndexable, PackedSubfield};
 
-use crate::builder::{column::Col, error::Error, witness::TableWitnessSegment, B128, B32};
+use crate::builder::{B32, B128, column::Col, error::Error, witness::TableWitnessSegment};
 
 /// Fills a structured [`crate::builder::structured::StructuredDynSize::Incrementing`] B32 column
 /// with values.

--- a/crates/m3/src/gadgets/sub.rs
+++ b/crates/m3/src/gadgets/sub.rs
@@ -4,12 +4,12 @@ use std::{array, marker::PhantomData};
 
 use binius_core::oracle::ShiftVariant;
 use binius_field::{
-	packed::set_packed_slice, Field, PackedExtension, PackedField, PackedFieldIndexable,
+	Field, PackedExtension, PackedField, PackedFieldIndexable, packed::set_packed_slice,
 };
 use itertools::izip;
 
 use crate::{
-	builder::{column::Col, types::B1, witness::TableWitnessSegment, TableBuilder, B128},
+	builder::{B128, TableBuilder, column::Col, types::B1, witness::TableWitnessSegment},
 	gadgets::add::UnsignedAddPrimitives,
 };
 
@@ -282,7 +282,7 @@ mod tests {
 		arch::OptimalUnderlier128b, as_packed_field::PackedType, packed::get_packed_slice,
 	};
 	use bumpalo::Bump;
-	use rand::{prelude::StdRng, Rng as _, SeedableRng};
+	use rand::{Rng as _, SeedableRng, prelude::StdRng};
 
 	use super::*;
 	use crate::builder::{ConstraintSystem, Statement, WitnessIndex};

--- a/crates/m3/src/gadgets/sub.rs
+++ b/crates/m3/src/gadgets/sub.rs
@@ -294,8 +294,8 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let test_vector: Vec<(u32, u32, u32, u32, bool)> = (0..N_ITER)
 			.map(|_| {
-				let x: u32 = rng.gen();
-				let y: u32 = rng.gen();
+				let x: u32 = rng.r#gen();
+				let y: u32 = rng.r#gen();
 				let z: u32 = x.wrapping_sub(y);
 				// (x, y, borrow_in, zout, final_borrow)
 				(x, y, 0x00000000, z, false)
@@ -318,9 +318,9 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let test_vector: Vec<(u32, u32, u32, u32, bool)> = (0..N_ITER)
 			.map(|_| {
-				let x: u32 = rng.gen();
-				let y: u32 = rng.gen();
-				let borrow_in = rng.gen::<bool>() as u32;
+				let x: u32 = rng.r#gen();
+				let y: u32 = rng.r#gen();
+				let borrow_in = rng.r#gen::<bool>() as u32;
 				let (x_minus_y, borrow1) = x.overflowing_sub(y);
 				let (z, borrow2) = x_minus_y.overflowing_sub(borrow_in);
 				let final_borrow = borrow1 | borrow2;

--- a/crates/m3/src/gadgets/util.rs
+++ b/crates/m3/src/gadgets/util.rs
@@ -2,9 +2,9 @@
 
 use std::array;
 
-use binius_field::{ext_basis, TowerField};
+use binius_field::{TowerField, ext_basis};
 
-use crate::builder::{upcast_col, Col, Expr, B1};
+use crate::builder::{B1, Col, Expr, upcast_col};
 
 /// Used to pack an array of `Col<B1>` into `Col<FP>` assuming `BIT_LENGTH` is the bit length of
 /// field `FP`

--- a/crates/m3/tests/collatz.rs
+++ b/crates/m3/tests/collatz.rs
@@ -103,13 +103,13 @@ mod arithmetization {
 		oracle::ShiftVariant,
 	};
 	use binius_field::{
-		arch::OptimalUnderlier128b, as_packed_field::PackedType, underlier::SmallU, Field,
-		PackedExtension, PackedField, PackedFieldIndexable, PackedSubfield,
+		Field, PackedExtension, PackedField, PackedFieldIndexable, PackedSubfield,
+		arch::OptimalUnderlier128b, as_packed_field::PackedType, underlier::SmallU,
 	};
 	use binius_m3::{
 		builder::{
-			test_utils::validate_system_witness, Col, ConstraintSystem, TableFiller, TableId,
-			TableWitnessSegment, WitnessIndex, B1, B128, B32,
+			B1, B32, B128, Col, ConstraintSystem, TableFiller, TableId, TableWitnessSegment,
+			WitnessIndex, test_utils::validate_system_witness,
 		},
 		gadgets::add::{U32Add, U32AddFlags},
 	};

--- a/crates/m3/tests/computed.rs
+++ b/crates/m3/tests/computed.rs
@@ -1,12 +1,12 @@
 // Copyright 2025 Irreducible Inc.
 
 use binius_field::{
-	arch::OptimalUnderlier128b, as_packed_field::PackedType, Field, PackedExtension,
-	PackedFieldIndexable,
+	Field, PackedExtension, PackedFieldIndexable, arch::OptimalUnderlier128b,
+	as_packed_field::PackedType,
 };
 use binius_m3::builder::{
-	test_utils::validate_system_witness, Col, ConstraintSystem, TableFiller, TableId,
-	TableWitnessSegment, WitnessIndex, B128,
+	B128, Col, ConstraintSystem, TableFiller, TableId, TableWitnessSegment, WitnessIndex,
+	test_utils::validate_system_witness,
 };
 use bumpalo::Bump;
 

--- a/crates/m3/tests/fibonacci.rs
+++ b/crates/m3/tests/fibonacci.rs
@@ -65,13 +65,14 @@ mod model {
 mod arithmetization {
 	use binius_core::constraint_system::channel::ChannelId;
 	use binius_field::{
-		arch::OptimalUnderlier128b, as_packed_field::PackedType, PackedExtension,
-		PackedFieldIndexable,
+		PackedExtension, PackedFieldIndexable, arch::OptimalUnderlier128b,
+		as_packed_field::PackedType,
 	};
 	use binius_m3::{
 		builder::{
-			test_utils::validate_system_witness, Boundary, Col, ConstraintSystem, FlushDirection,
-			TableBuilder, TableFiller, TableId, TableWitnessSegment, WitnessIndex, B1, B128, B32,
+			B1, B32, B128, Boundary, Col, ConstraintSystem, FlushDirection, TableBuilder,
+			TableFiller, TableId, TableWitnessSegment, WitnessIndex,
+			test_utils::validate_system_witness,
 		},
 		gadgets::add::{U32Add, U32AddFlags},
 	};

--- a/crates/m3/tests/flush_multiple_selectors.rs
+++ b/crates/m3/tests/flush_multiple_selectors.rs
@@ -1,13 +1,13 @@
 // Copyright 2025 Irreducible Inc.
 
 use binius_field::{
-	arch::OptimalUnderlier128b, as_packed_field::PackedType, packed::set_packed_slice, Field,
+	Field, arch::OptimalUnderlier128b, as_packed_field::PackedType, packed::set_packed_slice,
 };
 use binius_m3::{
 	builder::{
-		test_utils::{validate_system_witness, ClosureFiller},
-		Boundary, ConstraintSystem, FlushDirection, FlushOpts, StructuredDynSize, WitnessIndex, B1,
-		B128, B32,
+		B1, B32, B128, Boundary, ConstraintSystem, FlushDirection, FlushOpts, StructuredDynSize,
+		WitnessIndex,
+		test_utils::{ClosureFiller, validate_system_witness},
 	},
 	gadgets::structured::fill_incrementing_b32,
 };

--- a/crates/m3/tests/mul_div_tests.rs
+++ b/crates/m3/tests/mul_div_tests.rs
@@ -94,7 +94,7 @@ impl TableFiller for MulUU64TestTable {
 impl MulDivTestSuiteHelper for MulUU64TestTable {
 	fn generate_inputs(&self, table_size: usize) -> Vec<(B64, B64)> {
 		let mut rng = StdRng::seed_from_u64(0);
-		repeat_with(|| (B64::new(rng.gen::<u64>()), B64::new(rng.gen::<u64>())))
+		repeat_with(|| (B64::new(rng.r#gen::<u64>()), B64::new(rng.r#gen::<u64>())))
 			.take(table_size)
 			.collect::<Vec<_>>()
 	}
@@ -202,7 +202,7 @@ impl MulDivTestSuiteHelper for MulDiv32TestTable {
 		let mut rng = StdRng::seed_from_u64(seed);
 		match self.mul_div {
 			MulDivEnum::MulUU32(_) => {
-				repeat_with(|| (B32::new(rng.gen::<u32>()), B32::new(rng.gen::<u32>())))
+				repeat_with(|| (B32::new(rng.r#gen::<u32>()), B32::new(rng.r#gen::<u32>())))
 					.take(table_size)
 					.collect()
 			}
@@ -216,24 +216,24 @@ impl MulDivTestSuiteHelper for MulDiv32TestTable {
 
 				chain!(
 					EXPLICIT_TESTS.into_iter(),
-					repeat_with(|| (B32::new(rng.gen::<i32>() as u32), B32::new(rng.gen::<u32>())))
+					repeat_with(|| (B32::new(rng.r#gen::<i32>() as u32), B32::new(rng.r#gen::<u32>())))
 				)
 				.take(table_size)
 				.collect()
 			}
 			MulDivEnum::MulSS32(_) => repeat_with(|| {
-				(B32::new(rng.gen::<i32>() as u32), B32::new(rng.gen::<i32>() as u32))
+				(B32::new(rng.r#gen::<i32>() as u32), B32::new(rng.r#gen::<i32>() as u32))
 			})
 			.take(table_size)
 			.collect(),
 			MulDivEnum::DivUU32(_) => {
-				repeat_with(|| (B32::new(rng.gen::<u32>()), B32::new(rng.gen::<u32>())))
+				repeat_with(|| (B32::new(rng.r#gen::<u32>()), B32::new(rng.r#gen::<u32>())))
 					.filter(|(_, y)| y.val() != 0)
 					.take(table_size)
 					.collect()
 			}
 			MulDivEnum::DivSS32(_) => {
-				repeat_with(|| (B32::new(rng.gen::<u32>()), B32::new(rng.gen::<u32>())))
+				repeat_with(|| (B32::new(rng.r#gen::<u32>()), B32::new(rng.r#gen::<u32>())))
 					.filter(|(_, y)| y.val() != 0)
 					.take(table_size)
 					.collect()
@@ -384,8 +384,8 @@ fn test_mul_next_to_stacked_col() {
 
 	let mut rng = StdRng::seed_from_u64(0);
 	let test_inputs = repeat_with(|| {
-		let a = rng.gen::<u32>();
-		let b = rng.gen::<u32>();
+		let a = rng.r#gen::<u32>();
+		let b = rng.r#gen::<u32>();
 		(a, b)
 	})
 	.take(17)

--- a/crates/m3/tests/mul_div_tests.rs
+++ b/crates/m3/tests/mul_div_tests.rs
@@ -9,9 +9,9 @@ use binius_field::{
 };
 use binius_m3::{
 	builder::{
-		test_utils::{validate_system_witness, ClosureFiller},
-		ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment, WitnessIndex, B128,
-		B32, B64,
+		B32, B64, B128, ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment,
+		WitnessIndex,
+		test_utils::{ClosureFiller, validate_system_witness},
 	},
 	gadgets::{
 		div::{DivSS32, DivUU32},
@@ -21,7 +21,7 @@ use binius_m3::{
 use bumpalo::Bump;
 use bytemuck::Contiguous;
 use itertools::chain;
-use rand::{prelude::StdRng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng, prelude::StdRng};
 
 // This needs to create witness data as well as later query for checking outputs.
 trait MulDivTestSuiteHelper
@@ -216,7 +216,10 @@ impl MulDivTestSuiteHelper for MulDiv32TestTable {
 
 				chain!(
 					EXPLICIT_TESTS.into_iter(),
-					repeat_with(|| (B32::new(rng.r#gen::<i32>() as u32), B32::new(rng.r#gen::<u32>())))
+					repeat_with(|| (
+						B32::new(rng.r#gen::<i32>() as u32),
+						B32::new(rng.r#gen::<u32>())
+					))
 				)
 				.take(table_size)
 				.collect()

--- a/crates/macros/src/arith_circuit_poly.rs
+++ b/crates/macros/src/arith_circuit_poly.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use quote::{quote, ToTokens};
-use syn::{bracketed, parse::Parse, parse_quote, spanned::Spanned, Token};
+use quote::{ToTokens, quote};
+use syn::{Token, bracketed, parse::Parse, parse_quote, spanned::Spanned};
 
 #[derive(Debug)]
 pub(crate) struct ArithCircuitPolyItem {

--- a/crates/macros/src/arith_expr.rs
+++ b/crates/macros/src/arith_expr.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use quote::{quote, ToTokens};
-use syn::{bracketed, parse::Parse, parse_quote, spanned::Spanned, Token};
+use quote::{ToTokens, quote};
+use syn::{Token, bracketed, parse::Parse, parse_quote, spanned::Spanned};
 
 #[derive(Debug)]
 pub(crate) struct ArithExprItem(syn::Expr);
@@ -57,8 +57,13 @@ fn rewrite_expr(
 					"1" => parse_quote!(binius_field::Field::ONE),
 					_ => match prefixed_field {
 						Some(field) => parse_quote!(#field::new(#int)),
-						_ => return Err(syn::Error::new(expr.span(), "You need to specify an explicit field to use constants other than 0 or 1"))
-					}
+						_ => {
+							return Err(syn::Error::new(
+								expr.span(),
+								"You need to specify an explicit field to use constants other than 0 or 1",
+							));
+						}
+					},
 				};
 				*expr = parse_quote!(binius_math::ArithExpr::<#field>::Const(#value));
 			}

--- a/crates/macros/src/composition_poly.rs
+++ b/crates/macros/src/composition_poly.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use quote::{quote, ToTokens};
-use syn::{bracketed, parse::Parse, parse_quote, spanned::Spanned, Token};
+use quote::{ToTokens, quote};
+use syn::{Token, bracketed, parse::Parse, parse_quote, spanned::Spanned};
 
 #[derive(Debug)]
 pub(crate) struct CompositionPolyItem {

--- a/crates/macros/src/deserialize_bytes.rs
+++ b/crates/macros/src/deserialize_bytes.rs
@@ -34,10 +34,10 @@ pub fn parse_container_attributes(input: &DeriveInput) -> syn::Result<ContainerA
 /// taking into account container attributes like `eval_generics(X = Y, ...)`.
 ///
 /// This is similar to [`syn::Generics::split_for_impl`].
-pub fn split_for_impl<'gen, 'attr>(
-	generics: &'gen Generics,
+pub fn split_for_impl<'generics, 'attr>(
+	generics: &'generics Generics,
 	container_attributes: &'attr ContainerAttributes,
-) -> GenericsSplit<'gen, 'attr> {
+) -> GenericsSplit<'generics, 'attr> {
 	GenericsSplit::new(generics, &container_attributes.eval_generics)
 }
 

--- a/crates/macros/src/deserialize_bytes/parse.rs
+++ b/crates/macros/src/deserialize_bytes/parse.rs
@@ -1,10 +1,10 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use syn::{
+	Ident, TypePath,
 	parse::Parse,
 	punctuated::Punctuated,
 	token::{Comma, Eq},
-	Ident, TypePath,
 };
 
 /// Container attributes for the `deserialize_bytes` derive macro.

--- a/crates/macros/src/deserialize_bytes/quote.rs
+++ b/crates/macros/src/deserialize_bytes/quote.rs
@@ -11,19 +11,19 @@ use super::parse::GenericBinding;
 /// It is geneally used in the following way: quote! {impl #impl_generics MyStruct #type_generics
 /// #where_clause}
 #[derive(Debug, Clone)]
-pub struct GenericsSplit<'gen, 'attr> {
-	pub impl_generics: ImplGenerics<'gen, 'attr>,
-	pub type_generics: TypeGenerics<'gen, 'attr>,
-	pub where_clause: WhereClause<'gen, 'attr>,
+pub struct GenericsSplit<'generics, 'attr> {
+	pub impl_generics: ImplGenerics<'generics, 'attr>,
+	pub type_generics: TypeGenerics<'generics, 'attr>,
+	pub where_clause: WhereClause<'generics, 'attr>,
 }
 
-impl<'gen, 'attr> GenericsSplit<'gen, 'attr> {
+impl<'generics, 'attr> GenericsSplit<'generics, 'attr> {
 	/// Creates a new instance of [`GenericsSplit`].
 	///
 	/// ## Arguments
 	/// * `generics`: The generics from DeriveInput.
 	/// * `eval_generics`: The generics bindings coming from the `eval_generics` attribute.
-	pub fn new(generics: &'gen Generics, eval_generics: &'attr [GenericBinding]) -> Self {
+	pub fn new(generics: &'generics Generics, eval_generics: &'attr [GenericBinding]) -> Self {
 		Self {
 			impl_generics: ImplGenerics::new(generics, eval_generics),
 			type_generics: TypeGenerics::new(generics, eval_generics),
@@ -33,13 +33,13 @@ impl<'gen, 'attr> GenericsSplit<'gen, 'attr> {
 }
 
 #[derive(Debug, Clone)]
-pub struct ImplGenerics<'gen, 'attr> {
-	generics: &'gen Generics,
+pub struct ImplGenerics<'generics, 'attr> {
+	generics: &'generics Generics,
 	eval_generics: &'attr [GenericBinding],
 }
 
-impl<'gen, 'attr> ImplGenerics<'gen, 'attr> {
-	pub fn new(generics: &'gen Generics, eval_generics: &'attr [GenericBinding]) -> Self {
+impl<'generics, 'attr> ImplGenerics<'generics, 'attr> {
+	pub fn new(generics: &'generics Generics, eval_generics: &'attr [GenericBinding]) -> Self {
 		Self {
 			generics,
 			eval_generics,
@@ -73,13 +73,13 @@ impl ToTokens for ImplGenerics<'_, '_> {
 }
 
 #[derive(Debug, Clone)]
-pub struct TypeGenerics<'gen, 'attr> {
-	generics: &'gen Generics,
+pub struct TypeGenerics<'generics, 'attr> {
+	generics: &'generics Generics,
 	eval_generics: &'attr [GenericBinding],
 }
 
-impl<'gen, 'attr> TypeGenerics<'gen, 'attr> {
-	pub fn new(generics: &'gen Generics, eval_generics: &'attr [GenericBinding]) -> Self {
+impl<'generics, 'attr> TypeGenerics<'generics, 'attr> {
+	pub fn new(generics: &'generics Generics, eval_generics: &'attr [GenericBinding]) -> Self {
 		Self {
 			generics,
 			eval_generics,
@@ -116,13 +116,13 @@ impl ToTokens for TypeGenerics<'_, '_> {
 }
 
 #[derive(Debug, Clone)]
-pub struct WhereClause<'gen, 'attr> {
-	generics: &'gen Generics,
+pub struct WhereClause<'generics, 'attr> {
+	generics: &'generics Generics,
 	eval_generics: &'attr [GenericBinding],
 }
 
-impl<'gen, 'attr> WhereClause<'gen, 'attr> {
-	pub fn new(generics: &'gen Generics, eval_generics: &'attr [GenericBinding]) -> Self {
+impl<'generics, 'attr> WhereClause<'generics, 'attr> {
+	pub fn new(generics: &'generics Generics, eval_generics: &'attr [GenericBinding]) -> Self {
 		Self {
 			generics,
 			eval_generics,

--- a/crates/macros/src/deserialize_bytes/quote.rs
+++ b/crates/macros/src/deserialize_bytes/quote.rs
@@ -2,8 +2,8 @@
 
 use std::collections::{HashMap, HashSet};
 
-use quote::{quote, ToTokens};
-use syn::{punctuated::Punctuated, token::Comma, GenericParam, Generics, Type, WherePredicate};
+use quote::{ToTokens, quote};
+use syn::{GenericParam, Generics, Type, WherePredicate, punctuated::Punctuated, token::Comma};
 
 use super::parse::GenericBinding;
 
@@ -164,7 +164,7 @@ mod tests {
 	use quote::quote;
 	use syn::ItemStruct;
 
-	use crate::deserialize_bytes::{parse::ContainerAttributes, GenericsSplit};
+	use crate::deserialize_bytes::{GenericsSplit, parse::ContainerAttributes};
 
 	#[test]
 	fn test_generics() {

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -6,10 +6,10 @@ mod arith_expr;
 mod composition_poly;
 mod deserialize_bytes;
 
-use deserialize_bytes::{parse_container_attributes, split_for_impl, GenericsSplit};
+use deserialize_bytes::{GenericsSplit, parse_container_attributes, split_for_impl};
 use proc_macro::TokenStream;
-use quote::{quote, ToTokens};
-use syn::{parse_macro_input, parse_quote, spanned::Spanned, Data, DeriveInput, Fields, ItemImpl};
+use quote::{ToTokens, quote};
+use syn::{Data, DeriveInput, Fields, ItemImpl, parse_macro_input, parse_quote, spanned::Spanned};
 
 use crate::{
 	arith_circuit_poly::ArithCircuitPolyItem, arith_expr::ArithExprItem,

--- a/crates/macros/tests/arithmetic_circuit.rs
+++ b/crates/macros/tests/arithmetic_circuit.rs
@@ -4,7 +4,7 @@ use binius_field::*;
 use binius_macros::arith_circuit_poly;
 use binius_math::{CompositionPoly, RowsBatchRef};
 use paste::paste;
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{SeedableRng, rngs::StdRng};
 
 const BATCH_SIZE: usize = 32;
 

--- a/crates/math/benches/fold.rs
+++ b/crates/math/benches/fold.rs
@@ -2,10 +2,10 @@
 
 use std::iter::repeat_with;
 
-use binius_field::{ExtensionField, PackedBinaryField128x1b, PackedBinaryField1x128b, PackedField};
+use binius_field::{ExtensionField, PackedBinaryField1x128b, PackedBinaryField128x1b, PackedField};
 use binius_math::fold_right;
 use criterion::{
-	criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
+	BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::WallTime,
 };
 
 const fn packed_size<P: PackedField>(log_size: usize) -> usize {

--- a/crates/math/benches/tensor_prod_eq_ind.rs
+++ b/crates/math/benches/tensor_prod_eq_ind.rs
@@ -3,11 +3,11 @@
 use std::iter::repeat_with;
 
 use binius_field::{
-	arch::packed_64::PackedBinaryField32x2b, BinaryField128b, PackedBinaryField128x1b, PackedField,
+	BinaryField128b, PackedBinaryField128x1b, PackedField, arch::packed_64::PackedBinaryField32x2b,
 };
 use binius_math::tensor_prod_eq_ind;
 use criterion::{
-	criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
+	BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::WallTime,
 };
 
 pub fn bench_tensor_prod_eq_ind<P: PackedField>(

--- a/crates/math/src/arith_expr.rs
+++ b/crates/math/src/arith_expr.rs
@@ -2,7 +2,7 @@
 
 use std::{
 	cmp::Ordering,
-	collections::{hash_map::Entry, HashMap},
+	collections::{HashMap, hash_map::Entry},
 	fmt::{self, Display},
 	hash::{Hash, Hasher},
 	iter::{Product, Sum},
@@ -1156,7 +1156,7 @@ mod tests {
 	use std::collections::HashSet;
 
 	use assert_matches::assert_matches;
-	use binius_field::{BinaryField, BinaryField128b, BinaryField1b, BinaryField8b};
+	use binius_field::{BinaryField, BinaryField1b, BinaryField8b, BinaryField128b};
 	use binius_utils::{DeserializeBytes, SerializationMode, SerializeBytes};
 
 	use super::*;

--- a/crates/math/src/binary_subspace.rs
+++ b/crates/math/src/binary_subspace.rs
@@ -120,7 +120,7 @@ impl<F: BinaryField> Default for BinarySubspace<F> {
 #[cfg(test)]
 mod tests {
 	use assert_matches::assert_matches;
-	use binius_field::{BinaryField128b, BinaryField8b};
+	use binius_field::{BinaryField8b, BinaryField128b};
 
 	use super::*;
 

--- a/crates/math/src/error.rs
+++ b/crates/math/src/error.rs
@@ -53,12 +53,16 @@ pub enum Error {
 	HypercubeIndexOutOfRange { index: usize },
 	#[error("the output polynomial must have size {expected}")]
 	IncorrectOutputPolynomialSize { expected: usize },
-	#[error("the total number of coefficients, {total_length}, in the piecewise multilinear is too large: {total_length} > 2^{total_n_vars}")]
+	#[error(
+		"the total number of coefficients, {total_length}, in the piecewise multilinear is too large: {total_length} > 2^{total_n_vars}"
+	)]
 	PiecewiseMultilinearTooLong {
 		total_length: usize,
 		total_n_vars: usize,
 	},
-	#[error("there are a total of {actual} polynomials, according to n_pieces_by_vars, while you have provided evaluations for {expected}")]
+	#[error(
+		"there are a total of {actual} polynomials, according to n_pieces_by_vars, while you have provided evaluations for {expected}"
+	)]
 	PiecewiseMultilinearIncompatibleEvals { actual: usize, expected: usize },
 	#[error("cannot fold a constant multilinear")]
 	ConstantFold,

--- a/crates/math/src/fold.rs
+++ b/crates/math/src/fold.rs
@@ -4,18 +4,18 @@ use core::slice;
 use std::{any::TypeId, cmp::min, mem::MaybeUninit};
 
 use binius_field::{
+	AESTowerField128b, BinaryField1b, BinaryField128b, BinaryField128bPolyval, ExtensionField,
+	Field, PackedField,
 	arch::{ArchOptimal, OptimalUnderlier},
 	byte_iteration::{
-		can_iterate_bytes, create_partial_sums_lookup_tables, is_sequential_bytes, iterate_bytes,
-		ByteIteratorCallback,
+		ByteIteratorCallback, can_iterate_bytes, create_partial_sums_lookup_tables,
+		is_sequential_bytes, iterate_bytes,
 	},
 	packed::{
-		get_packed_slice, get_packed_slice_unchecked, set_packed_slice, set_packed_slice_unchecked,
-		PackedSlice,
+		PackedSlice, get_packed_slice, get_packed_slice_unchecked, set_packed_slice,
+		set_packed_slice_unchecked,
 	},
 	underlier::{UnderlierWithBitOps, WithUnderlier},
-	AESTowerField128b, BinaryField128b, BinaryField128bPolyval, BinaryField1b, ExtensionField,
-	Field, PackedField,
 };
 use binius_utils::bail;
 use bytemuck::fill_zeroes;
@@ -954,11 +954,11 @@ mod tests {
 	use std::iter::repeat_with;
 
 	use binius_field::{
-		packed::set_packed_slice, PackedBinaryField128x1b, PackedBinaryField16x32b,
-		PackedBinaryField16x8b, PackedBinaryField32x1b, PackedBinaryField512x1b,
-		PackedBinaryField64x8b, PackedBinaryField8x1b,
+		PackedBinaryField8x1b, PackedBinaryField16x8b, PackedBinaryField16x32b,
+		PackedBinaryField32x1b, PackedBinaryField64x8b, PackedBinaryField128x1b,
+		PackedBinaryField512x1b, packed::set_packed_slice,
 	};
-	use rand::{rngs::StdRng, SeedableRng};
+	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 

--- a/crates/math/src/matrix.rs
+++ b/crates/math/src/matrix.rs
@@ -262,7 +262,7 @@ impl<F: Field> SubAssign<&Self> for Matrix<F> {
 mod tests {
 	use binius_field::BinaryField32b;
 	use proptest::prelude::*;
-	use rand::{rngs::StdRng, SeedableRng};
+	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 

--- a/crates/math/src/mle_adapters.rs
+++ b/crates/math/src/mle_adapters.rs
@@ -3,10 +3,10 @@
 use std::{fmt::Debug, marker::PhantomData, ops::Deref, sync::Arc};
 
 use binius_field::{
+	ExtensionField, Field, PackedField, RepackedExtension,
 	packed::{
 		get_packed_slice, get_packed_slice_unchecked, set_packed_slice, set_packed_slice_unchecked,
 	},
-	ExtensionField, Field, PackedField, RepackedExtension,
 };
 use binius_utils::bail;
 
@@ -612,15 +612,15 @@ mod tests {
 	use std::iter::repeat_with;
 
 	use binius_field::{
-		arch::OptimalUnderlier256b, as_packed_field::PackedType, BinaryField128b, BinaryField16b,
-		BinaryField32b, BinaryField8b, PackedBinaryField16x8b, PackedBinaryField1x128b,
-		PackedBinaryField4x128b, PackedBinaryField4x32b, PackedBinaryField64x8b,
-		PackedBinaryField8x16b, PackedExtension, PackedField, PackedFieldIndexable,
+		BinaryField8b, BinaryField16b, BinaryField32b, BinaryField128b, PackedBinaryField1x128b,
+		PackedBinaryField4x32b, PackedBinaryField4x128b, PackedBinaryField8x16b,
+		PackedBinaryField16x8b, PackedBinaryField64x8b, PackedExtension, PackedField,
+		PackedFieldIndexable, arch::OptimalUnderlier256b, as_packed_field::PackedType,
 	};
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::{tensor_prod_eq_ind, MultilinearQuery};
+	use crate::{MultilinearQuery, tensor_prod_eq_ind};
 
 	type F = BinaryField16b;
 	type P = PackedBinaryField8x16b;

--- a/crates/math/src/multilinear_extension.rs
+++ b/crates/math/src/multilinear_extension.rs
@@ -3,17 +3,17 @@
 use std::{fmt::Debug, ops::Deref};
 
 use binius_field::{
+	ExtensionField, Field, PackedField,
 	as_packed_field::{AsSinglePacked, PackScalar, PackedType},
 	underlier::UnderlierType,
 	util::inner_product_par,
-	ExtensionField, Field, PackedField,
 };
 use binius_utils::bail;
 use bytemuck::zeroed_vec;
 use tracing::instrument;
 
 use crate::{
-	fold::fold_left, fold_middle, fold_right, zero_pad, Error, MultilinearQueryRef, PackingDeref,
+	Error, MultilinearQueryRef, PackingDeref, fold::fold_left, fold_middle, fold_right, zero_pad,
 };
 
 /// A multilinear polynomial represented by its evaluations over the boolean hypercube.
@@ -387,16 +387,16 @@ mod tests {
 	use std::iter::repeat_with;
 
 	use binius_field::{
-		arch::OptimalUnderlier256b, BinaryField128b, BinaryField16b as F, BinaryField1b,
-		BinaryField32b, BinaryField8b, PackedBinaryField16x1b, PackedBinaryField16x8b,
-		PackedBinaryField32x1b, PackedBinaryField4x32b, PackedBinaryField8x16b as P,
-		PackedBinaryField8x1b,
+		BinaryField1b, BinaryField8b, BinaryField16b as F, BinaryField32b, BinaryField128b,
+		PackedBinaryField4x32b, PackedBinaryField8x1b, PackedBinaryField8x16b as P,
+		PackedBinaryField16x1b, PackedBinaryField16x8b, PackedBinaryField32x1b,
+		arch::OptimalUnderlier256b,
 	};
 	use itertools::Itertools;
-	use rand::{rngs::StdRng, SeedableRng};
+	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
-	use crate::{tensor_prod_eq_ind, MultilinearQuery};
+	use crate::{MultilinearQuery, tensor_prod_eq_ind};
 
 	/// Expand the tensor product of the query values.
 	///

--- a/crates/math/src/multilinear_extension.rs
+++ b/crates/math/src/multilinear_extension.rs
@@ -513,16 +513,14 @@ mod tests {
 		P: PackedField,
 		PE: PackedField<Scalar: ExtensionField<P::Scalar>>,
 	{
-		let new_vals = values
+		values
 			.iter()
 			.flat_map(|v| {
 				(P::WIDTH * start_index..P::WIDTH * (start_index + 1))
 					.map(|i| v.get(i))
 					.collect::<Vec<_>>()
 			})
-			.collect::<Vec<_>>();
-
-		new_vals
+			.collect::<Vec<_>>()
 	}
 
 	#[test]

--- a/crates/math/src/multilinear_query.rs
+++ b/crates/math/src/multilinear_query.rs
@@ -6,7 +6,7 @@ use binius_field::{Field, PackedField};
 use binius_utils::bail;
 use bytemuck::zeroed_vec;
 
-use crate::{eq_ind_partial_eval, tensor_prod_eq_ind, Error};
+use crate::{Error, eq_ind_partial_eval, tensor_prod_eq_ind};
 
 /// Tensor product expansion of sumcheck round challenges.
 ///

--- a/crates/math/src/packing_deref.rs
+++ b/crates/math/src/packing_deref.rs
@@ -3,9 +3,9 @@
 use std::{marker::PhantomData, ops::Deref};
 
 use binius_field::{
+	Field,
 	as_packed_field::{PackScalar, PackedType},
 	underlier::{UnderlierType, WithUnderlier},
-	Field,
 };
 
 /// A wrapper for containers of underlier types that dereferences as packed field slices.

--- a/crates/math/src/piecewise_multilinear.rs
+++ b/crates/math/src/piecewise_multilinear.rs
@@ -3,7 +3,7 @@
 use binius_field::Field;
 use tracing::instrument;
 
-use crate::{extrapolate_line_scalar, Error};
+use crate::{Error, extrapolate_line_scalar};
 
 /// Evaluate a piecewise multilinear polynomial at a point, given the evaluations of the pieces.
 ///
@@ -122,7 +122,7 @@ mod tests {
 
 	use binius_field::BinaryField32b;
 	use binius_utils::checked_arithmetics::{log2_ceil_usize, log2_strict_usize};
-	use rand::{prelude::StdRng, SeedableRng};
+	use rand::{SeedableRng, prelude::StdRng};
 
 	use super::*;
 	use crate::{MultilinearExtension, MultilinearQuery};

--- a/crates/math/src/tensor_prod_eq_ind.rs
+++ b/crates/math/src/tensor_prod_eq_ind.rs
@@ -102,7 +102,7 @@ pub fn eq_ind_partial_eval<P: PackedField>(point: &[P::Scalar]) -> Vec<P> {
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{packed::set_packed_slice, Field, PackedBinaryField4x32b};
+	use binius_field::{Field, PackedBinaryField4x32b, packed::set_packed_slice};
 	use itertools::Itertools;
 
 	use super::*;

--- a/crates/math/src/univariate.rs
+++ b/crates/math/src/univariate.rs
@@ -3,11 +3,11 @@
 
 use auto_impl::auto_impl;
 use binius_field::{
-	packed::mul_by_subfield_scalar, BinaryField, ExtensionField, Field, PackedExtension,
-	PackedField,
+	BinaryField, ExtensionField, Field, PackedExtension, PackedField,
+	packed::mul_by_subfield_scalar,
 };
 use binius_utils::bail;
-use itertools::{izip, Either};
+use itertools::{Either, izip};
 
 use super::{binary_subspace::BinarySubspace, error::Error};
 use crate::Matrix;
@@ -308,11 +308,11 @@ mod tests {
 
 	use assert_matches::assert_matches;
 	use binius_field::{
-		util::inner_product_unchecked, AESTowerField32b, BinaryField32b, BinaryField8b,
+		AESTowerField32b, BinaryField8b, BinaryField32b, util::inner_product_unchecked,
 	};
 	use itertools::assert_equal;
 	use proptest::{collection::vec, proptest};
-	use rand::{rngs::StdRng, SeedableRng};
+	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 

--- a/crates/maybe_rayon/src/iter/indexed_parallel_iterator.rs
+++ b/crates/maybe_rayon/src/iter/indexed_parallel_iterator.rs
@@ -2,8 +2,8 @@
 // The code is initially based on `maybe-rayon` crate, https://github.com/shssoichiro/maybe-rayon
 
 use super::{
-	parallel_iterator::ParallelIteratorInner, parallel_wrapper::ParallelWrapper,
-	IntoParallelIterator, ParallelIterator,
+	IntoParallelIterator, ParallelIterator, parallel_iterator::ParallelIteratorInner,
+	parallel_wrapper::ParallelWrapper,
 };
 
 /// The reason why we need this trait is because `IndexedParallelIterator` contains
@@ -90,11 +90,7 @@ impl<I: Iterator> Iterator for Chunks<I> {
 				None => break,
 			}
 		}
-		if chunk.is_empty() {
-			None
-		} else {
-			Some(chunk)
-		}
+		if chunk.is_empty() { None } else { Some(chunk) }
 	}
 }
 

--- a/crates/maybe_rayon/src/iter/parallel_iterator.rs
+++ b/crates/maybe_rayon/src/iter/parallel_iterator.rs
@@ -11,7 +11,7 @@ use std::{
 use either::Either;
 
 use self::private::Try;
-use super::{parallel_wrapper::ParallelWrapper, FromParallelIterator, IntoParallelIterator};
+use super::{FromParallelIterator, IntoParallelIterator, parallel_wrapper::ParallelWrapper};
 
 /// `rayon::prelude::ParallelIterator` has at least `fold` method with a signature
 /// that is not compatible with the one in `std::iter::Iterator`. That's why we can't use

--- a/crates/ntt/benches/additive_ntt.rs
+++ b/crates/ntt/benches/additive_ntt.rs
@@ -3,14 +3,14 @@
 use std::{iter::repeat_with, mem};
 
 use binius_field::{
+	BinaryField, PackedBinaryField4x32b, PackedBinaryField8x16b, PackedBinaryField8x32b,
+	PackedBinaryField16x16b, PackedField,
 	arch::byte_sliced::{ByteSlicedAES32x16b, ByteSlicedAES32x32b},
-	BinaryField, PackedBinaryField16x16b, PackedBinaryField4x32b, PackedBinaryField8x16b,
-	PackedBinaryField8x32b, PackedField,
 };
 use binius_ntt::{AdditiveNTT, NTTShape, SingleThreadedNTT};
 use criterion::{
-	criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId, Criterion,
-	Throughput,
+	BenchmarkGroup, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
+	measurement::WallTime,
 };
 use rand::thread_rng;
 

--- a/crates/ntt/benches/large_transform.rs
+++ b/crates/ntt/benches/large_transform.rs
@@ -3,13 +3,13 @@
 use std::iter::repeat_with;
 
 use binius_field::{
+	AESTowerField32b, AESTowerField128b, BinaryField32b, BinaryField128b, BinaryField128bPolyval,
+	PackedExtension, TowerField,
 	arch::{OptimalUnderlier, OptimalUnderlierByteSliced},
 	as_packed_field::PackedType,
-	AESTowerField128b, AESTowerField32b, BinaryField128b, BinaryField128bPolyval, BinaryField32b,
-	PackedExtension, TowerField,
 };
 use binius_ntt::{AdditiveNTT, NTTShape, SingleThreadedNTT};
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use rand::thread_rng;
 
 fn bench_large_transform<F: TowerField, PE: PackedExtension<F>>(c: &mut Criterion, field: &str) {

--- a/crates/ntt/src/multithreaded.rs
+++ b/crates/ntt/src/multithreaded.rs
@@ -8,7 +8,7 @@ use binius_utils::rayon::get_log_max_threads;
 use super::{
 	additive_ntt::{AdditiveNTT, NTTShape},
 	error::Error,
-	single_threaded::{self, check_batch_transform_inputs_and_params, SingleThreadedNTT},
+	single_threaded::{self, SingleThreadedNTT, check_batch_transform_inputs_and_params},
 	strided_array::StridedArray2DViewMut,
 	twiddle::TwiddleAccess,
 };

--- a/crates/ntt/src/odd_interpolate.rs
+++ b/crates/ntt/src/odd_interpolate.rs
@@ -153,7 +153,7 @@ mod tests {
 	use std::iter::repeat_with;
 
 	use binius_field::{BinaryField32b, Field};
-	use rand::{rngs::StdRng, SeedableRng};
+	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 	use crate::single_threaded::SingleThreadedNTT;

--- a/crates/ntt/src/single_threaded.rs
+++ b/crates/ntt/src/single_threaded.rs
@@ -10,7 +10,7 @@ use super::{
 	error::Error,
 	twiddle::TwiddleAccess,
 };
-use crate::twiddle::{expand_subspace_evals, OnTheFlyTwiddleAccess, PrecomputedTwiddleAccess};
+use crate::twiddle::{OnTheFlyTwiddleAccess, PrecomputedTwiddleAccess, expand_subspace_evals};
 
 /// Implementation of `AdditiveNTT` that performs the computation single-threaded.
 #[derive(Debug)]
@@ -411,10 +411,10 @@ where
 mod tests {
 	use assert_matches::assert_matches;
 	use binius_field::{
-		BinaryField16b, BinaryField8b, PackedBinaryField8x16b, PackedFieldIndexable,
+		BinaryField8b, BinaryField16b, PackedBinaryField8x16b, PackedFieldIndexable,
 	};
 	use binius_math::Error as MathError;
-	use rand::{rngs::StdRng, SeedableRng};
+	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 

--- a/crates/ntt/src/strided_array.rs
+++ b/crates/ntt/src/strided_array.rs
@@ -45,8 +45,10 @@ impl<'a, T> StridedArray2DViewMut<'a, T> {
 	pub unsafe fn get_unchecked_ref(&self, i: usize, j: usize) -> &T {
 		debug_assert!(i < self.height);
 		debug_assert!(j < self.width());
-		self.data
-			.get_unchecked(i * self.data_width + j + self.cols.start)
+		unsafe {
+			self.data
+				.get_unchecked(i * self.data_width + j + self.cols.start)
+		}
 	}
 
 	/// Returns a mutable reference to the data at the given indices without bounds checking.
@@ -55,8 +57,10 @@ impl<'a, T> StridedArray2DViewMut<'a, T> {
 	pub unsafe fn get_unchecked_mut(&mut self, i: usize, j: usize) -> &mut T {
 		debug_assert!(i < self.height);
 		debug_assert!(j < self.width());
-		self.data
-			.get_unchecked_mut(i * self.data_width + j + self.cols.start)
+		unsafe {
+			self.data
+				.get_unchecked_mut(i * self.data_width + j + self.cols.start)
+		}
 	}
 
 	pub const fn height(&self) -> usize {

--- a/crates/ntt/src/tests/ntt_tests.rs
+++ b/crates/ntt/src/tests/ntt_tests.rs
@@ -3,20 +3,20 @@
 use std::ops::Range;
 
 use binius_field::{
+	AESTowerField8b, BinaryField, BinaryField8b, ByteSlicedAES8x16x16b, ByteSlicedAES16x32x8b,
+	PackedBinaryField8x32b, PackedBinaryField16x32b, PackedBinaryField32x16b, PackedExtension,
+	PackedField, RepackedExtension,
 	arch::{
+		packed_8::PackedBinaryField1x8b,
 		packed_16::{PackedBinaryField1x16b, PackedBinaryField2x8b},
 		packed_32::PackedBinaryField2x16b,
 		packed_64::{PackedBinaryField2x32b, PackedBinaryField4x16b},
-		packed_8::PackedBinaryField1x8b,
 	},
 	underlier::{NumCast, WithUnderlier},
-	AESTowerField8b, BinaryField, BinaryField8b, ByteSlicedAES16x32x8b, ByteSlicedAES8x16x16b,
-	PackedBinaryField16x32b, PackedBinaryField32x16b, PackedBinaryField8x32b, PackedExtension,
-	PackedField, RepackedExtension,
 };
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{SeedableRng, rngs::StdRng};
 
-use crate::{dynamic_dispatch::DynamicDispatchNTT, AdditiveNTT, NTTShape, SingleThreadedNTT};
+use crate::{AdditiveNTT, NTTShape, SingleThreadedNTT, dynamic_dispatch::DynamicDispatchNTT};
 
 /// Check that forward and inverse transformation of `ntt` on `data` is the same as forward and
 /// inverse transformation of `reference_ntt` on `data` and that the result of the roundtrip is the

--- a/crates/ntt/src/tests/reference.rs
+++ b/crates/ntt/src/tests/reference.rs
@@ -36,7 +36,12 @@ where
 	P: PackedField,
 {
 	unsafe fn get_unchecked(&self, index: usize) -> P::Scalar {
-		get_packed_slice_unchecked(self.data, self.batch_index + (index << self.log_batch_count))
+		unsafe {
+			get_packed_slice_unchecked(
+				self.data,
+				self.batch_index + (index << self.log_batch_count),
+			)
+		}
 	}
 
 	fn len(&self) -> usize {
@@ -49,11 +54,13 @@ where
 	P: PackedField,
 {
 	unsafe fn set_unchecked(&mut self, index: usize, value: P::Scalar) {
-		set_packed_slice_unchecked(
-			self.data,
-			self.batch_index + (index << self.log_batch_count),
-			value,
-		);
+		unsafe {
+			set_packed_slice_unchecked(
+				self.data,
+				self.batch_index + (index << self.log_batch_count),
+				value,
+			);
+		}
 	}
 }
 

--- a/crates/ntt/src/tests/reference.rs
+++ b/crates/ntt/src/tests/reference.rs
@@ -3,13 +3,13 @@
 use std::marker::PhantomData;
 
 use binius_field::{
-	packed::{get_packed_slice_unchecked, set_packed_slice_unchecked},
 	BinaryField, ExtensionField, PackedField,
+	packed::{get_packed_slice_unchecked, set_packed_slice_unchecked},
 };
 use binius_math::BinarySubspace;
 use binius_utils::random_access_sequence::{RandomAccessSequence, RandomAccessSequenceMut};
 
-use crate::{twiddle::TwiddleAccess, AdditiveNTT, Error, NTTShape, SingleThreadedNTT};
+use crate::{AdditiveNTT, Error, NTTShape, SingleThreadedNTT, twiddle::TwiddleAccess};
 
 /// A slice of packed field elements with an access to a batch with the given index:
 /// [batch_0_element_0, batch_1_element_0, ..., batch_0_element_1, batch_0_element_1, ...]

--- a/crates/ntt/src/twiddle.rs
+++ b/crates/ntt/src/twiddle.rs
@@ -354,7 +354,7 @@ where
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{BinaryField, BinaryField16b, BinaryField32b, BinaryField8b};
+	use binius_field::{BinaryField, BinaryField8b, BinaryField16b, BinaryField32b};
 	use binius_math::BinarySubspace;
 	use lazy_static::lazy_static;
 	use proptest::prelude::*;

--- a/crates/utils/src/array_2d.rs
+++ b/crates/utils/src/array_2d.rs
@@ -2,7 +2,7 @@
 
 use std::ops::{AddAssign, Deref, DerefMut, Index, IndexMut};
 
-use bytemuck::{allocation::zeroed_vec, Zeroable};
+use bytemuck::{Zeroable, allocation::zeroed_vec};
 
 /// 2D array with row-major layout.
 #[derive(Debug)]

--- a/crates/utils/src/array_2d.rs
+++ b/crates/utils/src/array_2d.rs
@@ -62,7 +62,7 @@ impl<T, Data: Deref<Target = [T]>> Array2D<T, Data> {
 	/// The caller must ensure that `i` and `j` are less than the number of rows and columns
 	/// respectively.
 	pub unsafe fn get_unchecked(&self, i: usize, j: usize) -> &T {
-		self.data.get_unchecked(i * self.cols + j)
+		unsafe { self.data.get_unchecked(i * self.cols + j) }
 	}
 
 	/// View of the array in a different shape, underlying elements stay the same.
@@ -91,7 +91,7 @@ impl<T, Data: DerefMut<Target = [T]>> Array2D<T, Data> {
 	/// The caller must ensure that `i` and `j` are less than the number of rows and columns
 	/// respectively.
 	pub unsafe fn get_unchecked_mut(&mut self, i: usize, j: usize) -> &mut T {
-		self.data.get_unchecked_mut(i * self.cols + j)
+		unsafe { self.data.get_unchecked_mut(i * self.cols + j) }
 	}
 
 	/// Mutable view of the array in a different shape, underlying elements stay the same.

--- a/crates/utils/src/random_access_sequence.rs
+++ b/crates/utils/src/random_access_sequence.rs
@@ -52,7 +52,7 @@ impl<T: Copy> RandomAccessSequence<T> for &[T] {
 
 	#[inline(always)]
 	unsafe fn get_unchecked(&self, index: usize) -> T {
-		*<[T]>::get_unchecked(self, index)
+		unsafe { *<[T]>::get_unchecked(self, index) }
 	}
 }
 
@@ -69,7 +69,7 @@ impl<T: Copy> RandomAccessSequence<T> for &mut [T] {
 
 	#[inline(always)]
 	unsafe fn get_unchecked(&self, index: usize) -> T {
-		*<[T]>::get_unchecked(self, index)
+		unsafe { *<[T]>::get_unchecked(self, index) }
 	}
 }
 
@@ -81,7 +81,9 @@ impl<T: Copy> RandomAccessSequenceMut<T> for &mut [T] {
 
 	#[inline(always)]
 	unsafe fn set_unchecked(&mut self, index: usize, value: T) {
-		*<[T]>::get_unchecked_mut(self, index) = value;
+		unsafe {
+			*<[T]>::get_unchecked_mut(self, index) = value;
+		}
 	}
 }
 
@@ -118,7 +120,7 @@ impl<T: Copy, Inner: RandomAccessSequence<T>> RandomAccessSequence<T>
 
 	#[inline(always)]
 	unsafe fn get_unchecked(&self, index: usize) -> T {
-		self.inner.get_unchecked(index + self.offset)
+		unsafe { self.inner.get_unchecked(index + self.offset) }
 	}
 }
 
@@ -153,7 +155,7 @@ impl<T: Copy, Inner: RandomAccessSequenceMut<T>> RandomAccessSequence<T>
 
 	#[inline(always)]
 	unsafe fn get_unchecked(&self, index: usize) -> T {
-		self.inner.get_unchecked(index + self.offset)
+		unsafe { self.inner.get_unchecked(index + self.offset) }
 	}
 }
 impl<T: Copy, Inner: RandomAccessSequenceMut<T>> RandomAccessSequenceMut<T>
@@ -161,7 +163,9 @@ impl<T: Copy, Inner: RandomAccessSequenceMut<T>> RandomAccessSequenceMut<T>
 {
 	#[inline(always)]
 	unsafe fn set_unchecked(&mut self, index: usize, value: T) {
-		self.inner.set_unchecked(index + self.offset, value);
+		unsafe {
+			self.inner.set_unchecked(index + self.offset, value);
+		}
 	}
 }
 

--- a/crates/utils/src/random_access_sequence.rs
+++ b/crates/utils/src/random_access_sequence.rs
@@ -187,10 +187,10 @@ mod tests {
 
 	fn check_collection_get_set<T: Eq + Copy + Debug>(
 		collection: &mut impl RandomAccessSequenceMut<T>,
-		gen: &mut impl FnMut() -> T,
+		r#gen: &mut impl FnMut() -> T,
 	) {
 		for i in 0..collection.len() {
-			let value = gen();
+			let value = r#gen();
 			collection.set(i, value);
 			assert_eq!(collection.get(i), value);
 			assert_eq!(unsafe { collection.get_unchecked(i) }, value);
@@ -209,16 +209,16 @@ mod tests {
 	#[test]
 	fn check_slice_mut() {
 		let mut rng = StdRng::seed_from_u64(0);
-		let mut gen = || -> usize { rng.gen() };
+		let mut r#gen = || -> usize { rng.r#gen() };
 
 		let mut slice: &mut [usize] = &mut [];
 
 		check_collection(&slice, slice);
-		check_collection_get_set(&mut slice, &mut gen);
+		check_collection_get_set(&mut slice, &mut r#gen);
 
 		let mut slice: &mut [usize] = &mut [1, 2, 3];
 		check_collection(&slice, slice);
-		check_collection_get_set(&mut slice, &mut gen);
+		check_collection_get_set(&mut slice, &mut r#gen);
 	}
 
 	#[test]
@@ -231,12 +231,12 @@ mod tests {
 	#[test]
 	fn test_subrange_mut() {
 		let mut rng = StdRng::seed_from_u64(0);
-		let mut gen = || -> usize { rng.gen() };
+		let mut r#gen = || -> usize { rng.r#gen() };
 
 		let mut slice: &mut [usize] = &mut [1, 2, 3, 4, 5];
 		let values = slice[1..4].to_vec();
 		let mut subrange = SequenceSubrangeMut::new(&mut slice, 1, 3);
 		check_collection(&subrange, &values);
-		check_collection_get_set(&mut subrange, &mut gen);
+		check_collection_get_set(&mut subrange, &mut r#gen);
 	}
 }

--- a/crates/utils/src/random_access_sequence.rs
+++ b/crates/utils/src/random_access_sequence.rs
@@ -169,7 +169,7 @@ impl<T: Copy, Inner: RandomAccessSequenceMut<T>> RandomAccessSequenceMut<T>
 mod tests {
 	use std::fmt::Debug;
 
-	use rand::{rngs::StdRng, Rng, SeedableRng};
+	use rand::{Rng, SeedableRng, rngs::StdRng};
 
 	use super::*;
 

--- a/crates/utils/src/serialization.rs
+++ b/crates/utils/src/serialization.rs
@@ -432,7 +432,7 @@ fn assert_enough_data_for(read_buf: &impl Buf, size: usize) -> Result<(), Serial
 #[cfg(test)]
 mod tests {
 	use generic_array::typenum::U32;
-	use rand::{rngs::StdRng, RngCore, SeedableRng};
+	use rand::{RngCore, SeedableRng, rngs::StdRng};
 
 	use super::*;
 

--- a/examples/b32_mul.rs
+++ b/examples/b32_mul.rs
@@ -1,15 +1,15 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use anyhow::Result;
-use binius_circuits::builder::{types::U, ConstraintSystemBuilder};
+use binius_circuits::builder::{ConstraintSystemBuilder, types::U};
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger};
-use binius_field::{tower::CanonicalTowerFamily, BinaryField32b, TowerField};
+use binius_field::{BinaryField32b, TowerField, tower::CanonicalTowerFamily};
 use binius_hal::make_portable_backend;
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_macros::arith_expr;
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
 use bytesize::ByteSize;
-use clap::{value_parser, Parser};
+use clap::{Parser, value_parser};
 use itertools::izip;
 use tracing_profile::init_tracing;
 

--- a/examples/bitwise_ops.rs
+++ b/examples/bitwise_ops.rs
@@ -3,14 +3,14 @@
 use std::{fmt::Display, str::FromStr};
 
 use anyhow::Result;
-use binius_circuits::builder::{types::U, ConstraintSystemBuilder};
+use binius_circuits::builder::{ConstraintSystemBuilder, types::U};
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger};
-use binius_field::{tower::CanonicalTowerFamily, BinaryField1b, BinaryField32b, TowerField};
+use binius_field::{BinaryField1b, BinaryField32b, TowerField, tower::CanonicalTowerFamily};
 use binius_hal::make_portable_backend;
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
 use bytesize::ByteSize;
-use clap::{value_parser, Parser};
+use clap::{Parser, value_parser};
 use tracing_profile::init_tracing;
 
 #[derive(Debug, Clone, Copy)]

--- a/examples/blake3_circuit.rs
+++ b/examples/blake3_circuit.rs
@@ -5,7 +5,7 @@ use std::array;
 use anyhow::Result;
 use binius_circuits::{
 	blake3::Blake3CompressState,
-	builder::{types::U, ConstraintSystemBuilder},
+	builder::{ConstraintSystemBuilder, types::U},
 };
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger};
 use binius_field::tower::CanonicalTowerFamily;
@@ -13,8 +13,8 @@ use binius_hal::make_portable_backend;
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_utils::rayon::adjust_thread_pool;
 use bytesize::ByteSize;
-use clap::{value_parser, Parser};
-use rand::{rngs::OsRng, Rng};
+use clap::{Parser, value_parser};
+use rand::{Rng, rngs::OsRng};
 use tracing_profile::init_tracing;
 
 #[derive(Debug, Parser)]

--- a/examples/blake3_circuit.rs
+++ b/examples/blake3_circuit.rs
@@ -48,13 +48,13 @@ fn main() -> Result<()> {
 	let mut rng = OsRng;
 	let input_witness = (0..args.n_compressions as usize)
 		.map(|_| {
-			let cv: [u32; 8] = array::from_fn(|_| rng.gen::<u32>());
-			let block: [u32; 16] = array::from_fn(|_| rng.gen::<u32>());
-			let counter = rng.gen::<u64>();
+			let cv: [u32; 8] = array::from_fn(|_| rng.r#gen::<u32>());
+			let block: [u32; 16] = array::from_fn(|_| rng.r#gen::<u32>());
+			let counter = rng.r#gen::<u64>();
 			let counter_low = counter as u32;
 			let counter_high = (counter >> 32) as u32;
-			let block_len = rng.gen::<u32>();
-			let flags = rng.gen::<u32>();
+			let block_len = rng.r#gen::<u32>();
+			let flags = rng.r#gen::<u32>();
 
 			Blake3CompressState {
 				cv,

--- a/examples/collatz.rs
+++ b/examples/collatz.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use binius_circuits::{
-	builder::{types::U, ConstraintSystemBuilder},
+	builder::{ConstraintSystemBuilder, types::U},
 	collatz::{Advice, Collatz},
 };
 use binius_core::{
@@ -13,7 +13,7 @@ use binius_field::tower::CanonicalTowerFamily;
 use binius_hal::make_portable_backend;
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_utils::rayon::adjust_thread_pool;
-use clap::{value_parser, Parser};
+use clap::{Parser, value_parser};
 use tracing_profile::init_tracing;
 
 #[derive(Debug, Parser)]

--- a/examples/groestl.rs
+++ b/examples/groestl.rs
@@ -6,23 +6,23 @@ use anyhow::Result;
 use binius_circuits::builder::types::U;
 use binius_core::fiat_shamir::HasherChallenger;
 use binius_field::{
+	Field, PackedExtension, PackedFieldIndexable, PackedSubfield,
 	arch::{OptimalUnderlier, OptimalUnderlier128b},
 	as_packed_field::PackedType,
 	linear_transformation::PackedTransformationFactory,
 	tower::CanonicalTowerFamily,
-	Field, PackedExtension, PackedFieldIndexable, PackedSubfield,
 };
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_m3::{
 	builder::{
-		ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment, WitnessIndex, B1,
-		B128, B8,
+		B1, B8, B128, ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment,
+		WitnessIndex,
 	},
 	gadgets::hash::groestl,
 };
 use binius_utils::rayon::adjust_thread_pool;
 use bytesize::ByteSize;
-use clap::{value_parser, Parser};
+use clap::{Parser, value_parser};
 use rand::thread_rng;
 use tracing_profile::init_tracing;
 

--- a/examples/keccak.rs
+++ b/examples/keccak.rs
@@ -6,22 +6,22 @@ use anyhow::Result;
 use binius_circuits::builder::types::U;
 use binius_core::fiat_shamir::HasherChallenger;
 use binius_field::{
-	arch::OptimalUnderlier, as_packed_field::PackedType,
-	linear_transformation::PackedTransformationFactory, tower::CanonicalTowerFamily,
-	PackedExtension, PackedFieldIndexable, PackedSubfield,
+	PackedExtension, PackedFieldIndexable, PackedSubfield, arch::OptimalUnderlier,
+	as_packed_field::PackedType, linear_transformation::PackedTransformationFactory,
+	tower::CanonicalTowerFamily,
 };
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_m3::{
 	builder::{
-		ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment, WitnessIndex, B1,
-		B128, B64, B8,
+		B1, B8, B64, B128, ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment,
+		WitnessIndex,
 	},
 	gadgets::hash::keccak::{self, Keccakf, StateMatrix},
 };
 use binius_utils::rayon::adjust_thread_pool;
 use bytesize::ByteSize;
-use clap::{value_parser, Parser};
-use rand::{thread_rng, RngCore};
+use clap::{Parser, value_parser};
+use rand::{RngCore, thread_rng};
 use tracing_profile::init_tracing;
 
 #[derive(Debug, Parser)]

--- a/examples/modular_mul.rs
+++ b/examples/modular_mul.rs
@@ -5,21 +5,21 @@ use std::array;
 use alloy_primitives::U512;
 use anyhow::Result;
 use binius_circuits::{
-	builder::{types::U, ConstraintSystemBuilder},
+	builder::{ConstraintSystemBuilder, types::U},
 	lasso::big_integer_ops::{byte_sliced_modular_mul, byte_sliced_test_utils::random_u512},
 	transparent,
 };
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger};
 use binius_field::{
+	BinaryField1b, BinaryField8b, Field, TowerField,
 	tower::CanonicalTowerFamily,
 	tower_levels::{TowerLevel4, TowerLevel8},
-	BinaryField1b, BinaryField8b, Field, TowerField,
 };
 use binius_hal::make_portable_backend;
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
 use bytesize::ByteSize;
-use clap::{value_parser, Parser};
+use clap::{Parser, value_parser};
 use rand::thread_rng;
 use tracing_profile::init_tracing;
 

--- a/examples/sha256_circuit.rs
+++ b/examples/sha256_circuit.rs
@@ -2,16 +2,16 @@
 
 use anyhow::Result;
 use binius_circuits::{
-	builder::{types::U, ConstraintSystemBuilder},
+	builder::{ConstraintSystemBuilder, types::U},
 	unconstrained::unconstrained,
 };
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger, oracle::OracleId};
-use binius_field::{tower::CanonicalTowerFamily, BinaryField1b};
+use binius_field::{BinaryField1b, tower::CanonicalTowerFamily};
 use binius_hal::make_portable_backend;
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
 use bytesize::ByteSize;
-use clap::{value_parser, Parser};
+use clap::{Parser, value_parser};
 use tracing_profile::init_tracing;
 
 #[derive(Debug, Parser)]

--- a/examples/sha256_circuit_with_lookup.rs
+++ b/examples/sha256_circuit_with_lookup.rs
@@ -2,18 +2,18 @@
 
 use anyhow::Result;
 use binius_circuits::{
-	builder::{types::U, ConstraintSystemBuilder},
+	builder::{ConstraintSystemBuilder, types::U},
 	unconstrained::unconstrained,
 };
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger, oracle::OracleId};
 use binius_field::{
-	arch::OptimalUnderlier, as_packed_field::PackedType, tower::CanonicalTowerFamily, BinaryField1b,
+	BinaryField1b, arch::OptimalUnderlier, as_packed_field::PackedType, tower::CanonicalTowerFamily,
 };
 use binius_hal::make_portable_backend;
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
 use bytesize::ByteSize;
-use clap::{value_parser, Parser};
+use clap::{Parser, value_parser};
 use tracing_profile::init_tracing;
 
 // P:LOG_WIDTH + BinaryField8b::TOWER_LEVEL - COMPRESSION_LOG_LEN

--- a/examples/u32_add.rs
+++ b/examples/u32_add.rs
@@ -3,15 +3,15 @@
 use anyhow::Result;
 use binius_circuits::{
 	arithmetic::Flags,
-	builder::{types::U, ConstraintSystemBuilder},
+	builder::{ConstraintSystemBuilder, types::U},
 };
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger};
-use binius_field::{tower::CanonicalTowerFamily, BinaryField1b};
+use binius_field::{BinaryField1b, tower::CanonicalTowerFamily};
 use binius_hal::make_portable_backend;
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
 use bytesize::ByteSize;
-use clap::{value_parser, Parser};
+use clap::{Parser, value_parser};
 use tracing_profile::init_tracing;
 
 #[derive(Debug, Parser)]

--- a/examples/u32_mul.rs
+++ b/examples/u32_mul.rs
@@ -4,7 +4,7 @@ use std::array;
 
 use anyhow::Result;
 use binius_circuits::{
-	builder::{types::U, ConstraintSystemBuilder},
+	builder::{ConstraintSystemBuilder, types::U},
 	lasso::{
 		batch::LookupBatch,
 		big_integer_ops::byte_sliced_mul,
@@ -14,15 +14,15 @@ use binius_circuits::{
 };
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger};
 use binius_field::{
+	BinaryField1b, BinaryField8b, BinaryField32b, Field,
 	tower::CanonicalTowerFamily,
 	tower_levels::{TowerLevel4, TowerLevel8},
-	BinaryField1b, BinaryField32b, BinaryField8b, Field,
 };
 use binius_hal::make_portable_backend;
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
 use bytesize::ByteSize;
-use clap::{value_parser, Parser};
+use clap::{Parser, value_parser};
 use tracing_profile::init_tracing;
 
 #[derive(Debug, Parser)]

--- a/examples/u32_mul_gkr.rs
+++ b/examples/u32_mul_gkr.rs
@@ -6,21 +6,21 @@ use anyhow::Result;
 use binius_circuits::builder::types::U;
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger};
 use binius_field::{
-	arch::OptimalUnderlier, as_packed_field::PackedType, tower::CanonicalTowerFamily, Field,
-	PackedExtension, PackedFieldIndexable,
+	Field, PackedExtension, PackedFieldIndexable, arch::OptimalUnderlier,
+	as_packed_field::PackedType, tower::CanonicalTowerFamily,
 };
 use binius_hal::make_portable_backend;
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_m3::{
 	builder::{
-		ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment, WitnessIndex, B1,
-		B128, B32,
+		B1, B32, B128, ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment,
+		WitnessIndex,
 	},
 	gadgets::mul::MulUU32,
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
 use bytesize::ByteSize;
-use clap::{value_parser, Parser};
+use clap::{Parser, value_parser};
 use rand::thread_rng;
 use tracing_profile::init_tracing;
 

--- a/examples/u32add_with_lookup.rs
+++ b/examples/u32add_with_lookup.rs
@@ -1,17 +1,17 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use anyhow::Result;
-use binius_circuits::builder::{types::U, ConstraintSystemBuilder};
+use binius_circuits::builder::{ConstraintSystemBuilder, types::U};
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger};
 use binius_field::{
-	arch::OptimalUnderlier, as_packed_field::PackedType, tower::CanonicalTowerFamily,
-	BinaryField1b, BinaryField8b,
+	BinaryField1b, BinaryField8b, arch::OptimalUnderlier, as_packed_field::PackedType,
+	tower::CanonicalTowerFamily,
 };
 use binius_hal::make_portable_backend;
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
 use bytesize::ByteSize;
-use clap::{value_parser, Parser};
+use clap::{Parser, value_parser};
 use tracing_profile::init_tracing;
 
 const MIN_N_ADDITIONS: usize = 1 << (PackedType::<OptimalUnderlier, BinaryField1b>::LOG_WIDTH);

--- a/examples/u64_mul.rs
+++ b/examples/u64_mul.rs
@@ -6,21 +6,21 @@ use anyhow::Result;
 use binius_circuits::builder::types::U;
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger};
 use binius_field::{
-	arch::OptimalUnderlier, as_packed_field::PackedType, tower::CanonicalTowerFamily, Field,
-	PackedExtension, PackedFieldIndexable,
+	Field, PackedExtension, PackedFieldIndexable, arch::OptimalUnderlier,
+	as_packed_field::PackedType, tower::CanonicalTowerFamily,
 };
 use binius_hal::make_portable_backend;
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_m3::{
 	builder::{
-		ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment, WitnessIndex, B1,
-		B128, B64,
+		B1, B64, B128, ConstraintSystem, Statement, TableFiller, TableId, TableWitnessSegment,
+		WitnessIndex,
 	},
 	gadgets::mul::MulUU64,
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
 use bytesize::ByteSize;
-use clap::{value_parser, Parser};
+use clap::{Parser, value_parser};
 use rand::thread_rng;
 use tracing_profile::init_tracing;
 

--- a/examples/u8mul.rs
+++ b/examples/u8mul.rs
@@ -2,16 +2,16 @@
 
 use anyhow::Result;
 use binius_circuits::{
-	builder::{types::U, ConstraintSystemBuilder},
+	builder::{ConstraintSystemBuilder, types::U},
 	lasso::{batch::LookupBatch, lookups},
 };
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger};
-use binius_field::{tower::CanonicalTowerFamily, BinaryField32b, BinaryField8b};
+use binius_field::{BinaryField8b, BinaryField32b, tower::CanonicalTowerFamily};
 use binius_hal::make_portable_backend;
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
 use bytesize::ByteSize;
-use clap::{value_parser, Parser};
+use clap::{Parser, value_parser};
 use tracing_profile::init_tracing;
 
 #[derive(Debug, Parser)]

--- a/examples/vision32b_circuit.rs
+++ b/examples/vision32b_circuit.rs
@@ -10,14 +10,14 @@
 use std::array;
 
 use anyhow::Result;
-use binius_circuits::builder::{types::U, ConstraintSystemBuilder};
+use binius_circuits::builder::{ConstraintSystemBuilder, types::U};
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger, oracle::OracleId};
-use binius_field::{tower::CanonicalTowerFamily, BinaryField32b};
+use binius_field::{BinaryField32b, tower::CanonicalTowerFamily};
 use binius_hal::make_portable_backend;
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
 use bytesize::ByteSize;
-use clap::{value_parser, Parser};
+use clap::{Parser, value_parser};
 use tracing_profile::init_tracing;
 
 #[derive(Debug, Parser)]


### PR DESCRIPTION
Most of the file changes are due to rustfmt sorting dependencies differently in Rust 2024 edition.
- `rng.gen()` had to be changed to `rng.r#gen()` since gen is now a reserved keyword in Rust 2024.
- All unsafe functions must now wrap any unsafe code it calls in explicit unsafe blocks