### PR TITLE
[m3] rename flush column indices to columns

### DIFF
--- a/crates/m3/src/builder/channel.rs
+++ b/crates/m3/src/builder/channel.rs
@@ -8,8 +8,7 @@ use crate::builder::{B1, Col};
 /// A flushing rule within a table.
 #[derive(Debug)]
 pub struct Flush {
-	// TODO: rename to columns.
-	pub column_indices: Vec<ColumnId>,
+	pub columns: Vec<ColumnId>,
 	pub channel_id: ChannelId,
 	pub direction: FlushDirection,
 	/// The number of times the values are flushed to the channel.

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -59,7 +59,7 @@ impl<F: TowerField> std::fmt::Display for ConstraintSystem<F> {
 				for flush in partition.flushes.iter() {
 					let channel = self.channels[flush.channel_id].name.clone();
 					let columns = flush
-						.column_indices
+						.columns
 						.iter()
 						.map(|i| table[*i].name.clone())
 						.collect::<Vec<_>>()
@@ -311,14 +311,14 @@ impl<F: TowerField> ConstraintSystem<F> {
 
 				// Translate flushes for the compiled constraint system.
 				for Flush {
-					column_indices,
+					columns: flush_columns,
 					channel_id,
 					direction,
 					multiplicity,
 					selectors,
 				} in flushes
 				{
-					let flush_oracles = column_indices
+					let flush_oracles = flush_columns
 						.iter()
 						.map(|&column_id| OracleOrConst::Oracle(oracle_lookup[column_id]))
 						.collect::<Vec<_>>();

--- a/crates/m3/src/builder/indexed_lookup.rs
+++ b/crates/m3/src/builder/indexed_lookup.rs
@@ -78,7 +78,7 @@ where
 						// TODO: This should be parallelized, which is pretty tricky.
 						let segment = table_index.full_segment();
 						let cols = flush
-							.column_indices
+							.columns
 							.iter()
 							.map(|&col_index| segment.get_dyn(col_index))
 							.collect::<Result<Vec<_>, _>>()?;

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -682,7 +682,7 @@ impl<F: TowerField> TablePartition<F> {
 		cols: impl IntoIterator<Item = Col<F>>,
 		opts: FlushOpts,
 	) {
-		let column_indices = cols
+		let columns = cols
 			.into_iter()
 			.map(|col| {
 				assert_eq!(col.table_id, self.table_id);
@@ -698,7 +698,7 @@ impl<F: TowerField> TablePartition<F> {
 			})
 			.collect::<Vec<_>>();
 		self.flushes.push(Flush {
-			column_indices,
+			columns,
 			channel_id,
 			direction,
 			multiplicity: opts.multiplicity,


### PR DESCRIPTION
As now we are using the column IDs instead of indices.