### PR TITLE
[m3] don't assume oracle id order in witness

### DIFF
--- a/crates/m3/src/builder/channel.rs
+++ b/crates/m3/src/builder/channel.rs
@@ -2,13 +2,14 @@
 
 use binius_core::constraint_system::channel::{ChannelId, FlushDirection};
 
-use super::column::ColumnIndex;
+use super::ColumnId;
 use crate::builder::{B1, Col};
 
 /// A flushing rule within a table.
 #[derive(Debug)]
 pub struct Flush {
-	pub column_indices: Vec<ColumnIndex>,
+	// TODO: rename to columns.
+	pub column_indices: Vec<ColumnId>,
 	pub channel_id: ChannelId,
 	pub direction: FlushDirection,
 	/// The number of times the values are flushed to the channel.
@@ -16,7 +17,7 @@ pub struct Flush {
 	/// Selector columns that determine which row events are flushed
 	///
 	/// The referenced selector columns must hold 1-bit values.
-	pub selectors: Vec<ColumnIndex>,
+	pub selectors: Vec<ColumnId>,
 }
 
 /// Options for a channel flush.

--- a/crates/m3/src/builder/column.rs
+++ b/crates/m3/src/builder/column.rs
@@ -9,10 +9,12 @@ use binius_math::ArithCircuit;
 use super::{structured::StructuredDynSize, table::TableId, types::B128};
 
 /// An index of a column within a table.
-pub type ColumnIndex = usize;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ColumnIndex(pub(crate) usize);
 
-/// An index of a column within a table.
-pub type ColumnPartitionIndex = usize;
+/// An index of a column within a partition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ColumnPartitionIndex(pub(crate) usize);
 
 /// A typed identifier for a column in a table.
 ///
@@ -23,7 +25,7 @@ pub type ColumnPartitionIndex = usize;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Col<F: TowerField, const VALUES_PER_ROW: usize = 1> {
 	pub table_id: TableId,
-	pub table_index: TableId,
+	pub table_index: ColumnIndex,
 	// Denormalized partition index so that we can use it to construct arithmetic expressions over
 	// the partition columns.
 	pub partition_index: ColumnPartitionIndex,
@@ -112,7 +114,7 @@ impl ColumnShape {
 ///
 /// IDs are assigned when columns are added to the constraint system and remain stable when more
 /// columns are added.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ColumnId {
 	pub table_id: TableId,
 	pub table_index: ColumnIndex,
@@ -152,7 +154,7 @@ pub enum ColumnDef<F: TowerField = B128> {
 		log_degree: usize,
 	},
 	Computed {
-		cols: Vec<ColumnIndex>,
+		cols: Vec<ColumnId>,
 		expr: ArithCircuit<F>,
 	},
 	Constant {
@@ -164,13 +166,13 @@ pub enum ColumnDef<F: TowerField = B128> {
 		expr: ArithCircuit<F>,
 	},
 	StaticExp {
-		bit_cols: Vec<ColumnIndex>,
+		bit_cols: Vec<ColumnId>,
 		base: F,
 		base_tower_level: usize,
 	},
 	DynamicExp {
-		bit_cols: Vec<ColumnIndex>,
-		base: ColumnIndex,
+		bit_cols: Vec<ColumnId>,
+		base: ColumnId,
 		base_tower_level: usize,
 	},
 }

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -1,5 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 
+use std::{cell, collections::BTreeMap, ops::Index};
+
 pub use binius_core::constraint_system::channel::{
 	Boundary, Flush as CompiledFlush, FlushDirection,
 };
@@ -19,7 +21,7 @@ use bumpalo::Bump;
 use itertools::chain;
 
 use super::{
-	Table, TableBuilder, TableSizeSpec, ZeroConstraint,
+	ColumnId, Table, TableBuilder, TableId, TableSizeSpec, ZeroConstraint,
 	channel::{Channel, Flush},
 	column::{ColumnDef, ColumnInfo},
 	error::Error,
@@ -35,6 +37,9 @@ use crate::builder::expr::ArithExprNamedVars;
 pub struct ConstraintSystem<F: TowerField = B128> {
 	pub tables: Vec<Table<F>>,
 	pub channels: Vec<Channel>,
+
+	// This is assigned as part of `ConstraintSystem::compile`.
+	oracle_lookup: cell::RefCell<Option<OracleLookup>>,
 }
 
 impl<F: TowerField> std::fmt::Display for ConstraintSystem<F> {
@@ -56,7 +61,7 @@ impl<F: TowerField> std::fmt::Display for ConstraintSystem<F> {
 					let columns = flush
 						.column_indices
 						.iter()
-						.map(|i| table.columns[*i].name.clone())
+						.map(|i| table[*i].name.clone())
 						.collect::<Vec<_>>()
 						.join(", ");
 					match flush.direction {
@@ -72,7 +77,7 @@ impl<F: TowerField> std::fmt::Display for ConstraintSystem<F> {
 				let names = partition
 					.columns
 					.iter()
-					.map(|&index| table.columns[index].name.clone())
+					.map(|&index| table[index].name.clone())
 					.collect::<Vec<_>>();
 
 				for constraint in partition.zero_constraints.iter() {
@@ -158,6 +163,16 @@ impl<F: TowerField> ConstraintSystem<F> {
 		WitnessIndex::new(self, allocator)
 	}
 
+	/// Returns the oracle lookup for this constraint system.
+	///
+	/// Note that this function returns the struct as of the last call to
+	/// [`ConstraintSystem::lookup`].
+	#[track_caller]
+	pub(crate) fn oracle_lookup<'a>(&'a self) -> cell::Ref<'a, OracleLookup> {
+		const MESSAGE: &str = "oracle_lookup was requested but constraint system was not compiled";
+		cell::Ref::map(self.oracle_lookup.borrow(), |o| o.as_ref().expect(MESSAGE))
+	}
+
 	/// Compiles a [`CompiledConstraintSystem`] for a particular statement.
 	///
 	/// The most important transformation that takes place in this step is creating multilinear
@@ -177,6 +192,8 @@ impl<F: TowerField> ConstraintSystem<F> {
 		let mut compiled_flushes = Vec::new();
 		let mut non_zero_oracle_ids = Vec::new();
 		let mut exponents = Vec::new();
+
+		let mut oracle_lookup = OracleLookup::new();
 
 		for (table, &count) in std::iter::zip(&self.tables, &statement.table_sizes) {
 			if count == 0 {
@@ -209,34 +226,16 @@ impl<F: TowerField> ConstraintSystem<F> {
 				TableSizeSpec::Arbitrary => (),
 			}
 
-			let mut oracle_lookup = Vec::new();
-
-			let mut transparent_single = vec![None; table.columns.len()];
-			for (table_index, info) in table.columns.iter().enumerate() {
-				if let ColumnDef::Constant { poly, .. } = &info.col {
-					let oracle_id = oracles
-						.add_named(format!("{}_single", info.name))
-						.transparent(poly.clone())?;
-					transparent_single[table_index] = Some(oracle_id);
-				}
-			}
+			let log_capacity = table::log_capacity(count);
 
 			// Add multilinear oracles for all table columns.
-			let log_capacity = table::log_capacity(count);
-			for column_info in table.columns.iter() {
-				let n_vars = log_capacity + column_info.shape.log_values_per_row;
-				let oracle_id = add_oracle_for_column(
-					&mut oracles,
-					&oracle_lookup,
-					&transparent_single,
-					column_info,
-					n_vars,
-				)?;
-				oracle_lookup.push(oracle_id);
-				if column_info.is_nonzero {
-					non_zero_oracle_ids.push(oracle_id);
-				}
-			}
+			add_oracles_for_columns(
+				&mut oracle_lookup,
+				&mut oracles,
+				table,
+				log_capacity,
+				&mut non_zero_oracle_ids,
+			)?;
 
 			for partition in table.partitions.values() {
 				let TablePartition {
@@ -255,48 +254,60 @@ impl<F: TowerField> ConstraintSystem<F> {
 					.collect::<Vec<_>>();
 
 				// Add Exponents with the same pack factor for the compiled constraint system.
-				columns.iter().for_each(|&index| {
-					let col_info = &table.columns[index].col;
-					if let ColumnDef::StaticExp {
-						bit_cols,
-						base,
-						base_tower_level,
-					} = col_info
-					{
-						let bits_ids = bit_cols
-							.iter()
-							.map(|&col_idx| oracle_lookup[col_idx])
-							.collect();
-						exponents.push(Exp {
-							base: OracleOrConst::Const {
-								base: *base,
-								tower_level: *base_tower_level,
-							},
-							bits_ids,
-							exp_result_id: oracle_lookup[index],
-						});
-					}
-					if let ColumnDef::DynamicExp { bit_cols, base, .. } = col_info {
-						let bits_ids = bit_cols
-							.iter()
-							.map(|&col_idx| oracle_lookup[col_idx])
-							.collect();
-						exponents.push(Exp {
-							base: OracleOrConst::Oracle(oracle_lookup[*base]),
-							bits_ids,
-							exp_result_id: oracle_lookup[index],
-						})
+				columns.iter().for_each(|index| {
+					let col = &table[*index];
+					let col_info = &table[*index].col;
+					match col_info {
+						ColumnDef::StaticExp {
+							bit_cols,
+							base,
+							base_tower_level,
+						} => {
+							let bits_ids = bit_cols
+								.iter()
+								.map(|&column_id| oracle_lookup[column_id])
+								.collect();
+							exponents.push(Exp {
+								base: OracleOrConst::Const {
+									base: *base,
+									tower_level: *base_tower_level,
+								},
+								bits_ids,
+								exp_result_id: oracle_lookup[col.id],
+							});
+						}
+						ColumnDef::DynamicExp { bit_cols, base, .. } => {
+							let bits_ids = bit_cols
+								.iter()
+								.map(|&col_idx| oracle_lookup[col_idx])
+								.collect();
+							exponents.push(Exp {
+								base: OracleOrConst::Oracle(oracle_lookup[*base]),
+								bits_ids,
+								exp_result_id: oracle_lookup[col.id],
+							})
+						}
+						_ => (),
 					}
 				});
 
+				// In case the size of the table is not defined as a power-of-two we need to add
+				// a special selector which is equal to 1 for the first `count` rows and 0 after
+				// that.
+				//
 				// StepDown witness data is populated in
 				// WitnessIndex::into_multilinear_extension_index
-				let step_down = (!table.requires_any_po2_size())
-					.then(|| {
-						let step_down_poly = StepDown::new(n_vars, count * values_per_row)?;
-						oracles.add_transparent(step_down_poly)
-					})
-					.transpose()?;
+				let mut step_down: Option<OracleId> = None;
+				if !table.requires_any_po2_size() {
+					let step_down_poly = StepDown::new(n_vars, count * values_per_row)?;
+					let oracle_id = oracles.add_transparent(step_down_poly)?;
+					oracle_lookup.register_step_down(
+						table.id(),
+						log2_strict_usize(*values_per_row),
+						oracle_id,
+					);
+					step_down = Some(oracle_id);
+				}
 
 				// Translate flushes for the compiled constraint system.
 				for Flush {
@@ -309,7 +320,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 				{
 					let flush_oracles = column_indices
 						.iter()
-						.map(|&column_index| OracleOrConst::Oracle(oracle_lookup[column_index]))
+						.map(|&column_id| OracleOrConst::Oracle(oracle_lookup[column_id]))
 						.collect::<Vec<_>>();
 					let selectors = chain!(
 						selectors
@@ -336,6 +347,8 @@ impl<F: TowerField> ConstraintSystem<F> {
 			}
 		}
 
+		*self.oracle_lookup.borrow_mut() = Some(oracle_lookup);
+
 		Ok(CompiledConstraintSystem {
 			oracles,
 			table_constraints,
@@ -345,6 +358,140 @@ impl<F: TowerField> ConstraintSystem<F> {
 			exponents,
 		})
 	}
+}
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum OracleMapping {
+	Regular(OracleId),
+	/// This is used for constant columns.
+	///
+	/// A constant columns are backed by a transparent oracle. That oracle is a single row and
+	/// is not repeating which is not really expected. So in order to reduce the factor of surprise
+	/// for the user, the original transparent is wrapped into a repeating virtual oracle.
+	TransparentCompound {
+		original: OracleId,
+		repeating: OracleId,
+	},
+}
+
+/// This structure holds metadata about every oracle ID in a constraint system.
+///
+/// This structure maintains mapping between the [`OracleId`] and the related [`ColumnId`].
+#[derive(Debug, Default)]
+pub(crate) struct OracleLookup {
+	column_to_oracle: BTreeMap<ColumnId, OracleMapping>,
+	partition_to_oracle: BTreeMap<(TableId, usize), OracleId>,
+}
+
+impl OracleLookup {
+	/// Creates a new empty Oracle Registry.
+	pub(crate) fn new() -> Self {
+		Self {
+			column_to_oracle: BTreeMap::new(),
+			partition_to_oracle: BTreeMap::new(),
+		}
+	}
+
+	/// Looks up the [`OracleMapping`] for a given column ID.
+	///
+	/// # Preconditions
+	///
+	/// The column ID must exist in the registry, otherwise this function will panic.
+	pub fn lookup(&self, column_id: ColumnId) -> &OracleMapping {
+		&self.column_to_oracle[&column_id]
+	}
+
+	/// Returns the step-down oracle for a table partition if it exists.
+	///
+	/// Returns `None` if no step-down oracle has been registered for the
+	/// given (table, partition_id) pair.
+	pub(crate) fn lookup_step_down(&self, table: TableId, partition_id: usize) -> Option<OracleId> {
+		self.partition_to_oracle
+			.get(&(table, partition_id))
+			.cloned()
+	}
+
+	/// Adds a mapping from a column ID to an oracle mapping.
+	///
+	/// # Preconditions
+	///
+	/// The column ID must not already be registered in the registry, otherwise this function
+	/// will panic.
+	fn register_regular(&mut self, column_id: ColumnId, oracle_id: OracleId) {
+		let prev = self
+			.column_to_oracle
+			.insert(column_id, OracleMapping::Regular(oracle_id));
+		assert!(prev.is_none());
+	}
+
+	/// Registers a transparent oracle mapping for a column.
+	///
+	/// This creates a compound mapping from a column to both an original and a repeating oracle.
+	/// This is specifically used for constant columns that need repeating behavior.
+	///
+	/// # Preconditions
+	///
+	/// The column ID must not already be registered in the registry, otherwise this function
+	/// will panic.
+	fn register_transparent(
+		&mut self,
+		column_id: ColumnId,
+		original: OracleId,
+		repeating: OracleId,
+	) {
+		let prev = self.column_to_oracle.insert(
+			column_id,
+			OracleMapping::TransparentCompound {
+				original,
+				repeating,
+			},
+		);
+		assert!(prev.is_none());
+	}
+
+	/// Registers a step-down oracle for a table partition.
+	///
+	/// # Preconditions
+	///
+	/// The (table, partition_id) pair must not already be registered in the registry, otherwise
+	/// this function will panic.
+	fn register_step_down(&mut self, table: TableId, partition_id: usize, oracle: OracleId) {
+		let prev = self
+			.partition_to_oracle
+			.insert((table, partition_id), oracle);
+		assert!(prev.is_none());
+	}
+}
+
+/// Indexing for [`OracleLookup`]. For transparents this returns the repeating column.
+impl Index<ColumnId> for OracleLookup {
+	type Output = OracleId;
+
+	fn index(&self, id: ColumnId) -> &Self::Output {
+		match &self.column_to_oracle[&id] {
+			OracleMapping::Regular(oracle_id) => oracle_id,
+			OracleMapping::TransparentCompound { repeating, .. } => repeating,
+		}
+	}
+}
+
+/// Add all columns within the given table into the given `oracle_lookup`. Also, fills out
+/// the `non_zero_oracle_ids`.
+fn add_oracles_for_columns<F: TowerField>(
+	oracle_lookup: &mut OracleLookup,
+	oracle_set: &mut MultilinearOracleSet<F>,
+	table: &Table<F>,
+	log_capacity: usize,
+	non_zero_oracle_ids: &mut Vec<OracleId>,
+) -> Result<(), Error> {
+	for column_info in table.columns.iter() {
+		let n_vars = log_capacity + column_info.shape.log_values_per_row;
+		add_oracle_for_column(oracle_set, oracle_lookup, column_info, n_vars)?;
+		if column_info.is_nonzero {
+			non_zero_oracle_ids.push(oracle_lookup[column_info.id]);
+		}
+	}
+	Ok(())
 }
 
 /// Add a table column to the multilinear oracle set with a specified number of variables.
@@ -357,21 +504,22 @@ impl<F: TowerField> ConstraintSystem<F> {
 /// * `n_vars` - number of variables of the multilinear oracle
 fn add_oracle_for_column<F: TowerField>(
 	oracles: &mut MultilinearOracleSet<F>,
-	oracle_lookup: &[OracleId],
-	transparent_single: &[Option<OracleId>],
+	oracle_lookup: &mut OracleLookup,
 	column_info: &ColumnInfo<F>,
 	n_vars: usize,
-) -> Result<OracleId, Error> {
+) -> Result<(), Error> {
 	let ColumnInfo {
-		id,
+		id: column_id,
 		col,
 		name,
 		shape,
 		..
 	} = column_info;
-	let addition = oracles.add_named(name);
-	let oracle_id = match col {
-		ColumnDef::Committed { tower_level } => addition.committed(n_vars, *tower_level),
+	match col {
+		ColumnDef::Committed { tower_level } => {
+			let oracle_id = oracles.add_named(name).committed(n_vars, *tower_level);
+			oracle_lookup.register_regular(*column_id, oracle_id);
+		}
 		ColumnDef::Selected {
 			col,
 			index,
@@ -386,7 +534,11 @@ fn add_oracle_for_column<F: TowerField>(
 					}
 				})
 				.collect();
-			addition.projected(oracle_lookup[col.table_index], index_values, 0)?
+			let oracle_id =
+				oracles
+					.add_named(name)
+					.projected(oracle_lookup[*col], index_values, 0)?;
+			oracle_lookup.register_regular(*column_id, oracle_id);
 		}
 		ColumnDef::Projected {
 			col,
@@ -403,19 +555,27 @@ fn add_oracle_for_column<F: TowerField>(
 					}
 				})
 				.collect();
-			addition.projected(oracle_lookup[col.table_index], query_values, *start_index)?
+			let oracle_id = oracles.add_named(name).projected(
+				oracle_lookup[*col],
+				query_values,
+				*start_index,
+			)?;
+			oracle_lookup.register_regular(*column_id, oracle_id);
 		}
 		ColumnDef::ZeroPadded {
 			col,
 			n_pad_vars,
 			start_index,
 			nonzero_index,
-		} => addition.zero_padded(
-			oracle_lookup[col.table_index],
-			*n_pad_vars,
-			*nonzero_index,
-			*start_index,
-		)?,
+		} => {
+			let oracle_id = oracles.add_named(name).zero_padded(
+				oracle_lookup[*col],
+				*n_pad_vars,
+				*nonzero_index,
+				*start_index,
+			)?;
+			oracle_lookup.register_regular(*column_id, oracle_id);
+		}
 		ColumnDef::Shifted {
 			col,
 			offset,
@@ -423,11 +583,19 @@ fn add_oracle_for_column<F: TowerField>(
 			variant,
 		} => {
 			// TODO: debug assert column at col.table_index has the same values_per_row as col.id
-			addition.shifted(oracle_lookup[col.table_index], *offset, *log_block_size, *variant)?
+			let oracle_id = oracles.add_named(name).shifted(
+				oracle_lookup[*col],
+				*offset,
+				*log_block_size,
+				*variant,
+			)?;
+			oracle_lookup.register_regular(*column_id, oracle_id);
 		}
 		ColumnDef::Packed { col, log_degree } => {
 			// TODO: debug assert column at col.table_index has the same values_per_row as col.id
-			addition.packed(oracle_lookup[col.table_index], *log_degree)?
+			let source = oracle_lookup[*col];
+			let oracle_id = oracles.add_named(name).packed(source, *log_degree)?;
+			oracle_lookup.register_regular(*column_id, oracle_id);
 		}
 		ColumnDef::Computed { cols, expr } => {
 			if let Ok(LinearNormalForm {
@@ -438,34 +606,60 @@ fn add_oracle_for_column<F: TowerField>(
 				let col_scalars = cols
 					.iter()
 					.zip(var_coeffs)
-					.map(|(&col_index, coeff)| (oracle_lookup[col_index], coeff))
+					.map(|(&col_id, coeff)| (oracle_lookup[col_id], coeff))
 					.collect::<Vec<_>>();
-				addition.linear_combination_with_offset(n_vars, offset, col_scalars)?
+				let oracle_id = oracles.add_named(name).linear_combination_with_offset(
+					n_vars,
+					offset,
+					col_scalars,
+				)?;
+				oracle_lookup.register_regular(*column_id, oracle_id);
 			} else {
 				let inner_oracles = cols
 					.iter()
 					.map(|&col_index| oracle_lookup[col_index])
 					.collect::<Vec<_>>();
-				addition.composite_mle(n_vars, inner_oracles, expr.clone())?
-			}
+				let oracle_id =
+					oracles
+						.add_named(name)
+						.composite_mle(n_vars, inner_oracles, expr.clone())?;
+				oracle_lookup.register_regular(*column_id, oracle_id);
+			};
 		}
-		ColumnDef::Constant { .. } => addition.repeating(
-			transparent_single[id.table_index].unwrap(),
-			n_vars - shape.log_values_per_row,
-		)?,
+		ColumnDef::Constant { poly, .. } => {
+			let oracle_id_original = oracles
+				.add_named(format!("{name}_single"))
+				.transparent(poly.clone())?;
+			let oracle_id_repeating = oracles
+				.add_named(name)
+				.repeating(oracle_id_original, n_vars - shape.log_values_per_row)?;
+			oracle_lookup.register_transparent(*column_id, oracle_id_original, oracle_id_repeating);
+		}
 		ColumnDef::StructuredDynSize(structured) => {
 			let expr = structured.expr(n_vars)?;
-			addition.transparent(ArithCircuit::from(&expr))?
+			let oracle_id = oracles
+				.add_named(name)
+				.transparent(ArithCircuit::from(&expr))?;
+			oracle_lookup.register_regular(*column_id, oracle_id);
 		}
-		ColumnDef::StructuredFixedSize { expr } => addition.transparent(expr.clone())?,
+		ColumnDef::StructuredFixedSize { expr } => {
+			let oracle_id = oracles.add_named(name).transparent(expr.clone())?;
+			oracle_lookup.register_regular(*column_id, oracle_id);
+		}
 		ColumnDef::StaticExp {
 			base_tower_level, ..
-		} => addition.committed(n_vars, *base_tower_level),
+		} => {
+			let oracle_id = oracles.add_named(name).committed(n_vars, *base_tower_level);
+			oracle_lookup.register_regular(*column_id, oracle_id);
+		}
 		ColumnDef::DynamicExp {
 			base_tower_level, ..
-		} => addition.committed(n_vars, *base_tower_level),
+		} => {
+			let oracle_id = oracles.add_named(name).committed(n_vars, *base_tower_level);
+			oracle_lookup.register_regular(*column_id, oracle_id);
+		}
 	};
-	Ok(oracle_id)
+	Ok(())
 }
 
 /// Translates a set of zero constraints from a particular table partition into a constraint set.

--- a/crates/m3/src/builder/expr.rs
+++ b/crates/m3/src/builder/expr.rs
@@ -44,7 +44,7 @@ impl<F: TowerField, const V: usize> From<Col<F, V>> for Expr<F, V> {
 	fn from(value: Col<F, V>) -> Self {
 		Expr {
 			table_id: value.table_id,
-			expr: ArithExpr::Var(value.partition_index),
+			expr: ArithExpr::Var(value.partition_index.0),
 		}
 	}
 }
@@ -55,8 +55,8 @@ impl<F: TowerField, const V: usize> std::ops::Add<Self> for Col<F, V> {
 	fn add(self, rhs: Self) -> Self::Output {
 		assert_eq!(self.table_id, rhs.table_id);
 
-		let lhs_expr = ArithExpr::Var(self.partition_index);
-		let rhs_expr = ArithExpr::Var(rhs.partition_index);
+		let lhs_expr = ArithExpr::Var(self.partition_index.0);
+		let rhs_expr = ArithExpr::Var(rhs.partition_index.0);
 
 		Expr {
 			table_id: self.table_id,
@@ -71,7 +71,7 @@ impl<F: TowerField, const V: usize> std::ops::Add<Col<F, V>> for Expr<F, V> {
 	fn add(self, rhs: Col<F, V>) -> Self::Output {
 		assert_eq!(self.table_id, rhs.table_id);
 
-		let rhs_expr = ArithExpr::Var(rhs.partition_index);
+		let rhs_expr = ArithExpr::Var(rhs.partition_index.0);
 		Expr {
 			table_id: self.table_id,
 			expr: self.expr + rhs_expr,
@@ -123,8 +123,8 @@ impl<F: TowerField, const V: usize> std::ops::Sub<Self> for Col<F, V> {
 
 	fn sub(self, rhs: Self) -> Self::Output {
 		assert_eq!(self.table_id, rhs.table_id);
-		let lhs_expr = ArithExpr::Var(self.partition_index);
-		let rhs_expr = ArithExpr::Var(rhs.partition_index);
+		let lhs_expr = ArithExpr::Var(self.partition_index.0);
+		let rhs_expr = ArithExpr::Var(rhs.partition_index.0);
 
 		Expr {
 			table_id: self.table_id,

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-use std::sync::Arc;
+use std::{ops::Index, sync::Arc};
 
 use binius_core::{
 	constraint_system::channel::{ChannelId, FlushDirection},
@@ -20,7 +20,7 @@ use binius_utils::{
 };
 
 use super::{
-	B1, ColumnIndex, FlushOpts,
+	B1, ColumnIndex, ColumnPartitionIndex, FlushOpts,
 	channel::Flush,
 	column::{Col, ColumnDef, ColumnId, ColumnInfo, ColumnShape},
 	expr::{Expr, ZeroConstraint},
@@ -182,23 +182,22 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		F: ExtensionField<FSub>,
 	{
 		let expr_circuit = ArithCircuit::from(expr.expr());
-		let partition_indexes = expr_circuit
+		// Indicies within the partition.
+		let indices_within_partition = expr_circuit
 			.vars_usage()
 			.iter()
 			.enumerate()
 			.filter(|(_, used)| **used)
 			.map(|(i, _)| i)
 			.collect::<Vec<_>>();
-		let cols = partition_indexes
+		let partition = &self.table.partitions[partition_id::<V>()];
+		let cols = indices_within_partition
 			.iter()
-			.map(|&partition_index| {
-				let partition = &self.table.partitions[partition_id::<V>()];
-				partition.columns[partition_index]
-			})
+			.map(|&partition_index| partition.columns[partition_index])
 			.collect::<Vec<_>>();
 
 		let mut var_remapping = vec![0; expr_circuit.n_vars()];
-		for (new_index, &old_index) in partition_indexes.iter().enumerate() {
+		for (new_index, &old_index) in indices_within_partition.iter().enumerate() {
 			var_remapping[old_index] = new_index;
 		}
 		let remapped_expr = expr_circuit
@@ -382,9 +381,20 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 	{
 		assert!(pow_bits.len() <= (1 << FExpBase::TOWER_LEVEL));
 
-		// TODO: Add check for pow_bits, F, FSub, VALUES_PER_ROW
+		// TODO: Add check for F, FSub, VALUES_PER_ROW
 		let namespaced_name = self.namespaced_name(name);
-		let bit_cols = pow_bits.iter().map(|bit| bit.id().table_index).collect();
+		let bit_cols = pow_bits
+			.iter()
+			.enumerate()
+			.map(|(index, bit)| {
+				assert_eq!(
+					self.table.id(),
+					bit.id().table_id,
+					"passed foreign table column at index={index}"
+				);
+				bit.id()
+			})
+			.collect();
 		self.table.new_column(
 			namespaced_name,
 			ColumnDef::StaticExp {
@@ -420,13 +430,25 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 	{
 		assert!(pow_bits.len() <= (1 << FExpBase::TOWER_LEVEL));
 
+		// TODO: Add check for F, FSub, VALUES_PER_ROW
 		let namespaced_name = self.namespaced_name(name);
-		let bit_cols = pow_bits.iter().map(|bit| bit.id().table_index).collect();
+		let bit_cols = pow_bits
+			.iter()
+			.enumerate()
+			.map(|(index, bit)| {
+				assert_eq!(
+					self.table.id(),
+					bit.id().table_id,
+					"passed foreign table column at index={index}"
+				);
+				bit.id()
+			})
+			.collect();
 		self.table.new_column(
 			namespaced_name,
 			ColumnDef::DynamicExp {
 				bit_cols,
-				base: base.id().table_index,
+				base: base.id(),
 				base_tower_level: FExpBase::TOWER_LEVEL,
 			},
 		)
@@ -491,9 +513,9 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		F: ExtensionField<FSub>,
 	{
 		assert_eq!(expr.table_id, self.id());
-		assert!(expr.table_index < self.table.columns.len());
+		assert!(expr.table_index.0 < self.table.columns.len());
 
-		self.table.columns[expr.table_index].is_nonzero = true;
+		self.table.columns[expr.table_index.0].is_nonzero = true;
 	}
 
 	pub fn pull<FSub>(&mut self, channel: ChannelId, cols: impl IntoIterator<Item = Col<FSub>>)
@@ -582,7 +604,7 @@ pub(super) struct TablePartition<F: TowerField = B128> {
 	pub table_id: TableId,
 	pub values_per_row: usize,
 	pub flushes: Vec<Flush>,
-	pub columns: Vec<ColumnIndex>,
+	pub columns: Vec<ColumnId>,
 	pub zero_constraints: Vec<ZeroConstraint<F>>,
 }
 
@@ -623,7 +645,7 @@ impl<F: TowerField> TablePartition<F> {
 			.into_iter()
 			.map(|col| {
 				assert_eq!(col.table_id, self.table_id);
-				col.table_index
+				col.id()
 			})
 			.collect();
 		let selectors = opts
@@ -631,7 +653,7 @@ impl<F: TowerField> TablePartition<F> {
 			.iter()
 			.map(|selector| {
 				assert_eq!(selector.table_id, self.table_id);
-				selector.table_index
+				selector.id()
 			})
 			.collect::<Vec<_>>();
 		self.flushes.push(Flush {
@@ -669,7 +691,7 @@ impl<F: TowerField> Table<F> {
 		F: ExtensionField<FSub>,
 	{
 		let table_id = self.id;
-		let table_index = self.columns.len();
+		let table_index = ColumnIndex(self.columns.len());
 		let partition = self.partition_mut(V);
 		let id = ColumnId {
 			table_id,
@@ -686,8 +708,8 @@ impl<F: TowerField> Table<F> {
 			is_nonzero: false,
 		};
 
-		let partition_index = partition.columns.len();
-		partition.columns.push(table_index);
+		let partition_index = ColumnPartitionIndex(partition.columns.len());
+		partition.columns.push(id);
 		self.columns.push(info);
 		Col::new(id, partition_index)
 	}
@@ -710,6 +732,23 @@ impl<F: TowerField> Table<F> {
 
 	pub fn stat(&self) -> TableStat {
 		TableStat::new(self)
+	}
+}
+
+impl<F: TowerField> Index<ColumnIndex> for Table<F> {
+	type Output = ColumnInfo<F>;
+
+	fn index(&self, index: ColumnIndex) -> &Self::Output {
+		&self.columns[index.0]
+	}
+}
+
+impl<F: TowerField> Index<ColumnId> for Table<F> {
+	type Output = ColumnInfo<F>;
+
+	fn index(&self, index: ColumnId) -> &Self::Output {
+		assert_eq!(index.table_id, self.id());
+		&self.columns[index.table_index.0]
 	}
 }
 

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -9,8 +9,9 @@ use std::{
 };
 
 use binius_core::{
-	oracle::OracleId, polynomial::ArithCircuitPoly, transparent::step_down::StepDown,
-	witness::MultilinearExtensionIndex,
+	polynomial::ArithCircuitPoly,
+	transparent::step_down::StepDown,
+	witness::{MultilinearExtensionIndex, MultilinearWitness},
 };
 use binius_field::{
 	ExtensionField, PackedExtension, PackedField, PackedFieldIndexable, PackedSubfield, TowerField,
@@ -30,8 +31,9 @@ use getset::CopyGetters;
 use itertools::Itertools;
 
 use super::{
-	ColumnDef, ColumnId, ColumnIndex, ConstraintSystem, Expr,
+	ColumnDef, ColumnId, ColumnInfo, ColumnPartitionIndex, ConstraintSystem, Expr,
 	column::{Col, ColumnShape},
+	constraint_system::OracleMapping,
 	error::Error,
 	table::{self, Table, TableId},
 	types::{B1, B8, B16, B32, B64, B128},
@@ -51,6 +53,7 @@ where
 	P: PackedField,
 	P::Scalar: TowerField,
 {
+	cs: &'cs ConstraintSystem<P::Scalar>,
 	allocator: &'alloc Bump,
 	/// Each entry is Left if the index hasn't been initialized & filled, and Right if it has.
 	tables: Vec<Either<&'cs Table<P::Scalar>, TableWitnessIndex<'cs, 'alloc, P>>>,
@@ -60,6 +63,7 @@ impl<'cs, 'alloc, F: TowerField, P: PackedField<Scalar = F>> WitnessIndex<'cs, '
 	/// Creates and allocates the witness index for a constraint system.
 	pub fn new(cs: &'cs ConstraintSystem<F>, allocator: &'alloc Bump) -> Self {
 		Self {
+			cs,
 			allocator,
 			tables: cs.tables.iter().map(Either::Left).collect(),
 		}
@@ -160,6 +164,28 @@ impl<'cs, 'alloc, F: TowerField, P: PackedField<Scalar = F>> WitnessIndex<'cs, '
 			.collect()
 	}
 
+	fn mk_column_witness<'a>(
+		log_capacity: usize,
+		shape: ColumnShape,
+		data: &'a [P],
+	) -> MultilinearWitness<'a, P>
+	where
+		P: PackedExtension<B1>
+			+ PackedExtension<B8>
+			+ PackedExtension<B16>
+			+ PackedExtension<B32>
+			+ PackedExtension<B64>
+			+ PackedExtension<B128>,
+	{
+		let n_vars = log_capacity + shape.log_values_per_row;
+		let underlier_count =
+			1 << (n_vars + shape.tower_height).saturating_sub(P::LOG_WIDTH + F::TOWER_LEVEL);
+		multilin_poly_from_underlier_data(&data[..underlier_count], n_vars, shape.tower_height)
+	}
+
+	/// Converts this witness into binius_core's [`MultilinearExtensionIndex`].
+	///
+	/// Note that this function must be called only after the [`ConstraintSystem::compile`].
 	pub fn into_multilinear_extension_index(self) -> MultilinearExtensionIndex<'alloc, P>
 	where
 		P: PackedExtension<B1>
@@ -169,8 +195,10 @@ impl<'cs, 'alloc, F: TowerField, P: PackedField<Scalar = F>> WitnessIndex<'cs, '
 			+ PackedExtension<B64>
 			+ PackedExtension<B128>,
 	{
+		let oracle_lookup = self.cs.oracle_lookup();
+
 		let mut index = MultilinearExtensionIndex::new();
-		let mut first_oracle_id_in_table = 0;
+
 		for table_witness in self.tables {
 			let Either::Right(table_witness) = table_witness else {
 				continue;
@@ -178,33 +206,65 @@ impl<'cs, 'alloc, F: TowerField, P: PackedField<Scalar = F>> WitnessIndex<'cs, '
 			let table = table_witness.table();
 			let cols = immutable_witness_index_columns(table_witness.cols);
 
-			// Append oracles for constant columns that are repeated.
-			let mut count = 0;
-			for (oracle_id_offset, col) in cols.into_iter().enumerate() {
-				let oracle_id = OracleId::from_index(first_oracle_id_in_table + oracle_id_offset);
-				let log_capacity = if col.is_single_row {
-					0
-				} else {
-					table_witness.log_capacity
-				};
-				let n_vars = log_capacity + col.shape.log_values_per_row;
-				let underlier_count = 1
-					<< (n_vars + col.shape.tower_height)
-						.saturating_sub(P::LOG_WIDTH + F::TOWER_LEVEL);
-				let witness = multilin_poly_from_underlier_data(
-					&col.data[..underlier_count],
-					n_vars,
-					col.shape.tower_height,
-				);
-				index.update_multilin_poly([(oracle_id, witness)]).unwrap();
-				count += 1;
+			// Here our objective is to add a witness for every oracle the table has created.
+			//
+			// There are some tricky parts that is worth keeping in mind:
+			//
+			// 1. Some oracles share witnesses, e.g. packed column has the same witness as the
+			//    column that it packs. Despite that they cannot share the underlying witness
+			//    polynomial because of the difference in n_vars.
+			//
+			// 2. Similarly, the constant column creates two oracles: the original constant and the
+			//    the user-visible one, repeating column. Instead of making the user to fill both
+			//    witnesses, we fill the original constant oracle with the truncated version of the
+			//    repeating column.
+			//
+			// 3. Another complication raises from the fact that a non-power-of-two sized table must
+			//    insert a special oracle that is 1 for every row until it's actual capacity and 0
+			//    for the rest of the table to the nearest power-of-two.
+
+			for col in cols.into_iter() {
+				let oracle_mapping = *oracle_lookup.lookup(col.column_id);
+				match oracle_mapping {
+					OracleMapping::Regular(oracle_id) => index
+						.update_multilin_poly([(
+							oracle_id,
+							Self::mk_column_witness(
+								table_witness.log_capacity,
+								col.shape,
+								col.data,
+							),
+						)])
+						.unwrap(),
+					OracleMapping::TransparentCompound {
+						original,
+						repeating,
+					} => {
+						// Create a single row poly witness for the original oracle and the
+						// repeating version of that for the repeating oracle.
+						let original_witness = Self::mk_column_witness(0, col.shape, col.data);
+						let repeating_witness = Self::mk_column_witness(
+							table_witness.log_capacity,
+							col.shape,
+							col.data,
+						);
+						index
+							.update_multilin_poly([
+								(original, original_witness),
+								(repeating, repeating_witness),
+							])
+							.unwrap();
+					}
+				}
 			}
 
 			if !table.requires_any_po2_size() {
 				// Every table partition has a step_down appended to the end of the table to support
 				// non-power of two height tables.
 				for log_values_per_row in table.partitions.keys() {
-					let oracle_id = OracleId::from_index(first_oracle_id_in_table + count);
+					let oracle_id = oracle_lookup
+						.lookup_step_down(table.id, log_values_per_row)
+						.unwrap();
 					let size = table_witness.size << log_values_per_row;
 					let log_size = table_witness.log_capacity + log_values_per_row;
 					let witness = StepDown::new(log_size, size)
@@ -213,11 +273,8 @@ impl<'cs, 'alloc, F: TowerField, P: PackedField<Scalar = F>> WitnessIndex<'cs, '
 						.unwrap()
 						.specialize_arc_dyn();
 					index.update_multilin_poly([(oracle_id, witness)]).unwrap();
-					count += 1;
 				}
 			}
-
-			first_oracle_id_in_table += count;
 		}
 		index
 	}
@@ -245,7 +302,7 @@ where
 					let segment = table_witness_index.full_segment();
 					for col in table.columns.iter() {
 						if let ColumnDef::Constant { data, .. } = &col.col {
-							let mut witness_data = segment.get_dyn_mut(col.id.table_index)?;
+							let mut witness_data = segment.get_dyn_mut(col.id)?;
 							let len = witness_data.size();
 							for (i, scalar) in data.iter().cycle().take(len).enumerate() {
 								witness_data.set(i, *scalar)?
@@ -306,7 +363,6 @@ where
 {
 	#[get_copy = "pub"]
 	table: &'cs Table<P::Scalar>,
-	oracle_offset: usize,
 	cols: Vec<WitnessIndexColumn<'alloc, P>>,
 	/// The number of table events that the index should contain.
 	#[get_copy = "pub"]
@@ -325,13 +381,14 @@ where
 pub struct WitnessIndexColumn<'a, P: PackedField> {
 	shape: ColumnShape,
 	data: WitnessDataMut<'a, P>,
-	is_single_row: bool,
+	column_id: ColumnId,
 }
 
 #[derive(Debug, Clone)]
 enum WitnessColumnInfo<T> {
 	Owned(T),
-	SameAsOracleId(OracleId),
+	/// This column is same as the column stored in `cols[.0]`.
+	SameAsIndex(usize),
 }
 
 type WitnessDataMut<'a, P> = WitnessColumnInfo<&'a mut [P]>;
@@ -345,10 +402,10 @@ impl<'a, P: PackedField> WitnessDataMut<'a, P> {
 type RefCellData<'a, P> = WitnessColumnInfo<RefCell<&'a mut [P]>>;
 
 #[derive(Debug)]
-pub struct ImmutableWitnessIndexColumn<'a, P: PackedField> {
-	pub shape: ColumnShape,
-	pub data: &'a [P],
-	pub is_single_row: bool,
+struct ImmutableWitnessIndexColumn<'a, P: PackedField> {
+	shape: ColumnShape,
+	data: &'a [P],
+	column_id: ColumnId,
 }
 
 /// Converts the vector of witness columns into immutable references to column data that may be
@@ -362,16 +419,16 @@ fn immutable_witness_index_columns<P: PackedField>(
 			shape: col.shape,
 			data: match col.data {
 				WitnessDataMut::Owned(data) => data,
-				WitnessDataMut::SameAsOracleId(id) => result[id.index()].data,
+				WitnessDataMut::SameAsIndex(index) => result[index].data,
 			},
-			is_single_row: col.is_single_row,
+			column_id: col.column_id,
 		});
 	}
 	result
 }
 
 impl<'cs, 'alloc, F: TowerField, P: PackedField<Scalar = F>> TableWitnessIndex<'cs, 'alloc, P> {
-	pub fn new(
+	pub(crate) fn new(
 		allocator: &'alloc bumpalo::Bump,
 		table: &'cs Table<F>,
 		size: usize,
@@ -385,44 +442,24 @@ impl<'cs, 'alloc, F: TowerField, P: PackedField<Scalar = F>> TableWitnessIndex<'
 		let log_capacity = table::log_capacity(size);
 		let packed_elem_log_bits = P::LOG_WIDTH + F::TOWER_LEVEL;
 
-		let mut cols = Vec::new();
-		let mut oracle_offset = 0;
-		let mut transparent_single_backing = vec![None; table.columns.len()];
-
-		for col in &table.columns {
-			if matches!(col.col, ColumnDef::Constant { .. }) {
-				transparent_single_backing[col.id.table_index] =
-					Some(OracleId::from_index(oracle_offset));
-				cols.push(WitnessIndexColumn {
-					shape: col.shape,
-					data: WitnessDataMut::new_owned(
-						allocator,
-						(col.shape.log_cell_size() + log_capacity)
-							.saturating_sub(packed_elem_log_bits),
-					),
-					is_single_row: true,
-				});
-				oracle_offset += 1;
-			}
-		}
-
-		cols.extend(table.columns.iter().map(|col| WitnessIndexColumn {
-			shape: col.shape,
-			data: match col.col {
-				ColumnDef::Packed { col: inner_col, .. } => {
-					let oracle_id = OracleId::from_index(oracle_offset + inner_col.table_index);
-					WitnessDataMut::SameAsOracleId(oracle_id)
-				}
-				ColumnDef::Constant { .. } => WitnessDataMut::SameAsOracleId(
-					transparent_single_backing[col.id.table_index].unwrap(),
-				),
-				_ => WitnessDataMut::new_owned(
+		let mut cols = Vec::with_capacity(table.columns.len());
+		for ColumnInfo { id, col, shape, .. } in &table.columns {
+			let data: WitnessDataMut<P> = if let ColumnDef::Packed { col: source, .. } = col {
+				// Packed column reuses the witness of the one it is based on.
+				WitnessDataMut::SameAsIndex(source.table_index.0)
+			} else {
+				// Everything else has it's own column.
+				WitnessDataMut::new_owned(
 					allocator,
-					(col.shape.log_cell_size() + log_capacity).saturating_sub(packed_elem_log_bits),
-				),
-			},
-			is_single_row: false,
-		}));
+					(shape.log_cell_size() + log_capacity).saturating_sub(packed_elem_log_bits),
+				)
+			};
+			cols.push(WitnessIndexColumn {
+				shape: *shape,
+				data,
+				column_id: *id,
+			});
+		}
 
 		// The minimum segment size is chosen such that the segment of each column is at least one
 		// underlier in size.
@@ -444,7 +481,6 @@ impl<'cs, 'alloc, F: TowerField, P: PackedField<Scalar = F>> TableWitnessIndex<'
 			size,
 			log_capacity,
 			min_log_segment_size,
-			oracle_offset,
 		})
 	}
 
@@ -462,7 +498,7 @@ impl<'cs, 'alloc, F: TowerField, P: PackedField<Scalar = F>> TableWitnessIndex<'
 			.cols
 			.iter_mut()
 			.map(|col| match &mut col.data {
-				WitnessDataMut::SameAsOracleId(id) => RefCellData::SameAsOracleId(*id),
+				WitnessDataMut::SameAsIndex(id) => RefCellData::SameAsIndex(*id),
 				WitnessDataMut::Owned(data) => RefCellData::Owned(RefCell::new(data)),
 			})
 			.collect();
@@ -471,7 +507,6 @@ impl<'cs, 'alloc, F: TowerField, P: PackedField<Scalar = F>> TableWitnessIndex<'
 			cols,
 			log_size: self.log_capacity,
 			index: 0,
-			oracle_offset: self.oracle_offset,
 		}
 	}
 
@@ -592,7 +627,7 @@ impl<'cs, 'alloc, F: TowerField, P: PackedField<Scalar = F>> TableWitnessIndex<'
 			.iter_mut()
 			.map(|col| match col {
 				RefCellData::Owned(data) => WitnessColumnInfo::Owned(data.get_mut()),
-				RefCellData::SameAsOracleId(idx) => WitnessColumnInfo::SameAsOracleId(*idx),
+				RefCellData::SameAsIndex(idx) => WitnessColumnInfo::SameAsIndex(*idx),
 			})
 			.collect::<Vec<_>>();
 
@@ -692,7 +727,7 @@ impl<'cs, 'alloc, F: TowerField, P: PackedField<Scalar = F>> TableWitnessIndex<'
 			.iter_mut()
 			.map(|col| match col {
 				RefCellData::Owned(data) => WitnessColumnInfo::Owned(data.get_mut()),
-				RefCellData::SameAsOracleId(idx) => WitnessColumnInfo::SameAsOracleId(*idx),
+				RefCellData::SameAsIndex(idx) => WitnessColumnInfo::SameAsIndex(*idx),
 			})
 			.collect::<Vec<_>>();
 
@@ -737,7 +772,6 @@ where
 	P::Scalar: TowerField,
 {
 	table: &'a Table<P::Scalar>,
-	oracle_offset: usize,
 	cols: Vec<WitnessColumnInfo<(&'a mut [P], usize)>>,
 	log_segment_size: usize,
 	start_index: usize,
@@ -760,12 +794,11 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegmentedView<'a
 						.saturating_sub(P::LOG_WIDTH + F::TOWER_LEVEL);
 					WitnessColumnInfo::Owned((&mut **data, 1 << chunk_size))
 				}
-				WitnessColumnInfo::SameAsOracleId(id) => WitnessColumnInfo::SameAsOracleId(*id),
+				WitnessColumnInfo::SameAsIndex(id) => WitnessColumnInfo::SameAsIndex(*id),
 			})
 			.collect::<Vec<_>>();
 		Self {
 			table: witness.table,
-			oracle_offset: witness.oracle_offset,
 			cols,
 			log_segment_size,
 			start_index: 0,
@@ -789,15 +822,14 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegmentedView<'a
 						WitnessColumnInfo::Owned((data_1, *chunk_size)),
 					)
 				}
-				WitnessColumnInfo::SameAsOracleId(id) => {
-					(WitnessColumnInfo::SameAsOracleId(*id), WitnessColumnInfo::SameAsOracleId(*id))
+				WitnessColumnInfo::SameAsIndex(id) => {
+					(WitnessColumnInfo::SameAsIndex(*id), WitnessColumnInfo::SameAsIndex(*id))
 				}
 			})
 			.unzip();
 		(
 			TableWitnessSegmentedView {
 				table: self.table,
-				oracle_offset: self.oracle_offset,
 				cols: cols_0,
 				log_segment_size: self.log_segment_size,
 				start_index: self.start_index,
@@ -805,7 +837,6 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegmentedView<'a
 			},
 			TableWitnessSegmentedView {
 				table: self.table,
-				oracle_offset: self.oracle_offset,
 				cols: cols_1,
 				log_segment_size: self.log_segment_size,
 				start_index: self.start_index + index,
@@ -817,7 +848,6 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegmentedView<'a
 	fn into_iter(self) -> impl Iterator<Item = TableWitnessSegment<'a, P>> {
 		let TableWitnessSegmentedView {
 			table,
-			oracle_offset,
 			cols,
 			log_segment_size,
 			start_index,
@@ -834,8 +864,8 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegmentedView<'a
 							data.chunks_mut(chunk_size)
 								.map(|chunk| RefCellData::Owned(RefCell::new(chunk))),
 						),
-						WitnessColumnInfo::SameAsOracleId(id) => itertools::Either::Right(
-							iter::repeat_n(id, n_segments).map(RefCellData::SameAsOracleId),
+						WitnessColumnInfo::SameAsIndex(id) => itertools::Either::Right(
+							iter::repeat_n(id, n_segments).map(RefCellData::SameAsIndex),
 						),
 					})
 					.collect(),
@@ -846,7 +876,6 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegmentedView<'a
 				cols,
 				log_size: log_segment_size,
 				index: start_index + index,
-				oracle_offset,
 			});
 			itertools::Either::Right(iter)
 		}
@@ -855,7 +884,6 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegmentedView<'a
 	fn into_par_iter(self) -> impl IndexedParallelIterator<Item = TableWitnessSegment<'a, P>> {
 		let TableWitnessSegmentedView {
 			table,
-			oracle_offset,
 			cols,
 			log_segment_size,
 			start_index,
@@ -881,7 +909,7 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegmentedView<'a
 					WitnessColumnInfo::Owned((data, chunk_size)) => {
 						WitnessColumnInfo::Owned((data, chunk_size))
 					}
-					WitnessColumnInfo::SameAsOracleId(id) => WitnessColumnInfo::SameAsOracleId(id),
+					WitnessColumnInfo::SameAsIndex(id) => WitnessColumnInfo::SameAsIndex(id),
 				}
 			})
 			.collect::<Vec<_>>();
@@ -890,7 +918,7 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegmentedView<'a
 			let col_strides = cols
 				.iter()
 				.map(|col| match col {
-					WitnessColumnInfo::SameAsOracleId(id) => RefCellData::SameAsOracleId(*id),
+					WitnessColumnInfo::SameAsIndex(id) => RefCellData::SameAsIndex(*id),
 					WitnessColumnInfo::Owned((data, chunk_size)) => {
 						RefCellData::Owned(RefCell::new(unsafe {
 							// Safety: The function borrows self mutably, so we have mutable access
@@ -907,7 +935,6 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegmentedView<'a
 				cols: col_strides,
 				log_size: log_segment_size,
 				index: start_index + i,
-				oracle_offset,
 			}
 		})
 	}
@@ -924,13 +951,15 @@ where
 	P::Scalar: TowerField,
 {
 	table: &'a Table<P::Scalar>,
+	/// Stores the actual data for the witness columns.
+	///
+	/// The order of the columns corresponds to the same order as defined in the table.
 	cols: Vec<RefCellData<'a, P>>,
 	#[get_copy = "pub"]
 	log_size: usize,
 	/// The index of the segment in the segmented table witness.
 	#[get_copy = "pub"]
 	index: usize,
-	oracle_offset: usize,
 }
 
 impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegment<'a, P> {
@@ -949,7 +978,7 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegment<'a, P> {
 		}
 
 		let col = self
-			.get_col_data(col.table_index)
+			.get_col_data(col.id())
 			.ok_or_else(|| Error::MissingColumn(col.id()))?;
 		let col_ref = col.try_borrow().map_err(Error::WitnessBorrow)?;
 		Ok(Ref::map(col_ref, |packed| PackedExtension::cast_bases(packed)))
@@ -971,7 +1000,7 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegment<'a, P> {
 		}
 
 		let col = self
-			.get_col_data(col.table_index)
+			.get_col_data(col.id())
 			.ok_or_else(|| Error::MissingColumn(col.id()))?;
 		let col_ref = col.try_borrow_mut().map_err(Error::WitnessBorrowMut)?;
 		Ok(RefMut::map(col_ref, |packed| PackedExtension::cast_bases_mut(packed)))
@@ -1012,7 +1041,7 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegment<'a, P> {
 		F: ExtensionField<FSub> + Pod,
 	{
 		let col = self
-			.get_col_data(col.table_index)
+			.get_col_data(col.id())
 			.ok_or_else(|| Error::MissingColumn(col.id()))?;
 		let col_ref = col.try_borrow().map_err(Error::WitnessBorrow)?;
 		Ok(Ref::map(col_ref, |col| must_cast_slice(P::unpack_scalars(col))))
@@ -1034,7 +1063,7 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegment<'a, P> {
 		}
 
 		let col = self
-			.get_col_data(col.table_index)
+			.get_col_data(col.id())
 			.ok_or_else(|| Error::MissingColumn(col.id()))?;
 		let col_ref = col.try_borrow_mut().map_err(Error::WitnessBorrowMut)?;
 		Ok(RefMut::map(col_ref, |col| must_cast_slice_mut(P::unpack_scalars_mut(col))))
@@ -1070,15 +1099,10 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegment<'a, P> {
 			.iter()
 			.zip(expr_circuit.vars_usage())
 			.enumerate()
-			.map(|(i, (col_index, used))| {
+			.map(|(partition_index, (col_id, used))| {
 				used.then(|| {
-					self.get(Col::<FSub, V>::new(
-						ColumnId {
-							table_id: self.table.id(),
-							table_index: *col_index,
-						},
-						i,
-					))
+					// TODO: conjuring up Col is discouraged.
+					self.get(Col::<FSub, V>::new(*col_id, ColumnPartitionIndex(partition_index)))
 				})
 				.transpose()
 			})
@@ -1109,15 +1133,15 @@ impl<'a, F: TowerField, P: PackedField<Scalar = F>> TableWitnessSegment<'a, P> {
 		1 << self.log_size
 	}
 
-	fn get_col_data(&self, table_index: ColumnIndex) -> Option<&RefCell<&'a mut [P]>> {
-		let oracle_id = OracleId::from_index(self.oracle_offset + table_index);
-		self.get_col_data_by_oracle_offset(oracle_id)
+	fn get_col_data(&self, column_id: ColumnId) -> Option<&RefCell<&'a mut [P]>> {
+		let column_index = column_id.table_index.0;
+		self.get_col_data_by_index(column_index)
 	}
 
-	fn get_col_data_by_oracle_offset(&self, oracle_id: OracleId) -> Option<&RefCell<&'a mut [P]>> {
-		match self.cols.get(oracle_id.index()) {
+	fn get_col_data_by_index(&self, index: usize) -> Option<&RefCell<&'a mut [P]>> {
+		match self.cols.get(index) {
 			Some(RefCellData::Owned(data)) => Some(data),
-			Some(RefCellData::SameAsOracleId(id)) => self.get_col_data_by_oracle_offset(*id),
+			Some(RefCellData::SameAsIndex(index)) => self.get_col_data_by_index(*index),
 			None => None,
 		}
 	}
@@ -1136,16 +1160,13 @@ where
 	/// For a given column index within a table, return the immutable upcasted witness data
 	pub fn get_dyn(
 		&self,
-		col_index: ColumnIndex,
+		col_id: ColumnId,
 	) -> Result<Box<dyn WitnessColView<P::Scalar> + '_>, Error> {
-		let col = self.get_col_data(col_index).ok_or_else(|| {
-			Error::MissingColumn(ColumnId {
-				table_id: self.table.id(),
-				table_index: col_index,
-			})
-		})?;
+		let col = self
+			.get_col_data(col_id)
+			.ok_or_else(|| Error::MissingColumn(col_id))?;
 		let col_ref = col.try_borrow().map_err(Error::WitnessBorrow)?;
-		let tower_level = self.table.columns[col_index].shape.tower_height;
+		let tower_level = self.table[col_id].shape.tower_height;
 		let ret: Box<dyn WitnessColView<_>> = match tower_level {
 			0 => Box::new(WitnessColViewImpl(Ref::map(col_ref, |packed| {
 				PackedExtension::<B1>::cast_bases(packed)
@@ -1173,16 +1194,13 @@ where
 	/// For a given column index within a table, return the mutable witness data.
 	pub fn get_dyn_mut(
 		&self,
-		col_index: ColumnIndex,
+		col_id: ColumnId,
 	) -> Result<Box<dyn WitnessColViewMut<P::Scalar> + '_>, Error> {
-		let col = self.get_col_data(col_index).ok_or_else(|| {
-			Error::MissingColumn(ColumnId {
-				table_id: self.table.id(),
-				table_index: col_index,
-			})
-		})?;
+		let col = self
+			.get_col_data(col_id)
+			.ok_or_else(|| Error::MissingColumn(col_id))?;
 		let col_ref = col.try_borrow_mut().map_err(Error::WitnessBorrowMut)?;
-		let tower_level = self.table.columns[col_index].shape.tower_height;
+		let tower_level = self.table[col_id].shape.tower_height;
 		let ret: Box<dyn WitnessColViewMut<_>> = match tower_level {
 			0 => Box::new(WitnessColViewImpl(RefMut::map(col_ref, |packed| {
 				PackedExtension::<B1>::cast_bases_mut(packed)
@@ -1283,7 +1301,7 @@ mod tests {
 	use std::{array, iter::repeat_with};
 
 	use assert_matches::assert_matches;
-	use binius_core::oracle::MultilinearOracleSet;
+	use binius_core::oracle::{MultilinearOracleSet, OracleId};
 	use binius_field::{
 		arch::{OptimalUnderlier128b, OptimalUnderlier256b},
 		packed::{len_packed_slice, set_packed_slice},
@@ -1293,7 +1311,7 @@ mod tests {
 	use super::*;
 	use crate::builder::{
 		ConstraintSystem, Statement, TableBuilder,
-		types::{B1, B8, B32},
+		types::{B1, B8, B16, B32},
 	};
 
 	#[test]
@@ -1674,12 +1692,12 @@ mod tests {
 			.collect::<Vec<_>>();
 		{
 			let mut data: Box<dyn WitnessColViewMut<_>> =
-				segment.get_dyn_mut(test_col.table_index).unwrap();
+				segment.get_dyn_mut(test_col.id()).unwrap();
 			row.iter().enumerate().for_each(|(i, val)| {
 				data.set(i, (*val).into()).unwrap();
 			})
 		}
-		let data = segment.get_dyn(test_col.table_index).unwrap();
+		let data = segment.get_dyn(test_col.id()).unwrap();
 		row.iter().enumerate().for_each(|(i, val)| {
 			let down_cast: B32 = data.get(i).try_into().unwrap();
 			assert_eq!(down_cast, *val)
@@ -1712,18 +1730,19 @@ mod tests {
 		let allocator = Bump::new();
 
 		let table_size = 123;
+		let statement = Statement {
+			boundaries: vec![],
+			table_sizes: vec![table_size],
+		};
+		let ccs = cs.compile(&statement).unwrap();
 		let mut index = WitnessIndex::<PackedType<OptimalUnderlier, B128>>::new(&cs, &allocator);
 
 		{
 			let _ = index.init_table(table_id, table_size).unwrap();
 			index.fill_constant_cols().unwrap();
 		}
-		let statement = Statement {
-			boundaries: vec![],
-			table_sizes: vec![table_size],
-		};
+
 		let witness = index.into_multilinear_extension_index();
-		let ccs = cs.compile(&statement).unwrap();
 		let non_packed_col_id = find_oracle_id_with_name(&ccs.oracles, "unpacked_col").unwrap();
 
 		// Query MultilinearExtensionIndex to see if the constants are correct.


### PR DESCRIPTION
This changeset aims to fix the implicit dependency of the witness on the order
of oracles added in `ConstraintSystem::compile`.. See [CRY-356] for more
details.

This does several things:

1. Prefers using ColumnId over indices
2. Introduction of `OracleLookup`

This starts using the ColumnId where possible. This change should really make
much less likely to confuse indices and improve general type-safety, and as well
as simplify the code a bit (one type is better than multiple). However, this
makes the column IDs to carry table_id around, but I don't think this is a
problem since the code is not hot.

Introduction the `OracleLookup` type. Prior this changeset
the data about which oracle came from which columns was lost. This type
is meant to store this information explicitly to be read by the witness
handling code.

This opens up for other use-cases where you might want to pass some data
from the compilation process into the witness generation, as that seems to be
inherently important: compilation creates oracles from columns and witness
filling operates on oracles.

Ideally though IMO we should really introduce a special type that represents
the compilation output:

1. `TableStat` should be a function of the compiled constraint system. That
   said, we can easily account for that.
2. Warnings. Optionally catch silly things like a committed column that is not
   referenced in a virtual column or a constraint.
3. It will also contain the data similiar to OracleLookup.

[CRY-356]: https://linear.app/irreducible/issue/CRY-356/dont-assume-the-order-of-compilation-of-oracles