### PR TITLE
[zerocheck] Step towards reusing ntt

### DIFF
--- a/crates/core/src/protocols/sumcheck/prove/univariate.rs
+++ b/crates/core/src/protocols/sumcheck/prove/univariate.rs
@@ -3,10 +3,10 @@
 use std::{collections::HashMap, iter::repeat_n};
 
 use binius_field::{
+	BinaryField, ExtensionField, Field, PackedExtension, PackedField, PackedSubfield, TowerField,
 	packed::{get_packed_slice, get_packed_slice_checked},
 	recast_packed_mut,
 	util::inner_product_unchecked,
-	BinaryField, ExtensionField, Field, PackedExtension, PackedField, PackedSubfield, TowerField,
 };
 use binius_hal::ComputationBackend;
 use binius_math::{
@@ -15,7 +15,7 @@ use binius_math::{
 };
 use binius_maybe_rayon::prelude::*;
 use binius_ntt::{
-	twiddle::TwiddleAccess, AdditiveNTT, NTTShape, OddInterpolate, SingleThreadedNTT,
+	AdditiveNTT, NTTShape, OddInterpolate, SingleThreadedNTT, twiddle::TwiddleAccess,
 };
 use binius_utils::{bail, checked_arithmetics::log2_ceil_usize};
 use bytemuck::zeroed_vec;
@@ -26,13 +26,13 @@ use tracing::instrument;
 use crate::{
 	composition::{BivariateProduct, IndexComposition},
 	protocols::sumcheck::{
+		Error,
 		common::{equal_n_vars_check, small_field_embedding_degree_check},
 		prove::{
-			logging::{ExpandQueryData, UnivariateSkipCalculateCoeffsData},
 			RegularSumcheckProver,
+			logging::{ExpandQueryData, UnivariateSkipCalculateCoeffsData},
 		},
 		zerocheck::{domain_size, extrapolated_scalars_count},
-		Error,
 	},
 };
 
@@ -626,9 +626,11 @@ where
 		ntt.forward_transform(round_evals, shape, 0, 0)?;
 
 		// Sanity check: first 1 << skip_rounds evals are still zeros.
-		debug_assert!(round_evals[..1 << skip_rounds]
-			.iter()
-			.all(|&coeff| coeff == F::ZERO));
+		debug_assert!(
+			round_evals[..1 << skip_rounds]
+				.iter()
+				.all(|&coeff| coeff == F::ZERO)
+		);
 
 		// Trim the result.
 		round_evals.resize(max_domain_size, F::ZERO);
@@ -685,16 +687,16 @@ mod tests {
 	use std::sync::Arc;
 
 	use binius_field::{
+		BinaryField1b, BinaryField8b, BinaryField16b, BinaryField128b, ExtensionField, Field,
+		PackedBinaryField4x32b, PackedExtension, PackedField, PackedFieldIndexable, TowerField,
 		arch::{OptimalUnderlier128b, OptimalUnderlier512b},
 		as_packed_field::{PackScalar, PackedType},
 		underlier::UnderlierType,
-		BinaryField128b, BinaryField16b, BinaryField1b, BinaryField8b, ExtensionField, Field,
-		PackedBinaryField4x32b, PackedExtension, PackedField, PackedFieldIndexable, TowerField,
 	};
 	use binius_hal::make_portable_backend;
 	use binius_math::{BinarySubspace, CompositionPoly, EvaluationDomain, MultilinearPoly};
 	use binius_ntt::SingleThreadedNTT;
-	use rand::{prelude::StdRng, SeedableRng};
+	use rand::{SeedableRng, prelude::StdRng};
 
 	use crate::{
 		composition::{IndexComposition, ProductComposition},
@@ -859,10 +861,12 @@ mod tests {
 
 			// naive computation of the univariate skip output
 			let round_evals_len = 4usize << skip_rounds;
-			assert!(output
-				.round_evals
-				.iter()
-				.all(|round_evals| round_evals.len() == round_evals_len));
+			assert!(
+				output
+					.round_evals
+					.iter()
+					.all(|round_evals| round_evals.len() == round_evals_len)
+			);
 
 			let compositions = compositions
 				.iter()

--- a/crates/core/src/protocols/sumcheck/prove/univariate.rs
+++ b/crates/core/src/protocols/sumcheck/prove/univariate.rs
@@ -3,10 +3,10 @@
 use std::{collections::HashMap, iter::repeat_n};
 
 use binius_field::{
-	BinaryField, ExtensionField, Field, PackedExtension, PackedField, PackedSubfield, TowerField,
 	packed::{get_packed_slice, get_packed_slice_checked},
 	recast_packed_mut,
 	util::inner_product_unchecked,
+	BinaryField, ExtensionField, Field, PackedExtension, PackedField, PackedSubfield, TowerField,
 };
 use binius_hal::ComputationBackend;
 use binius_math::{
@@ -14,7 +14,9 @@ use binius_math::{
 	MultilinearPoly, RowsBatchRef,
 };
 use binius_maybe_rayon::prelude::*;
-use binius_ntt::{AdditiveNTT, NTTShape, OddInterpolate, SingleThreadedNTT};
+use binius_ntt::{
+	twiddle::TwiddleAccess, AdditiveNTT, NTTShape, OddInterpolate, SingleThreadedNTT,
+};
 use binius_utils::{bail, checked_arithmetics::log2_ceil_usize};
 use bytemuck::zeroed_vec;
 use itertools::izip;
@@ -24,13 +26,13 @@ use tracing::instrument;
 use crate::{
 	composition::{BivariateProduct, IndexComposition},
 	protocols::sumcheck::{
-		Error,
 		common::{equal_n_vars_check, small_field_embedding_degree_check},
 		prove::{
-			RegularSumcheckProver,
 			logging::{ExpandQueryData, UnivariateSkipCalculateCoeffsData},
+			RegularSumcheckProver,
 		},
 		zerocheck::{domain_size, extrapolated_scalars_count},
+		Error,
 	},
 };
 
@@ -489,7 +491,8 @@ where
 	// So far evals of each composition are "staggered" in a sense that they are evaluated on the
 	// smallest domain which guarantees uniqueness of the round polynomial. We extrapolate them to
 	// max_domain_size to aid in Gruen section 3.2 optimization below and batch mixing.
-	let round_evals = extrapolate_round_evals(staggered_round_evals, skip_rounds, max_domain_size)?;
+	let round_evals =
+		extrapolate_round_evals(&fdomain_ntt, staggered_round_evals, skip_rounds, max_domain_size)?;
 	drop(coeffs_span);
 
 	Ok(ZerocheckUnivariateEvalsOutput {
@@ -565,15 +568,31 @@ fn spread_product<P, FBase>(
 // is not larger than the composition degree), which enables additive-NTT based subquadratic
 // techniques.
 #[instrument(skip_all, level = "debug")]
-fn extrapolate_round_evals<F: TowerField>(
+fn extrapolate_round_evals<F, FDomain, TA>(
+	ntt: &SingleThreadedNTT<FDomain, TA>,
 	mut round_evals: Vec<Vec<F>>,
 	skip_rounds: usize,
 	max_domain_size: usize,
-) -> Result<Vec<Vec<F>>, Error> {
+) -> Result<Vec<Vec<F>>, Error>
+where
+	F: BinaryField + ExtensionField<FDomain>,
+	FDomain: BinaryField,
+	TA: TwiddleAccess<FDomain>,
+{
 	// Instantiate a large enough NTT over F to be able to forward transform to full domain size.
-	// REVIEW: should be possible to use an existing FDomain NTT with striding, possibly with larger
-	// domain.
-	let ntt = SingleThreadedNTT::with_canonical_field(log2_ceil_usize(max_domain_size))?;
+	// TODO: We can't currently use the `ntt` directly because it is over FDomain. It'd be nice to
+	// have helpers that apply a subfield NTT to an extension field vector, without the
+	// PackedExtension relation that `forward_transform_ext` and `inverse_transform_ext` require.
+	let subspace_upcast = BinarySubspace::new_unchecked(
+		ntt.subspace(0)
+			.basis()
+			.iter()
+			.copied()
+			.map(F::from)
+			.collect(),
+	);
+	let ntt = SingleThreadedNTT::with_subspace(&subspace_upcast)
+		.expect("ntt provided is valid; subspace is equivalent but upcast to F");
 
 	// Cache OddInterpolate instances, which, albeit small in practice, take cubic time to create.
 	let mut odd_interpolates = HashMap::new();
@@ -597,7 +616,7 @@ fn extrapolate_round_evals<F: TowerField>(
 		odd_interpolate.inverse_transform(&ntt, round_evals)?;
 
 		// Use forward NTT to extrapolate novel representation to the max domain size.
-		let next_log_n = log2_ceil_usize(max_domain_size);
+		let next_log_n = ntt.log_domain_size();
 		round_evals.resize(1 << next_log_n, F::ZERO);
 
 		let shape = NTTShape {
@@ -607,11 +626,9 @@ fn extrapolate_round_evals<F: TowerField>(
 		ntt.forward_transform(round_evals, shape, 0, 0)?;
 
 		// Sanity check: first 1 << skip_rounds evals are still zeros.
-		debug_assert!(
-			round_evals[..1 << skip_rounds]
-				.iter()
-				.all(|&coeff| coeff == F::ZERO)
-		);
+		debug_assert!(round_evals[..1 << skip_rounds]
+			.iter()
+			.all(|&coeff| coeff == F::ZERO));
 
 		// Trim the result.
 		round_evals.resize(max_domain_size, F::ZERO);
@@ -668,16 +685,16 @@ mod tests {
 	use std::sync::Arc;
 
 	use binius_field::{
-		BinaryField1b, BinaryField8b, BinaryField16b, BinaryField128b, ExtensionField, Field,
-		PackedBinaryField4x32b, PackedExtension, PackedField, PackedFieldIndexable, TowerField,
 		arch::{OptimalUnderlier128b, OptimalUnderlier512b},
 		as_packed_field::{PackScalar, PackedType},
 		underlier::UnderlierType,
+		BinaryField128b, BinaryField16b, BinaryField1b, BinaryField8b, ExtensionField, Field,
+		PackedBinaryField4x32b, PackedExtension, PackedField, PackedFieldIndexable, TowerField,
 	};
 	use binius_hal::make_portable_backend;
 	use binius_math::{BinarySubspace, CompositionPoly, EvaluationDomain, MultilinearPoly};
 	use binius_ntt::SingleThreadedNTT;
-	use rand::{SeedableRng, prelude::StdRng};
+	use rand::{prelude::StdRng, SeedableRng};
 
 	use crate::{
 		composition::{IndexComposition, ProductComposition},
@@ -842,12 +859,10 @@ mod tests {
 
 			// naive computation of the univariate skip output
 			let round_evals_len = 4usize << skip_rounds;
-			assert!(
-				output
-					.round_evals
-					.iter()
-					.all(|round_evals| round_evals.len() == round_evals_len)
-			);
+			assert!(output
+				.round_evals
+				.iter()
+				.all(|round_evals| round_evals.len() == round_evals_len));
 
 			let compositions = compositions
 				.iter()


### PR DESCRIPTION
This make a step towards reusing the already-created NTT object in extrapolate_round_evals. We still can't actually use it because of extension field nonsense, but at least this ensures that the NTT domains are consistent.