### PR TITLE
[pre-commit] Fix rustfmt pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     name: Run `rustfmt`
     language: rust
     types: [rust]
-    entry: rustfmt
+    entry: cargo fmt --
     stages: [commit]
   - id: clippy
     name: Run cargo clippy


### PR DESCRIPTION
Use cargo fmt instead of rustfmt for pre-commit hook