### PR TITLE
[Fix] evalcheck for ZeroPadded zero-variable polynomials

### DIFF
--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -572,6 +572,10 @@ where
 					.get(padded.id(), &inner_eval_point)
 					.expect("precomputed above");
 
+				if inner_eval_point.is_empty() && eval.is_zero() {
+					transcript.message().write_scalar(inner_eval);
+				}
+
 				self.prove_multilinear(
 					EvalcheckMultilinearClaim {
 						id: padded.id(),

--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -26,6 +26,7 @@ use crate::{
 		ConstraintSet, ConstraintSetBuilder, Error as OracleError, MultilinearOracleSet,
 		MultilinearPolyOracle, MultilinearPolyVariant, OracleId,
 	},
+	polynomial::MultivariatePoly,
 	protocols::evalcheck::{
 		logging::MLEFoldHighDimensionsData,
 		subclaims::{
@@ -34,6 +35,7 @@ use crate::{
 		},
 	},
 	transcript::ProverTranscript,
+	transparent::select_row::SelectRow,
 	witness::MultilinearExtensionIndex,
 };
 
@@ -567,14 +569,21 @@ where
 				.copied()
 				.collect::<Vec<_>>();
 
+				let zs =
+					&eval_point[padded.start_index()..padded.start_index() + padded.n_pad_vars()];
+				let select_row = SelectRow::new(zs.len(), padded.nonzero_index())?;
+				let select_row_term = select_row
+					.evaluate(zs)
+					.expect("select_row is constructor with zs.len() variables");
+
+				if eval.is_zero() && select_row_term.is_zero() {
+					return Ok(());
+				}
+
 				let inner_eval = *self
 					.evals_memoization
 					.get(padded.id(), &inner_eval_point)
 					.expect("precomputed above");
-
-				if inner_eval_point.is_empty() && eval.is_zero() {
-					transcript.message().write_scalar(inner_eval);
-				}
 
 				self.prove_multilinear(
 					EvalcheckMultilinearClaim {

--- a/crates/core/src/protocols/evalcheck/tests.rs
+++ b/crates/core/src/protocols/evalcheck/tests.rs
@@ -671,7 +671,7 @@ fn test_evalcheck_serialization() {
 }
 
 #[test]
-pub fn tets_zero_vars_zeropadding() {
+pub fn test_zero_padded_zero_vars() {
 	let mut oracles = MultilinearOracleSet::<BinaryField128b>::new();
 	let mut witness_index = MultilinearExtensionIndex::<BinaryField128b>::new();
 

--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -253,11 +253,15 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 					.evaluate(zs)
 					.expect("select_row is constructor with zs.len() variables");
 
-				if eval.is_zero() && select_row_term.is_zero() {
-					return Ok(());
-				}
-
-				let inner_eval = eval * select_row_term.invert_or_zero();
+				let inner_eval = match select_row_term.invert() {
+					Some(invert) => eval * invert,
+					None if eval.is_zero() => return Ok(()),
+					None => {
+						return Err(
+							VerificationError::IncorrectEvaluation(multilinear_label).into()
+						);
+					}
+				};
 
 				self.verify_multilinear(
 					EvalcheckMultilinearClaim {

--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -253,18 +253,11 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 					.evaluate(zs)
 					.expect("select_row is constructor with zs.len() variables");
 
-				let inner_eval = if subclaim_eval_point.is_empty() && eval.is_zero() {
-					let inner_eval = transcript.message().read_scalar()?;
+				if eval.is_zero() && select_row_term.is_zero() {
+					return Ok(());
+				}
 
-					if inner_eval * select_row_term != eval {
-						return Err(
-							VerificationError::IncorrectEvaluation(multilinear_label).into()
-						);
-					}
-					inner_eval
-				} else {
-					eval * select_row_term.invert_or_zero()
-				};
+				let inner_eval = eval * select_row_term.invert_or_zero();
 
 				self.verify_multilinear(
 					EvalcheckMultilinearClaim {

--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -253,7 +253,18 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 					.evaluate(zs)
 					.expect("select_row is constructor with zs.len() variables");
 
-				let inner_eval = eval * select_row_term.invert_or_zero();
+				let inner_eval = if subclaim_eval_point.is_empty() && eval.is_zero() {
+					let inner_eval = transcript.message().read_scalar()?;
+
+					if inner_eval * select_row_term != eval {
+						return Err(
+							VerificationError::IncorrectEvaluation(multilinear_label).into()
+						);
+					}
+					inner_eval
+				} else {
+					eval * select_row_term.invert_or_zero()
+				};
 
 				self.verify_multilinear(
 					EvalcheckMultilinearClaim {


### PR DESCRIPTION
There’s a case where a committed polynomial with n_vars = 0 and value [32] can be ZeroPadded into [32, 0, 0, 0], and the evaluation of this zero-padded polynomial may become 0.

As a result, when the verifier tries to derive:

inner_eval = eval * select_row_term.invert_or_zero()

for this committed polynomial, inner_eval ends up being 0, whereas it should be 32.

My hotfix for this case writes the original eval of the committed polynomial into the transcript and checks:

inner_eval * select_row_term == eval

So I believe this approach is secure.