### PR TITLE
Remove outdated condition that prevented 1b optimization to happen

### DIFF
--- a/crates/math/src/fold.rs
+++ b/crates/math/src/fold.rs
@@ -437,10 +437,6 @@ where
 		return false;
 	}
 
-	if P::LOG_WIDTH + LOG_QUERY_SIZE > PE::LOG_WIDTH {
-		return false;
-	}
-
 	let cached_tables =
 		create_partial_sums_lookup_tables(PackedSlice::new_with_len(query, 1 << LOG_QUERY_SIZE));
 


### PR DESCRIPTION
This condition was mistakenly left since the times this function was multithreaded.

This rolls back the slowdown that happened after https://github.com/IrreducibleOSS/binius/commit/57a4d56a4723c30683e384a8e35d1be5d68e1e84 