### PR TITLE
[m3] slap track_caller on assert_balanced

### DIFF
--- a/crates/m3/src/emulate.rs
+++ b/crates/m3/src/emulate.rs
@@ -55,6 +55,7 @@ impl<T: Eq + PartialEq + Ord + PartialOrd> Channel<T> {
 }
 
 impl<T: Debug + Ord + PartialOrd> Channel<T> {
+	#[track_caller]
 	pub fn assert_balanced(&self) {
 		if !self.is_balanced() {
 			let (push, pull) = self


### PR DESCRIPTION
What this does is it improves the experience when running without RUST_BACKTRACE
=1.

Specifically, if we changed the collatz example to pull 2 instead of 1, we
would get the panic message below. Note the source of panic, it points to the
collatz code rather than the Channel code.

    thread 'model::test_collatz_high_level_validation' panicked at crates/m3/tests/collatz.rs:53:27:
    Channel is not balanced:
      Unbalanced pushes:
        1: 1
      Unbalanced pulls:
        1: 2