### PR TITLE
[ntt] Add coset_bits parameter to AdditiveNTT

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -37,6 +37,7 @@ transpose.workspace = true
 [dev-dependencies]
 binius_macros = { path = "../macros", default-features = false }
 criterion.workspace = true
+proptest.workspace = true
 rand = { workspace = true, features = ["std"] }
 
 [lib]

--- a/crates/core/src/protocols/fri/tests.rs
+++ b/crates/core/src/protocols/fri/tests.rs
@@ -3,15 +3,15 @@
 use std::{iter::repeat_with, vec};
 
 use binius_field::{
-	arch::{packed_64::PackedBinaryField4x16b, OptimalUnderlier128b},
+	BinaryField, BinaryField16b, BinaryField32b, BinaryField128b, ExtensionField,
+	PackedBinaryField16x16b, PackedField, TowerField,
+	arch::{OptimalUnderlier128b, packed_64::PackedBinaryField4x16b},
 	as_packed_field::{PackScalar, PackedType},
 	underlier::UnderlierType,
-	BinaryField, BinaryField128b, BinaryField16b, BinaryField32b, ExtensionField,
-	PackedBinaryField16x16b, PackedField, TowerField,
 };
-use binius_hal::{make_portable_backend, ComputationBackendExt};
+use binius_hal::{ComputationBackendExt, make_portable_backend};
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
-use binius_math::{fold_right, MultilinearExtension, MultilinearQuery};
+use binius_math::{MultilinearExtension, MultilinearQuery, fold_right};
 use binius_maybe_rayon::prelude::ParallelIterator;
 use binius_ntt::{AdditiveNTT, NTTShape, SingleThreadedNTT};
 use binius_utils::checked_arithmetics::log2_strict_usize;
@@ -24,8 +24,8 @@ use crate::{
 	fiat_shamir::{CanSample, HasherChallenger},
 	merkle_tree::{BinaryMerkleTreeProver, MerkleTreeProver},
 	protocols::fri::{
-		self, to_par_scalar_small_chunks, CommitOutput, FRIFolder, FRIParams, FRIVerifier,
-		FoldRoundOutput,
+		self, CommitOutput, FRIFolder, FRIParams, FRIVerifier, FoldRoundOutput,
+		to_par_scalar_small_chunks,
 	},
 	reed_solomon::reed_solomon::ReedSolomonCode,
 	transcript::ProverTranscript,

--- a/crates/core/src/protocols/fri/tests.rs
+++ b/crates/core/src/protocols/fri/tests.rs
@@ -3,31 +3,97 @@
 use std::{iter::repeat_with, vec};
 
 use binius_field::{
-	BinaryField, BinaryField16b, BinaryField32b, BinaryField128b, ExtensionField,
-	PackedBinaryField16x16b, PackedField, TowerField,
-	arch::{OptimalUnderlier128b, packed_64::PackedBinaryField4x16b},
+	arch::{packed_64::PackedBinaryField4x16b, OptimalUnderlier128b},
 	as_packed_field::{PackScalar, PackedType},
 	underlier::UnderlierType,
+	BinaryField, BinaryField128b, BinaryField16b, BinaryField32b, ExtensionField,
+	PackedBinaryField16x16b, PackedField, TowerField,
 };
-use binius_hal::{ComputationBackendExt, make_portable_backend};
+use binius_hal::{make_portable_backend, ComputationBackendExt};
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
-use binius_math::MultilinearExtension;
+use binius_math::{fold_right, MultilinearExtension, MultilinearQuery};
 use binius_maybe_rayon::prelude::ParallelIterator;
-use binius_ntt::SingleThreadedNTT;
+use binius_ntt::{AdditiveNTT, NTTShape, SingleThreadedNTT};
 use binius_utils::checked_arithmetics::log2_strict_usize;
+use bytemuck::zeroed_vec;
+use proptest::prelude::*;
 use rand::prelude::*;
 
-use super::to_par_scalar_big_chunks;
+use super::{fold_interleaved, to_par_scalar_big_chunks};
 use crate::{
 	fiat_shamir::{CanSample, HasherChallenger},
 	merkle_tree::{BinaryMerkleTreeProver, MerkleTreeProver},
 	protocols::fri::{
-		self, CommitOutput, FRIFolder, FRIParams, FRIVerifier, FoldRoundOutput,
-		to_par_scalar_small_chunks,
+		self, to_par_scalar_small_chunks, CommitOutput, FRIFolder, FRIParams, FRIVerifier,
+		FoldRoundOutput,
 	},
 	reed_solomon::reed_solomon::ReedSolomonCode,
 	transcript::ProverTranscript,
 };
+
+proptest! {
+	#[test]
+	fn test_fri_compatible_ntt_domains(log_dim in 0..8usize, arity in 0..4usize) {
+		test_help_fri_compatible_ntt_domains(log_dim, arity);
+	}
+}
+
+fn test_help_fri_compatible_ntt_domains(log_dim: usize, arity: usize) {
+	let ntt = SingleThreadedNTT::<BinaryField32b>::new(32).unwrap();
+
+	let msg = repeat_with(|| BinaryField32b::random(&mut thread_rng()))
+		.take(1 << (log_dim + arity))
+		.collect::<Vec<_>>();
+	let challenges = repeat_with(|| BinaryField32b::random(&mut thread_rng()))
+		.take(arity)
+		.collect::<Vec<_>>();
+
+	let query = MultilinearQuery::expand(&challenges).into_expansion();
+
+	// Fold the message using regular folding.
+	let mut folded_msg = zeroed_vec(1 << log_dim);
+	fold_right::<BinaryField32b, BinaryField32b>(
+		&msg,
+		log_dim + arity,
+		&query,
+		arity,
+		&mut folded_msg,
+	)
+	.unwrap();
+
+	// Encode the message over the large domain.
+	let mut codeword = msg.clone();
+	ntt.forward_transform(
+		&mut codeword,
+		NTTShape {
+			log_y: log_dim + arity,
+			..Default::default()
+		},
+		0,
+		0,
+		0,
+	)
+	.unwrap();
+
+	// Fold the encoded message using FRI folding.
+	let folded_codeword = fold_interleaved(&ntt, &codeword, &challenges, log_dim + arity, 0);
+
+	// Encode the folded message.
+	ntt.forward_transform(
+		&mut folded_msg,
+		NTTShape {
+			log_y: log_dim,
+			..Default::default()
+		},
+		0,
+		0,
+		0,
+	)
+	.unwrap();
+
+	// Check that folding and encoding commute.
+	assert_eq!(folded_codeword, folded_msg);
+}
 
 fn test_commit_prove_verify_success<U, F, FA>(
 	log_dimension: usize,

--- a/crates/core/src/protocols/fri/tests.rs
+++ b/crates/core/src/protocols/fri/tests.rs
@@ -62,7 +62,7 @@ fn test_help_fri_compatible_ntt_domains(log_dim: usize, arity: usize) {
 	.unwrap();
 
 	// Encode the message over the large domain.
-	let mut codeword = msg.clone();
+	let mut codeword = msg;
 	ntt.forward_transform(
 		&mut codeword,
 		NTTShape {

--- a/crates/core/src/protocols/sumcheck/prove/univariate.rs
+++ b/crates/core/src/protocols/sumcheck/prove/univariate.rs
@@ -3,10 +3,10 @@
 use std::{collections::HashMap, iter::repeat_n};
 
 use binius_field::{
+	BinaryField, ExtensionField, Field, PackedExtension, PackedField, PackedSubfield, TowerField,
 	packed::{get_packed_slice, get_packed_slice_checked},
 	recast_packed_mut,
 	util::inner_product_unchecked,
-	BinaryField, ExtensionField, Field, PackedExtension, PackedField, PackedSubfield, TowerField,
 };
 use binius_hal::ComputationBackend;
 use binius_math::{
@@ -26,13 +26,13 @@ use tracing::instrument;
 use crate::{
 	composition::{BivariateProduct, IndexComposition},
 	protocols::sumcheck::{
+		Error,
 		common::{equal_n_vars_check, small_field_embedding_degree_check},
 		prove::{
-			logging::{ExpandQueryData, UnivariateSkipCalculateCoeffsData},
 			RegularSumcheckProver,
+			logging::{ExpandQueryData, UnivariateSkipCalculateCoeffsData},
 		},
 		zerocheck::{domain_size, extrapolated_scalars_count},
-		Error,
 	},
 };
 
@@ -626,9 +626,11 @@ where
 		ntt.forward_transform(round_evals, shape, 0, 0, 0)?;
 
 		// Sanity check: first 1 << skip_rounds evals are still zeros.
-		debug_assert!(round_evals[..1 << skip_rounds]
-			.iter()
-			.all(|&coeff| coeff == F::ZERO));
+		debug_assert!(
+			round_evals[..1 << skip_rounds]
+				.iter()
+				.all(|&coeff| coeff == F::ZERO)
+		);
 
 		// Trim the result.
 		round_evals.resize(max_domain_size, F::ZERO);
@@ -687,16 +689,16 @@ mod tests {
 	use std::sync::Arc;
 
 	use binius_field::{
+		BinaryField1b, BinaryField8b, BinaryField16b, BinaryField128b, ExtensionField, Field,
+		PackedBinaryField4x32b, PackedExtension, PackedField, PackedFieldIndexable, TowerField,
 		arch::{OptimalUnderlier128b, OptimalUnderlier512b},
 		as_packed_field::{PackScalar, PackedType},
 		underlier::UnderlierType,
-		BinaryField128b, BinaryField16b, BinaryField1b, BinaryField8b, ExtensionField, Field,
-		PackedBinaryField4x32b, PackedExtension, PackedField, PackedFieldIndexable, TowerField,
 	};
 	use binius_hal::make_portable_backend;
 	use binius_math::{BinarySubspace, CompositionPoly, EvaluationDomain, MultilinearPoly};
 	use binius_ntt::SingleThreadedNTT;
-	use rand::{prelude::StdRng, SeedableRng};
+	use rand::{SeedableRng, prelude::StdRng};
 
 	use crate::{
 		composition::{IndexComposition, ProductComposition},
@@ -861,10 +863,12 @@ mod tests {
 
 			// naive computation of the univariate skip output
 			let round_evals_len = 4usize << skip_rounds;
-			assert!(output
-				.round_evals
-				.iter()
-				.all(|round_evals| round_evals.len() == round_evals_len));
+			assert!(
+				output
+					.round_evals
+					.iter()
+					.all(|round_evals| round_evals.len() == round_evals_len)
+			);
 
 			let compositions = compositions
 				.iter()

--- a/crates/core/src/protocols/sumcheck/prove/univariate.rs
+++ b/crates/core/src/protocols/sumcheck/prove/univariate.rs
@@ -3,10 +3,10 @@
 use std::{collections::HashMap, iter::repeat_n};
 
 use binius_field::{
-	BinaryField, ExtensionField, Field, PackedExtension, PackedField, PackedSubfield, TowerField,
 	packed::{get_packed_slice, get_packed_slice_checked},
 	recast_packed_mut,
 	util::inner_product_unchecked,
+	BinaryField, ExtensionField, Field, PackedExtension, PackedField, PackedSubfield, TowerField,
 };
 use binius_hal::ComputationBackend;
 use binius_math::{
@@ -26,13 +26,13 @@ use tracing::instrument;
 use crate::{
 	composition::{BivariateProduct, IndexComposition},
 	protocols::sumcheck::{
-		Error,
 		common::{equal_n_vars_check, small_field_embedding_degree_check},
 		prove::{
-			RegularSumcheckProver,
 			logging::{ExpandQueryData, UnivariateSkipCalculateCoeffsData},
+			RegularSumcheckProver,
 		},
 		zerocheck::{domain_size, extrapolated_scalars_count},
+		Error,
 	},
 };
 
@@ -626,11 +626,9 @@ where
 		ntt.forward_transform(round_evals, shape, 0, 0)?;
 
 		// Sanity check: first 1 << skip_rounds evals are still zeros.
-		debug_assert!(
-			round_evals[..1 << skip_rounds]
-				.iter()
-				.all(|&coeff| coeff == F::ZERO)
-		);
+		debug_assert!(round_evals[..1 << skip_rounds]
+			.iter()
+			.all(|&coeff| coeff == F::ZERO));
 
 		// Trim the result.
 		round_evals.resize(max_domain_size, F::ZERO);
@@ -687,16 +685,16 @@ mod tests {
 	use std::sync::Arc;
 
 	use binius_field::{
-		BinaryField1b, BinaryField8b, BinaryField16b, BinaryField128b, ExtensionField, Field,
-		PackedBinaryField4x32b, PackedExtension, PackedField, PackedFieldIndexable, TowerField,
 		arch::{OptimalUnderlier128b, OptimalUnderlier512b},
 		as_packed_field::{PackScalar, PackedType},
 		underlier::UnderlierType,
+		BinaryField128b, BinaryField16b, BinaryField1b, BinaryField8b, ExtensionField, Field,
+		PackedBinaryField4x32b, PackedExtension, PackedField, PackedFieldIndexable, TowerField,
 	};
 	use binius_hal::make_portable_backend;
 	use binius_math::{BinarySubspace, CompositionPoly, EvaluationDomain, MultilinearPoly};
 	use binius_ntt::SingleThreadedNTT;
-	use rand::{SeedableRng, prelude::StdRng};
+	use rand::{prelude::StdRng, SeedableRng};
 
 	use crate::{
 		composition::{IndexComposition, ProductComposition},
@@ -861,12 +859,10 @@ mod tests {
 
 			// naive computation of the univariate skip output
 			let round_evals_len = 4usize << skip_rounds;
-			assert!(
-				output
-					.round_evals
-					.iter()
-					.all(|round_evals| round_evals.len() == round_evals_len)
-			);
+			assert!(output
+				.round_evals
+				.iter()
+				.all(|round_evals| round_evals.len() == round_evals_len));
 
 			let compositions = compositions
 				.iter()

--- a/crates/core/src/protocols/sumcheck/prove/univariate.rs
+++ b/crates/core/src/protocols/sumcheck/prove/univariate.rs
@@ -608,7 +608,8 @@ where
 			let ell = n.trailing_zeros() as usize;
 			assert!(ell >= skip_rounds);
 
-			OddInterpolate::new(n >> ell, ell, ntt.twiddles())
+			let coset_bits = ntt.log_domain_size() - ell;
+			OddInterpolate::new(n >> ell, ell, coset_bits, ntt.twiddles())
 				.expect("domain large enough by construction")
 		});
 
@@ -658,8 +659,7 @@ where
 		log_z: log_batch,
 	};
 
-	let n_chunks = extrapolated_evals.len() / evals.len();
-	let coset_bits = min_bits(n_chunks);
+	let coset_bits = ntt.log_domain_size() - skip_rounds;
 
 	// Inverse NTT: convert evals to novel basis representation
 	ntt.inverse_transform(evals, shape, 0, coset_bits, 0)?;

--- a/crates/core/src/protocols/sumcheck/prove/univariate.rs
+++ b/crates/core/src/protocols/sumcheck/prove/univariate.rs
@@ -660,7 +660,7 @@ where
 	let coset_bits = min_bits(n_chunks);
 
 	// Inverse NTT: convert evals to novel basis representation
-	ntt.inverse_transform(evals, shape, 0, 0, 0)?;
+	ntt.inverse_transform(evals, shape, 0, coset_bits, 0)?;
 
 	// Forward NTT: evaluate novel basis representation at consecutive cosets
 	for (coset, extrapolated_chunk) in izip!(1.., extrapolated_evals.chunks_exact_mut(evals.len()))

--- a/crates/core/src/reed_solomon/reed_solomon.rs
+++ b/crates/core/src/reed_solomon/reed_solomon.rs
@@ -143,7 +143,7 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 			log_y: self.log_len(),
 			..Default::default()
 		};
-		ntt.forward_transform(code, shape, 0, self.log_inv_rate)?;
+		ntt.forward_transform(code, shape, 0, 0, self.log_inv_rate)?;
 		Ok(())
 	}
 

--- a/crates/ntt/benches/additive_ntt.rs
+++ b/crates/ntt/benches/additive_ntt.rs
@@ -3,14 +3,14 @@
 use std::{iter::repeat_with, mem};
 
 use binius_field::{
+	BinaryField, PackedBinaryField4x32b, PackedBinaryField8x16b, PackedBinaryField8x32b,
+	PackedBinaryField16x16b, PackedField,
 	arch::byte_sliced::{ByteSlicedAES32x16b, ByteSlicedAES32x32b},
-	BinaryField, PackedBinaryField16x16b, PackedBinaryField4x32b, PackedBinaryField8x16b,
-	PackedBinaryField8x32b, PackedField,
 };
 use binius_ntt::{AdditiveNTT, NTTShape, SingleThreadedNTT};
 use criterion::{
-	criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId, Criterion,
-	Throughput,
+	BenchmarkGroup, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
+	measurement::WallTime,
 };
 use rand::thread_rng;
 

--- a/crates/ntt/benches/additive_ntt.rs
+++ b/crates/ntt/benches/additive_ntt.rs
@@ -3,14 +3,14 @@
 use std::{iter::repeat_with, mem};
 
 use binius_field::{
-	BinaryField, PackedBinaryField4x32b, PackedBinaryField8x16b, PackedBinaryField8x32b,
-	PackedBinaryField16x16b, PackedField,
 	arch::byte_sliced::{ByteSlicedAES32x16b, ByteSlicedAES32x32b},
+	BinaryField, PackedBinaryField16x16b, PackedBinaryField4x32b, PackedBinaryField8x16b,
+	PackedBinaryField8x32b, PackedField,
 };
 use binius_ntt::{AdditiveNTT, NTTShape, SingleThreadedNTT};
 use criterion::{
-	BenchmarkGroup, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
-	measurement::WallTime,
+	criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId, Criterion,
+	Throughput,
 };
 use rand::thread_rng;
 
@@ -136,7 +136,7 @@ fn bench_forward_transform(c: &mut Criterion) {
 				..Default::default()
 			};
 			group.bench_function(BenchmarkId::new(name, param), |b| {
-				b.iter(|| ntt.forward_transform(data, shape, 0, 0));
+				b.iter(|| ntt.forward_transform(data, shape, 0, 0, 0));
 			});
 		}
 	}
@@ -166,7 +166,7 @@ fn bench_inverse_transform(c: &mut Criterion) {
 				..Default::default()
 			};
 			group.bench_function(BenchmarkId::new(name, param), |b| {
-				b.iter(|| ntt.inverse_transform(data, shape, 0, 0));
+				b.iter(|| ntt.inverse_transform(data, shape, 0, 0, 0));
 			});
 		}
 	}

--- a/crates/ntt/benches/large_transform.rs
+++ b/crates/ntt/benches/large_transform.rs
@@ -3,13 +3,13 @@
 use std::iter::repeat_with;
 
 use binius_field::{
+	AESTowerField32b, AESTowerField128b, BinaryField32b, BinaryField128b, BinaryField128bPolyval,
+	PackedExtension, TowerField,
 	arch::{OptimalUnderlier, OptimalUnderlierByteSliced},
 	as_packed_field::PackedType,
-	AESTowerField128b, AESTowerField32b, BinaryField128b, BinaryField128bPolyval, BinaryField32b,
-	PackedExtension, TowerField,
 };
 use binius_ntt::{AdditiveNTT, NTTShape, SingleThreadedNTT};
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use rand::thread_rng;
 
 fn bench_large_transform<F: TowerField, PE: PackedExtension<F>>(c: &mut Criterion, field: &str) {

--- a/crates/ntt/benches/large_transform.rs
+++ b/crates/ntt/benches/large_transform.rs
@@ -3,13 +3,13 @@
 use std::iter::repeat_with;
 
 use binius_field::{
-	AESTowerField32b, AESTowerField128b, BinaryField32b, BinaryField128b, BinaryField128bPolyval,
-	PackedExtension, TowerField,
 	arch::{OptimalUnderlier, OptimalUnderlierByteSliced},
 	as_packed_field::PackedType,
+	AESTowerField128b, AESTowerField32b, BinaryField128b, BinaryField128bPolyval, BinaryField32b,
+	PackedExtension, TowerField,
 };
 use binius_ntt::{AdditiveNTT, NTTShape, SingleThreadedNTT};
-use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use rand::thread_rng;
 
 fn bench_large_transform<F: TowerField, PE: PackedExtension<F>>(c: &mut Criterion, field: &str) {
@@ -35,7 +35,7 @@ fn bench_large_transform<F: TowerField, PE: PackedExtension<F>>(c: &mut Criterio
 				.unwrap()
 				.precompute_twiddles();
 			group.bench_function(BenchmarkId::new("single-thread/precompute", &params), |b| {
-				b.iter(|| ntt.forward_transform_ext(&mut data, shape, 0, 0));
+				b.iter(|| ntt.forward_transform_ext(&mut data, shape, 0, 0, 0));
 			});
 
 			let ntt = SingleThreadedNTT::<F>::new(log_dim)
@@ -43,7 +43,7 @@ fn bench_large_transform<F: TowerField, PE: PackedExtension<F>>(c: &mut Criterio
 				.precompute_twiddles()
 				.multithreaded();
 			group.bench_function(BenchmarkId::new("multithread/precompute", &params), |b| {
-				b.iter(|| ntt.forward_transform_ext(&mut data, shape, 0, 0));
+				b.iter(|| ntt.forward_transform_ext(&mut data, shape, 0, 0, 0));
 			});
 		}
 	}

--- a/crates/ntt/src/additive_ntt.rs
+++ b/crates/ntt/src/additive_ntt.rs
@@ -44,7 +44,7 @@ pub struct NTTShape {
 ///
 /// An [`AdditiveNTT`] implementation with a maximum domain dimension of $\ell$ can be applied on
 /// a sequence of  $\ell + 1$ evaluation domains of sizes $2^0, \ldots, 2^\ell$. These are the
-/// domains $S^(0), \ldots, S^(\ell)$ defined in [DP24] Section 3. The methods
+/// domains $S^(0), \ldots, S^(\ell)$ defined in [DP24] Section 4. The methods
 /// [`Self::forward_transform`] and [`Self::inverse_transform`] require a parameter
 /// `log_domain_size` that indicates which of the $S^(i)$ domains to use for the transformation's
 /// evaluation domain and novel polynomial basis. (Remember, the novel polynomial basis is itself

--- a/crates/ntt/src/additive_ntt.rs
+++ b/crates/ntt/src/additive_ntt.rs
@@ -82,7 +82,8 @@ pub trait AdditiveNTT<F: BinaryField> {
 		&self,
 		data: &mut [P],
 		shape: NTTShape,
-		coset: u32,
+		coset: usize,
+		coset_bits: usize,
 		skip_rounds: usize,
 	) -> Result<(), Error>;
 
@@ -103,7 +104,8 @@ pub trait AdditiveNTT<F: BinaryField> {
 		&self,
 		data: &mut [P],
 		shape: NTTShape,
-		coset: u32,
+		coset: usize,
+		coset_bits: usize,
 		skip_rounds: usize,
 	) -> Result<(), Error>;
 
@@ -111,27 +113,29 @@ pub trait AdditiveNTT<F: BinaryField> {
 		&self,
 		data: &mut [PE],
 		shape: NTTShape,
-		coset: u32,
+		coset: usize,
+		coset_bits: usize,
 		skip_rounds: usize,
 	) -> Result<(), Error> {
 		let shape_ext = NTTShape {
 			log_x: shape.log_x + PE::Scalar::LOG_DEGREE,
 			..shape
 		};
-		self.forward_transform(PE::cast_bases_mut(data), shape_ext, coset, skip_rounds)
+		self.forward_transform(PE::cast_bases_mut(data), shape_ext, coset, coset_bits, skip_rounds)
 	}
 
 	fn inverse_transform_ext<PE: PackedExtension<F>>(
 		&self,
 		data: &mut [PE],
 		shape: NTTShape,
-		coset: u32,
+		coset: usize,
+		coset_bits: usize,
 		skip_rounds: usize,
 	) -> Result<(), Error> {
 		let shape_ext = NTTShape {
 			log_x: shape.log_x + PE::Scalar::LOG_DEGREE,
 			..shape
 		};
-		self.inverse_transform(PE::cast_bases_mut(data), shape_ext, coset, skip_rounds)
+		self.inverse_transform(PE::cast_bases_mut(data), shape_ext, coset, coset_bits, skip_rounds)
 	}
 }

--- a/crates/ntt/src/additive_ntt.rs
+++ b/crates/ntt/src/additive_ntt.rs
@@ -42,6 +42,17 @@ pub struct NTTShape {
 /// domain. The inverse transformation interpolates polynomial values over the domain into novel
 /// polynomial basis coefficients.
 ///
+/// An [`AdditiveNTT`] implementation with a maximum domain dimension of $\ell$ can be applied on
+/// a sequence of  $\ell + 1$ evaluation domains of sizes $2^0, \ldots, 2^\ell$. These are the
+/// domains $S^(0), \ldots, S^(\ell)$ defined in [DP24] Section 3. The methods
+/// [`Self::forward_transform`] and [`Self::inverse_transform`] require a parameter
+/// `log_domain_size` that indicates which of the $S^(i)$ domains to use for the transformation's
+/// evaluation domain and novel polynomial basis. (Remember, the novel polynomial basis is itself
+/// parameterized by basis). **Counterintuitively, the field subspace $S^(i)$ is not necessarily a
+/// subset of $S^(i+1)$**. We choose this behavior for the [`AdditiveNTT`] trait because it
+/// facilitates compatibility with FRI when batching proximity tests for codewords of different
+/// dimensions.
+///
 /// [LCH14]: <https://arxiv.org/abs/1404.3458>
 /// [DP24]: <https://eprint.iacr.org/2024/504>
 pub trait AdditiveNTT<F: BinaryField> {
@@ -70,7 +81,11 @@ pub trait AdditiveNTT<F: BinaryField> {
 	/// The scalars of `data`, viewed in natural order, represent a tensor of `shape` dimensions.
 	/// See [`NTTShape`] for layout details. The transform is inplace, output adheres to `shape`.
 	///
-	/// The `coset` specifies the evaluation domain as an indexed coset of the subspace.
+	/// The `coset` specifies the evaluation domain as an indexed coset of the subspace. The coset
+	/// index must representable in `coset_bits` bits. The evaluation domain of the NTT is chosen
+	/// to be the subspace $S^{(i)}$ with dimension `shape.log_y + coset_bits`. Choosing the NTT
+	/// domain in this way ensures consistency of the domains when using FRI with different
+	/// codeword lengths.
 	///
 	/// The transformation accepts a `skip_rounds` parameter, which is a number of NTT layers to
 	/// skip at the beginning of the forward transform. This corresponds to parallel NTTs on
@@ -92,7 +107,11 @@ pub trait AdditiveNTT<F: BinaryField> {
 	/// The scalars of `data`, viewed in natural order, represent a tensor of `shape` dimensions.
 	/// See [`NTTShape`] for layout details. The transform is inplace, output adheres to `shape`.
 	///
-	/// The `coset` specifies the evaluation domain as an indexed coset of the subspace.
+	/// The `coset` specifies the evaluation domain as an indexed coset of the subspace. The coset
+	/// index must representable in `coset_bits` bits. The evaluation domain of the NTT is chosen
+	/// to be the subspace $S^{(i)}$ with dimension `shape.log_y + coset_bits`. Choosing the NTT
+	/// domain in this way ensures consistency of the domains when using FRI with different
+	/// codeword lengths.
 	///
 	/// The transformation accepts a `skip_rounds` parameter, which is a number of NTT layers to
 	/// skip at the end of the inverse transform. This corresponds to parallel NTTs on multiple

--- a/crates/ntt/src/dynamic_dispatch.rs
+++ b/crates/ntt/src/dynamic_dispatch.rs
@@ -116,17 +116,22 @@ impl<F: BinaryField> AdditiveNTT<F> for DynamicDispatchNTT<F> {
 		&self,
 		data: &mut [P],
 		shape: NTTShape,
-		coset: u32,
+		coset: usize,
+		coset_bits: usize,
 		skip_rounds: usize,
 	) -> Result<(), Error> {
 		match self {
-			Self::SingleThreaded(ntt) => ntt.forward_transform(data, shape, coset, skip_rounds),
-			Self::SingleThreadedPrecompute(ntt) => {
-				ntt.forward_transform(data, shape, coset, skip_rounds)
+			Self::SingleThreaded(ntt) => {
+				ntt.forward_transform(data, shape, coset, coset_bits, skip_rounds)
 			}
-			Self::MultiThreaded(ntt) => ntt.forward_transform(data, shape, coset, skip_rounds),
+			Self::SingleThreadedPrecompute(ntt) => {
+				ntt.forward_transform(data, shape, coset, coset_bits, skip_rounds)
+			}
+			Self::MultiThreaded(ntt) => {
+				ntt.forward_transform(data, shape, coset, coset_bits, skip_rounds)
+			}
 			Self::MultiThreadedPrecompute(ntt) => {
-				ntt.forward_transform(data, shape, coset, skip_rounds)
+				ntt.forward_transform(data, shape, coset, coset_bits, skip_rounds)
 			}
 		}
 	}
@@ -135,17 +140,22 @@ impl<F: BinaryField> AdditiveNTT<F> for DynamicDispatchNTT<F> {
 		&self,
 		data: &mut [P],
 		shape: NTTShape,
-		coset: u32,
+		coset: usize,
+		coset_bits: usize,
 		skip_rounds: usize,
 	) -> Result<(), Error> {
 		match self {
-			Self::SingleThreaded(ntt) => ntt.inverse_transform(data, shape, coset, skip_rounds),
-			Self::SingleThreadedPrecompute(ntt) => {
-				ntt.inverse_transform(data, shape, coset, skip_rounds)
+			Self::SingleThreaded(ntt) => {
+				ntt.inverse_transform(data, shape, coset, coset_bits, skip_rounds)
 			}
-			Self::MultiThreaded(ntt) => ntt.inverse_transform(data, shape, coset, skip_rounds),
+			Self::SingleThreadedPrecompute(ntt) => {
+				ntt.inverse_transform(data, shape, coset, coset_bits, skip_rounds)
+			}
+			Self::MultiThreaded(ntt) => {
+				ntt.inverse_transform(data, shape, coset, coset_bits, skip_rounds)
+			}
 			Self::MultiThreadedPrecompute(ntt) => {
-				ntt.inverse_transform(data, shape, coset, skip_rounds)
+				ntt.inverse_transform(data, shape, coset, coset_bits, skip_rounds)
 			}
 		}
 	}

--- a/crates/ntt/src/error.rs
+++ b/crates/ntt/src/error.rs
@@ -20,6 +20,8 @@ pub enum Error {
 	BatchTooLarge,
 	#[error("the skip_rounds parameter exceeds the total number of NTT rounds")]
 	SkipRoundsTooLarge,
+	#[error("coset index must be less than 2**{coset_bits}, got {coset}")]
+	CosetIndexOutOfBounds { coset: usize, coset_bits: usize },
 	#[error("odd interpolation length mismatch, expected to be exactly {expected_len}")]
 	OddInterpolateIncorrectLength { expected_len: usize },
 	#[error("math error: {0}")]

--- a/crates/ntt/src/multithreaded.rs
+++ b/crates/ntt/src/multithreaded.rs
@@ -8,7 +8,7 @@ use binius_utils::rayon::get_log_max_threads;
 use super::{
 	additive_ntt::{AdditiveNTT, NTTShape},
 	error::Error,
-	single_threaded::{self, SingleThreadedNTT, check_batch_transform_inputs_and_params},
+	single_threaded::{self, check_batch_transform_inputs_and_params, SingleThreadedNTT},
 	strided_array::StridedArray2DViewMut,
 	twiddle::TwiddleAccess,
 };
@@ -62,7 +62,8 @@ where
 		&self,
 		data: &mut [P],
 		shape: NTTShape,
-		coset: u32,
+		coset: usize,
+		coset_bits: usize,
 		skip_rounds: usize,
 	) -> Result<(), Error> {
 		forward_transform(
@@ -71,6 +72,7 @@ where
 			data,
 			shape,
 			coset,
+			coset_bits,
 			skip_rounds,
 			self.log_max_threads,
 		)
@@ -80,7 +82,8 @@ where
 		&self,
 		data: &mut [P],
 		shape: NTTShape,
-		coset: u32,
+		coset: usize,
+		coset_bits: usize,
 		skip_rounds: usize,
 	) -> Result<(), Error> {
 		inverse_transform(
@@ -89,6 +92,7 @@ where
 			data,
 			shape,
 			coset,
+			coset_bits,
 			skip_rounds,
 			self.log_max_threads,
 		)
@@ -101,11 +105,19 @@ fn forward_transform<F: BinaryField, P: PackedField<Scalar = F>>(
 	s_evals: &[impl TwiddleAccess<F> + Sync],
 	data: &mut [P],
 	shape: NTTShape,
-	coset: u32,
+	coset: usize,
+	coset_bits: usize,
 	skip_rounds: usize,
 	log_max_threads: usize,
 ) -> Result<(), Error> {
-	check_batch_transform_inputs_and_params(log_domain_size, data, shape, coset, skip_rounds)?;
+	check_batch_transform_inputs_and_params(
+		log_domain_size,
+		data,
+		shape,
+		coset,
+		coset_bits,
+		skip_rounds,
+	)?;
 
 	match data.len() {
 		0 => return Ok(()),
@@ -118,6 +130,7 @@ fn forward_transform<F: BinaryField, P: PackedField<Scalar = F>>(
 					data,
 					shape,
 					coset,
+					coset_bits,
 					skip_rounds,
 				),
 			};
@@ -167,7 +180,7 @@ fn forward_transform<F: BinaryField, P: PackedField<Scalar = F>>(
 				// i indexes the layer of the NTT network, also the binary subspace.
 				for i in (0..par_rounds.saturating_sub(skip_rounds)).rev() {
 					let s_evals_par_i = &s_evals[log_y - par_rounds + i];
-					let coset_offset = (coset as usize) << (par_rounds - 1 - i);
+					let coset_offset = coset << (par_rounds - 1 - i);
 
 					// j indexes the outer Z tensor axis.
 					for j in 0..1 << log_z {
@@ -210,7 +223,8 @@ fn forward_transform<F: BinaryField, P: PackedField<Scalar = F>>(
 					log_y: single_thread_log_y,
 					log_z: log_row_z,
 				},
-				coset << par_rounds | inner_coset as u32,
+				coset << par_rounds | inner_coset,
+				coset_bits + par_rounds,
 				skip_rounds.saturating_sub(par_rounds),
 			)
 		})?;
@@ -224,11 +238,19 @@ fn inverse_transform<F: BinaryField, P: PackedField<Scalar = F>>(
 	s_evals: &[impl TwiddleAccess<F> + Sync],
 	data: &mut [P],
 	shape: NTTShape,
-	coset: u32,
+	coset: usize,
+	coset_bits: usize,
 	skip_rounds: usize,
 	log_max_threads: usize,
 ) -> Result<(), Error> {
-	check_batch_transform_inputs_and_params(log_domain_size, data, shape, coset, skip_rounds)?;
+	check_batch_transform_inputs_and_params(
+		log_domain_size,
+		data,
+		shape,
+		coset,
+		coset_bits,
+		skip_rounds,
+	)?;
 
 	match data.len() {
 		0 => return Ok(()),
@@ -241,6 +263,7 @@ fn inverse_transform<F: BinaryField, P: PackedField<Scalar = F>>(
 					data,
 					shape,
 					coset,
+					coset_bits,
 					skip_rounds,
 				),
 			};
@@ -291,7 +314,8 @@ fn inverse_transform<F: BinaryField, P: PackedField<Scalar = F>>(
 					log_y: single_thread_log_y,
 					log_z: log_row_z,
 				},
-				coset << par_rounds | inner_coset as u32,
+				coset << par_rounds | inner_coset,
+				coset_bits + par_rounds,
 				skip_rounds.saturating_sub(par_rounds),
 			)
 		})?;
@@ -309,7 +333,7 @@ fn inverse_transform<F: BinaryField, P: PackedField<Scalar = F>>(
 			// i indexes the layer of the NTT network, also the binary subspace.
 			for i in 0..par_rounds.saturating_sub(skip_rounds) {
 				let s_evals_par_i = &s_evals[log_y - par_rounds + i];
-				let coset_offset = (coset as usize) << (par_rounds - 1 - i);
+				let coset_offset = coset << (par_rounds - 1 - i);
 
 				// j indexes the outer Z tensor axis.
 				for j in 0..1 << log_z {

--- a/crates/ntt/src/multithreaded.rs
+++ b/crates/ntt/src/multithreaded.rs
@@ -8,7 +8,7 @@ use binius_utils::rayon::get_log_max_threads;
 use super::{
 	additive_ntt::{AdditiveNTT, NTTShape},
 	error::Error,
-	single_threaded::{self, check_batch_transform_inputs_and_params, SingleThreadedNTT},
+	single_threaded::{self, SingleThreadedNTT, check_batch_transform_inputs_and_params},
 	strided_array::StridedArray2DViewMut,
 	twiddle::TwiddleAccess,
 };

--- a/crates/ntt/src/multithreaded.rs
+++ b/crates/ntt/src/multithreaded.rs
@@ -335,6 +335,7 @@ fn inverse_transform<F: BinaryField, P: PackedField<Scalar = F>>(
 		.into_par_strides(1 << log_stride_len)
 		.for_each(|mut stride| {
 			// i indexes the layer of the NTT network, also the binary subspace.
+			#[allow(clippy::needless_range_loop)]
 			for i in 0..par_rounds.saturating_sub(skip_rounds) {
 				let s_evals_par_i = &s_evals[i];
 				let coset_offset = coset << (par_rounds - 1 - i);

--- a/crates/ntt/src/multithreaded.rs
+++ b/crates/ntt/src/multithreaded.rs
@@ -218,7 +218,7 @@ fn forward_transform<F: BinaryField, P: PackedField<Scalar = F>>(
 		.try_for_each(|(inner_coset, chunk)| {
 			single_threaded::forward_transform(
 				log_domain_size,
-				s_evals, //[0..log_y - par_rounds],
+				s_evals,
 				chunk,
 				NTTShape {
 					log_x,

--- a/crates/ntt/src/odd_interpolate.rs
+++ b/crates/ntt/src/odd_interpolate.rs
@@ -2,10 +2,7 @@
 
 use binius_field::BinaryField;
 use binius_math::Matrix;
-use binius_utils::{
-	bail,
-	checked_arithmetics::{log2_ceil_usize, min_bits},
-};
+use binius_utils::{bail, checked_arithmetics::log2_ceil_usize};
 
 use crate::{
 	additive_ntt::{AdditiveNTT, NTTShape},
@@ -67,7 +64,7 @@ impl<F: BinaryField> OddInterpolate<F> {
 			});
 		}
 
-		let coset_bits = min_bits(d);
+		let coset_bits = log2_ceil_usize(d);
 		let log_required_domain_size = coset_bits + ell;
 		if ntt.log_domain_size() < log_required_domain_size {
 			bail!(Error::DomainTooSmall {
@@ -132,7 +129,8 @@ where
 		});
 	}
 
-	for (j, twiddle_access_j_plus_ell) in twiddle_access[ell..ell + log_d].iter().enumerate() {
+	let twiddle_access = &twiddle_access[twiddle_access.len() - log_d..];
+	for (j, twiddle_access_j_plus_ell) in twiddle_access.iter().enumerate() {
 		assert!(twiddle_access_j_plus_ell.log_n() >= log_d - 1 - j);
 
 		for i in 0..d {

--- a/crates/ntt/src/odd_interpolate.rs
+++ b/crates/ntt/src/odd_interpolate.rs
@@ -155,7 +155,7 @@ mod tests {
 	use std::iter::repeat_with;
 
 	use binius_field::{BinaryField32b, Field};
-	use rand::{rngs::StdRng, SeedableRng};
+	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 	use crate::single_threaded::SingleThreadedNTT;

--- a/crates/ntt/src/odd_interpolate.rs
+++ b/crates/ntt/src/odd_interpolate.rs
@@ -13,20 +13,33 @@ use crate::{
 pub struct OddInterpolate<F: BinaryField> {
 	vandermonde_inverse: Matrix<F>,
 	ell: usize,
+	coset_bits: usize,
 }
 
 impl<F: BinaryField> OddInterpolate<F> {
 	/// Create a new odd interpolator into novel polynomial basis for domains of size $d \times
 	/// 2^{\ell}$. Takes a reference to NTT twiddle factors to seed the "Vandermonde" matrix and
 	/// compute its inverse. Time complexity is $\mathcal{O}(d^3).$
-	pub fn new<TA>(d: usize, ell: usize, twiddle_access: &[TA]) -> Result<Self, Error>
+	pub fn new<TA>(
+		d: usize,
+		ell: usize,
+		coset_bits: usize,
+		twiddle_access: &[TA],
+	) -> Result<Self, Error>
 	where
 		TA: TwiddleAccess<F>,
 	{
+		if d > (1 << coset_bits) {
+			bail!(Error::CosetIndexOutOfBounds {
+				coset: d - 1,
+				coset_bits
+			});
+		}
+
 		// TODO: This constructor should accept an `impl AdditiveNTT` instead of an
 		// `impl TwiddleAccess`. It can use `AdditiveNTT::get_subspace_eval` instead of the twiddle
 		// accessors directly. `AdditiveNTT` is a more public interface.
-		let vandermonde = novel_vandermonde(d, ell, twiddle_access)?;
+		let vandermonde = novel_vandermonde(d, ell, coset_bits, twiddle_access)?;
 
 		let mut vandermonde_inverse = Matrix::zeros(d, d);
 		vandermonde.inverse_into(&mut vandermonde_inverse)?;
@@ -34,6 +47,7 @@ impl<F: BinaryField> OddInterpolate<F> {
 		Ok(Self {
 			vandermonde_inverse,
 			ell,
+			coset_bits,
 		})
 	}
 
@@ -64,8 +78,7 @@ impl<F: BinaryField> OddInterpolate<F> {
 			});
 		}
 
-		let coset_bits = log2_ceil_usize(d);
-		let log_required_domain_size = coset_bits + ell;
+		let log_required_domain_size = self.coset_bits + ell;
 		if ntt.log_domain_size() < log_required_domain_size {
 			bail!(Error::DomainTooSmall {
 				log_required_domain_size
@@ -77,7 +90,7 @@ impl<F: BinaryField> OddInterpolate<F> {
 			..Default::default()
 		};
 		for (i, chunk) in data.chunks_exact_mut(1 << ell).enumerate() {
-			ntt.inverse_transform(chunk, shape, i, coset_bits, 0)?;
+			ntt.inverse_transform(chunk, shape, i, self.coset_bits, 0)?;
 		}
 
 		// Given M and a vector v, do the "strided product" M v. In more detail: we assume matrix is
@@ -104,7 +117,12 @@ impl<F: BinaryField> OddInterpolate<F> {
 /// $j^{\text{th}}$ element of the field with respect to the $\beta^{(\ell)}_i$ in little Endian
 /// order. The matrix has dimensions $d\times d$. The key trick is that
 /// $\widehat{W}^{(\ell)}_i(\beta^{\ell}_j) = $\widehat{W}_{i+\ell}(\beta_{j+\ell})$.
-fn novel_vandermonde<F, TA>(d: usize, ell: usize, twiddle_access: &[TA]) -> Result<Matrix<F>, Error>
+fn novel_vandermonde<F, TA>(
+	d: usize,
+	ell: usize,
+	coset_bits: usize,
+	twiddle_access: &[TA],
+) -> Result<Matrix<F>, Error>
 where
 	F: BinaryField,
 	TA: TwiddleAccess<F>,
@@ -122,16 +140,16 @@ where
 	// $X_0$ is the function "1".
 	(0..d).for_each(|j| x_ell[(j, 0)] = F::ONE);
 
-	let log_required_domain_size = log_d + ell;
+	let log_required_domain_size = coset_bits + ell;
 	if twiddle_access.len() < log_required_domain_size {
 		bail!(Error::DomainTooSmall {
 			log_required_domain_size
 		});
 	}
 
-	let twiddle_access = &twiddle_access[twiddle_access.len() - log_d..];
-	for (j, twiddle_access_j_plus_ell) in twiddle_access.iter().enumerate() {
-		assert!(twiddle_access_j_plus_ell.log_n() >= log_d - 1 - j);
+	let twiddle_access = &twiddle_access[twiddle_access.len() - coset_bits..];
+	for (j, twiddle_access_j_plus_ell) in twiddle_access.iter().take(log_d).enumerate() {
+		assert!(twiddle_access_j_plus_ell.log_n() >= coset_bits - 1 - j);
 
 		for i in 0..d {
 			x_ell[(i, 1 << j)] = twiddle_access_j_plus_ell.get(i >> (j + 1))
@@ -155,6 +173,7 @@ mod tests {
 	use std::iter::repeat_with;
 
 	use binius_field::{BinaryField32b, Field};
+	use binius_utils::checked_arithmetics::log2_ceil_usize;
 	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
@@ -187,7 +206,9 @@ mod tests {
 				ntt.forward_transform(&mut ntt_evals, shape, 0, 0, 0)
 					.unwrap();
 
-				let odd_interpolate = OddInterpolate::new(d, ell, &ntt.s_evals).unwrap();
+				let coset_bits = next_log_n.saturating_sub(ell);
+				let odd_interpolate =
+					OddInterpolate::new(d, ell, coset_bits, &ntt.s_evals).unwrap();
 				odd_interpolate
 					.inverse_transform(&ntt, &mut ntt_evals[..d << ell])
 					.unwrap();

--- a/crates/ntt/src/single_threaded.rs
+++ b/crates/ntt/src/single_threaded.rs
@@ -11,7 +11,7 @@ use super::{
 	error::Error,
 	twiddle::TwiddleAccess,
 };
-use crate::twiddle::{expand_subspace_evals, OnTheFlyTwiddleAccess, PrecomputedTwiddleAccess};
+use crate::twiddle::{OnTheFlyTwiddleAccess, PrecomputedTwiddleAccess, expand_subspace_evals};
 
 /// Implementation of `AdditiveNTT` that performs the computation single-threaded.
 #[derive(Debug)]
@@ -461,10 +461,10 @@ mod tests {
 
 	use assert_matches::assert_matches;
 	use binius_field::{
-		BinaryField16b, BinaryField8b, Field, PackedBinaryField8x16b, PackedFieldIndexable,
+		BinaryField8b, BinaryField16b, Field, PackedBinaryField8x16b, PackedFieldIndexable,
 	};
 	use binius_math::Error as MathError;
-	use rand::{rngs::StdRng, SeedableRng};
+	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 

--- a/crates/ntt/src/single_threaded.rs
+++ b/crates/ntt/src/single_threaded.rs
@@ -4,6 +4,7 @@ use std::{cmp, marker::PhantomData};
 
 use binius_field::{BinaryField, PackedField, TowerField};
 use binius_math::BinarySubspace;
+use binius_utils::bail;
 
 use super::{
 	additive_ntt::{AdditiveNTT, NTTShape},
@@ -375,10 +376,10 @@ pub fn check_batch_transform_inputs_and_params<PB: PackedField>(
 	} = shape;
 
 	if !data.len().is_power_of_two() {
-		return Err(Error::PowerOfTwoLengthRequired);
+		bail!(Error::PowerOfTwoLengthRequired);
 	}
 	if skip_rounds > log_y {
-		return Err(Error::SkipRoundsTooLarge);
+		bail!(Error::SkipRoundsTooLarge);
 	}
 
 	let full_sized_y = (data.len() * PB::WIDTH) >> (log_x + log_z);
@@ -386,18 +387,18 @@ pub fn check_batch_transform_inputs_and_params<PB: PackedField>(
 	// Verify that our log_y exactly matches the data length, except when we are NTT-ing one packed
 	// field
 	if (1 << log_y != full_sized_y && data.len() > 2) || (1 << log_y > full_sized_y) {
-		return Err(Error::BatchTooLarge);
+		bail!(Error::BatchTooLarge);
 	}
 
 	if coset >= (1 << coset_bits) {
-		return Err(Error::CosetIndexOutOfBounds { coset, coset_bits });
+		bail!(Error::CosetIndexOutOfBounds { coset, coset_bits });
 	}
 
 	// The domain size should be at least large enough to represent the given coset.
 	let log_required_domain_size = log_y + coset_bits;
 	if log_required_domain_size > log_domain_size {
-		return Err(Error::DomainTooSmall {
-			log_required_domain_size,
+		bail!(Error::DomainTooSmall {
+			log_required_domain_size
 		});
 	}
 

--- a/crates/ntt/src/single_threaded.rs
+++ b/crates/ntt/src/single_threaded.rs
@@ -190,6 +190,10 @@ pub fn forward_transform<F: BinaryField, P: PackedField<Scalar = F>>(
 	// packed base field elements.
 	let cutoff = log_w.saturating_sub(log_x);
 
+	// Choose the twiddle factors so that NTTs on differently sized domains, with the same
+	// coset_bits, share the beginning layer twiddles.
+	let s_evals = &s_evals[log_domain_size - (log_y + coset_bits)..];
+
 	// i indexes the layer of the NTT network, also the binary subspace.
 	for i in (cutoff..(log_y - skip_rounds)).rev() {
 		let s_evals_i = &s_evals[i];
@@ -299,6 +303,10 @@ pub fn inverse_transform<F: BinaryField, P: PackedField<Scalar = F>>(
 	// Cutoff is the stage of the NTT where each the butterfly units are contained within
 	// packed base field elements.
 	let cutoff = log_w.saturating_sub(log_x);
+
+	// Choose the twiddle factors so that NTTs on differently sized domains, with the same
+	// coset_bits, share the final layer twiddles.
+	let s_evals = &s_evals[log_domain_size - (log_y + coset_bits)..];
 
 	#[allow(clippy::needless_range_loop)]
 	for i in 0..cutoff.min(log_y - skip_rounds) {

--- a/crates/ntt/src/tests/ntt_tests.rs
+++ b/crates/ntt/src/tests/ntt_tests.rs
@@ -3,20 +3,20 @@
 use std::ops::Range;
 
 use binius_field::{
+	AESTowerField8b, BinaryField, BinaryField8b, ByteSlicedAES8x16x16b, ByteSlicedAES16x32x8b,
+	PackedBinaryField8x32b, PackedBinaryField16x32b, PackedBinaryField32x16b, PackedExtension,
+	PackedField, RepackedExtension,
 	arch::{
+		packed_8::PackedBinaryField1x8b,
 		packed_16::{PackedBinaryField1x16b, PackedBinaryField2x8b},
 		packed_32::PackedBinaryField2x16b,
 		packed_64::{PackedBinaryField2x32b, PackedBinaryField4x16b},
-		packed_8::PackedBinaryField1x8b,
 	},
 	underlier::{NumCast, WithUnderlier},
-	AESTowerField8b, BinaryField, BinaryField8b, ByteSlicedAES16x32x8b, ByteSlicedAES8x16x16b,
-	PackedBinaryField16x32b, PackedBinaryField32x16b, PackedBinaryField8x32b, PackedExtension,
-	PackedField, RepackedExtension,
 };
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{SeedableRng, rngs::StdRng};
 
-use crate::{dynamic_dispatch::DynamicDispatchNTT, AdditiveNTT, NTTShape, SingleThreadedNTT};
+use crate::{AdditiveNTT, NTTShape, SingleThreadedNTT, dynamic_dispatch::DynamicDispatchNTT};
 
 /// Check that forward and inverse transformation of `ntt` on `data` is the same as forward and
 /// inverse transformation of `reference_ntt` on `data` and that the result of the roundtrip is the

--- a/crates/ntt/src/tests/reference.rs
+++ b/crates/ntt/src/tests/reference.rs
@@ -3,13 +3,13 @@
 use std::marker::PhantomData;
 
 use binius_field::{
-	packed::{get_packed_slice_unchecked, set_packed_slice_unchecked},
 	BinaryField, ExtensionField, PackedField,
+	packed::{get_packed_slice_unchecked, set_packed_slice_unchecked},
 };
 use binius_math::BinarySubspace;
 use binius_utils::random_access_sequence::{RandomAccessSequence, RandomAccessSequenceMut};
 
-use crate::{twiddle::TwiddleAccess, AdditiveNTT, Error, NTTShape, SingleThreadedNTT};
+use crate::{AdditiveNTT, Error, NTTShape, SingleThreadedNTT, twiddle::TwiddleAccess};
 
 /// A slice of packed field elements with an access to a batch with the given index:
 /// [batch_0_element_0, batch_1_element_0, ..., batch_0_element_1, batch_0_element_1, ...]

--- a/crates/ntt/src/tests/reference.rs
+++ b/crates/ntt/src/tests/reference.rs
@@ -87,6 +87,8 @@ where
 		});
 	}
 
+	let s_evals = &s_evals[log_domain_size - (log_n + coset_bits)..];
+
 	for i in (0..(log_n - skip_rounds)).rev() {
 		let s_evals_i = &s_evals[i];
 		for j in 0..1 << (log_n - 1 - i) {
@@ -131,6 +133,8 @@ where
 			log_required_domain_size: log_n + coset_bits,
 		});
 	}
+
+	let s_evals = &s_evals[log_domain_size - (log_n + coset_bits)..];
 
 	#[allow(clippy::needless_range_loop)]
 	for i in 0..(log_n - skip_rounds) {

--- a/crates/utils/src/checked_arithmetics.rs
+++ b/crates/utils/src/checked_arithmetics.rs
@@ -17,10 +17,20 @@ pub const fn checked_log_2(val: usize) -> usize {
 	result as _
 }
 
-/// Computes `ceil(log_2(n))`.
+/// Computes the binary logarithm of $n$ rounded up to the nearest integer.
+///
+/// When $n$ is 0, this function returns 0. Otherwise, it returns $\lceil \log_2 n \rceil$.
 #[must_use]
 pub const fn log2_ceil_usize(n: usize) -> usize {
-	(usize::BITS - n.saturating_sub(1).leading_zeros()) as usize
+	min_bits(n.saturating_sub(1))
+}
+
+/// Returns the number of bits needed to represent $n$.
+///
+/// When $n$ is 0, this function returns 0. Otherwise, it returns $\lfloor \log_2 n \rfloor + 1$.
+#[must_use]
+pub const fn min_bits(n: usize) -> usize {
+	(usize::BITS - n.leading_zeros()) as usize
 }
 
 /// Computes `log_2(n)`

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,10 +15,8 @@ binius_hal = { path = "../crates/hal", default-features = false }
 binius_hash = { path = "../crates/hash", default-features = false }
 binius_m3 = { path = "../crates/m3", default-features = false }
 binius_macros = { path = "../crates/macros", default-features = false }
-binius_math = { path = "../crates/math", default-features = false }
 binius_utils = { path = "../crates/utils", default-features = false }
 bumpalo.workspace = true
-bytemuck.workspace = true
 bytesize.workspace = true
 clap = { version = "4.5.20", features = ["derive"] }
 itertools.workspace = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,6 +15,7 @@ binius_hal = { path = "../crates/hal", default-features = false }
 binius_hash = { path = "../crates/hash", default-features = false }
 binius_m3 = { path = "../crates/m3", default-features = false }
 binius_macros = { path = "../crates/macros", default-features = false }
+binius_math = { path = "../crates/math", default-features = false }
 binius_utils = { path = "../crates/utils", default-features = false }
 bumpalo.workspace = true
 bytesize.workspace = true


### PR DESCRIPTION
Modify the AdditiveNTT behavior so that the evaluation domains for differently-sized transforms are FRI-compatible. By FRI-compatible, we mean that encoding then FRI folding commutes with tensor folding then encoding. This is checked with a proptest in the `fri` module.

The interfaces for AdditiveNTT should be cleaned up to use structs with named fields and Default impls instead of many parameters. I'm leaving this for future work.

Fixes CRY-71