### PR TITLE
[m3] Binary merkle tree example internal nodes deduped. 

### DIFF
--- a/crates/m3/tests/merkle_tree.rs
+++ b/crates/m3/tests/merkle_tree.rs
@@ -272,7 +272,7 @@ mod model {
 			// deduped, these need to be pushed into the nodes channel as many times as they are
 			// referenced in the paths.
 
-			//tracks the filled nodes in the tree
+			// Tracks the filled nodes in the tree
 			let mut filled_nodes = HashMap::new();
 
 			for path in paths.iter() {

--- a/crates/m3/tests/merkle_tree.rs
+++ b/crates/m3/tests/merkle_tree.rs
@@ -321,18 +321,17 @@ mod model {
 				let mut parent_node = [0u8; 32];
 				for (i, &node) in nodes.iter().enumerate() {
 					match filled_nodes.get_mut(&(*root_id, index >> (i + 1), nodes.len() - i - 1)) {
-						Some((_, _, _, flush_left, flush_right)) => {
+						Some((_, _, parent, flush_left, flush_right)) => {
 							if (index >> i) & 1 == 0 {
-								compress(&current_child, &node, &mut parent_node);
+								parent_node = *parent;
 								*flush_left = true;
 							} else {
-								compress(&node, &current_child, &mut parent_node);
+								parent_node = *parent;
 								*flush_right = true;
 							}
 						}
 						None => {
 							if (index >> i) & 1 == 0 {
-								compress(&current_child, &node, &mut parent_node);
 								filled_nodes.insert(
 									(*root_id, index >> (i + 1), nodes.len() - i - 1),
 									(current_child, node, parent_node, true, false),

--- a/crates/m3/tests/merkle_tree.rs
+++ b/crates/m3/tests/merkle_tree.rs
@@ -332,6 +332,7 @@ mod model {
 						}
 						None => {
 							if (index >> i) & 1 == 0 {
+								compress(&node, &current_child, &mut parent_node);
 								filled_nodes.insert(
 									(*root_id, index >> (i + 1), nodes.len() - i - 1),
 									(current_child, node, parent_node, true, false),

--- a/crates/m3/tests/merkle_tree.rs
+++ b/crates/m3/tests/merkle_tree.rs
@@ -191,11 +191,6 @@ mod model {
 				index: self.parent_index,
 			});
 
-			println!(
-				"push (root_id: {:?}, depth: {:?}, index: {:?})",
-				self.root_id, self.parent_depth, self.parent_index
-			);
-
 			if self.flush_left {
 				node_channel.pull(NodeFlushToken {
 					root_id: self.root_id,
@@ -203,12 +198,6 @@ mod model {
 					depth: self.parent_depth + 1,
 					index: 2 * self.parent_index,
 				});
-				println!(
-					"pull (root_id: {:?}, depth: {:?}, index: {:?})",
-					self.root_id,
-					self.parent_depth + 1,
-					2 * self.parent_index
-				);
 			}
 			if self.flush_right {
 				node_channel.pull(NodeFlushToken {
@@ -217,12 +206,6 @@ mod model {
 					depth: self.parent_depth + 1,
 					index: 2 * self.parent_index + 1,
 				});
-				println!(
-					"pull (root_id: {:?}, depth: {:?}, index: {:?})",
-					self.root_id,
-					self.parent_depth + 1,
-					2 * self.parent_index + 1
-				);
 			}
 		}
 	}
@@ -316,6 +299,7 @@ mod model {
 					},
 				);
 
+				// Populate the root table's events.
 				root_nodes.insert(MerkleRootEvent::new(*root_id, roots[*root_id as usize]));
 
 				let mut parent_node = [0u8; 32];


### PR DESCRIPTION
Deduped internal nodes in Binary Merkle tree example, addressed nits.