### PR TITLE
[CRY-364] Add bivariate_product round calculation function

### DIFF
--- a/crates/compute/src/layer.rs
+++ b/crates/compute/src/layer.rs
@@ -14,7 +14,7 @@ use super::{
 use crate::memory::SizedSlice;
 
 /// A hardware abstraction layer (HAL) for compute operations.
-pub trait ComputeLayer<F: Field> {
+pub trait ComputeLayer<F: Field>: 'static {
 	/// The device memory.
 	type DevMem: ComputeMemory<F>;
 

--- a/crates/compute/src/lib.rs
+++ b/crates/compute/src/lib.rs
@@ -10,3 +10,6 @@ pub mod alloc;
 pub mod cpu;
 pub mod layer;
 pub mod memory;
+
+pub use layer::*;
+pub use memory::*;

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 assert_matches.workspace = true
 auto_impl.workspace = true
 binius_macros = { path = "../macros", default-features = false }
+binius_compute = { path = "../compute", default-features = false }
 binius_field = { path = "../field", default-features = false }
 binius_hal = { path = "../hal", default-features = false }
 binius_hash = { path = "../hash", default-features = false }

--- a/crates/core/src/composition/index.rs
+++ b/crates/core/src/composition/index.rs
@@ -5,16 +5,18 @@ use std::fmt::Debug;
 use binius_field::PackedField;
 use binius_math::{ArithCircuit, CompositionPoly, RowsBatchRef};
 use binius_utils::bail;
+use getset::Getters;
 
 use crate::polynomial::Error;
 
 /// An adapter which allows evaluating a composition over a larger query by indexing into it.
 /// See [`index_composition`] for a factory method.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Getters)]
 pub struct IndexComposition<C, const N: usize> {
 	/// Number of variables in a larger query
 	n_vars: usize,
 	/// Mapping from the inner composition query variables to outer query variables
+	#[get = "pub"]
 	indices: [usize; N],
 	/// Inner composition
 	composition: C,

--- a/crates/core/src/protocols/sumcheck/mod.rs
+++ b/crates/core/src/protocols/sumcheck/mod.rs
@@ -14,6 +14,7 @@ mod oracles;
 pub mod prove;
 #[cfg(test)]
 mod tests;
+pub mod v3;
 pub mod verify_sumcheck;
 pub mod verify_zerocheck;
 pub mod zerocheck;

--- a/crates/core/src/protocols/sumcheck/v3/bivariate_product.rs
+++ b/crates/core/src/protocols/sumcheck/v3/bivariate_product.rs
@@ -4,7 +4,7 @@ use std::iter;
 
 use binius_compute::{ComputeLayer, ComputeMemory, FSlice, KernelBuffer, KernelMemMap};
 use binius_field::{TowerField, util::powers};
-use binius_math::ArithExpr;
+use binius_math::{ArithExpr, CompositionPoly};
 
 use super::error::Error;
 use crate::composition::{BivariateProduct, IndexComposition};
@@ -51,9 +51,8 @@ pub fn calculate_round_evals<'a, F: TowerField, HAL: ComputeLayer<F>>(
 	let prod_evaluators = compositions
 		.iter()
 		.map(|composition| {
-			let [idx0, idx1] = composition.indices();
-			let prod_expr = composition.expression();
-			hal.compile_expr(&prod_expr)
+			let prod_expr = CompositionPoly::<F>::expression(&composition);
+			hal.compile_expr(&ArithExpr::from(prod_expr))
 		})
 		.collect::<Result<Vec<_>, _>>()?;
 

--- a/crates/core/src/protocols/sumcheck/v3/bivariate_product.rs
+++ b/crates/core/src/protocols/sumcheck/v3/bivariate_product.rs
@@ -1,0 +1,285 @@
+// Copyright 2025 Irreducible Inc.
+
+use std::iter;
+
+use binius_compute::{ComputeLayer, ComputeMemory, FSlice, KernelBuffer, KernelMemMap};
+use binius_field::{TowerField, util::powers};
+use binius_math::ArithExpr;
+
+use super::error::Error;
+use crate::composition::{BivariateProduct, IndexComposition};
+
+/// Calculates the evaluations of the products of pairs of partially specialized multilinear
+/// polynomials for sumcheck.
+///
+/// This performs round evaluation for a special case sumcheck prover for a sumcheck over bivariate
+/// products of multilinear polynomials, defined over the same field as the sumcheck challenges,
+/// using high-to-low variable binding order.
+///
+/// In more details, this function takes a slice of multilinear polynomials over a large field `F`
+/// and a description of pairs of them, and computes the hypercube sum of the evaluations of these
+/// pairs of multilinears at select points. The evaluation points are 0 and the "infinity" point.
+/// The meaning of the infinity evaluation point is described in the documentation of
+/// [`binius_math::univariate::EvaluationDomain`].
+///
+/// The evaluations are batched by mixing with the powers of a batch coefficient.
+///
+/// ## Mathematical Definition
+///
+/// Let $\alpha$ be the batching coefficient, $P_0, \ldots, P_{m-1}$ be the multilinears, and
+/// $t \in \left(\mathbb{N}^2 \right)^k$ be a sequence of tuples of indices. This returns two
+/// values:
+///
+/// $$
+/// z_1 = \sum_{i=0}^{k-1} \alpha^i \sum_{v \in B_{m-1}} P_{t_{0,i}}(v || 0) P_{t_{1,i}}(v || 0)
+/// \\\\ z_\infty = \sum_{i=0}^{k-1} \alpha^i \sum_{v \in B_{m-1}} P_{t_{0,i}}(v || \infty)
+/// P_{t_{1,i}}(v || \infty) \\
+/// $$
+///
+/// ## Returns
+///
+/// Returns the batched, summed evaluations at 0 and infinity.
+pub fn calculate_round_evals<'a, F: TowerField, HAL: ComputeLayer<F>>(
+	hal: &HAL,
+	n_vars: usize,
+	batch_coeff: F,
+	multilins: &[FSlice<'a, F, HAL>],
+	compositions: &[IndexComposition<BivariateProduct, 2>],
+) -> Result<[F; 2], Error> {
+	// TODO: if n_vars is too small, transfer data and fall back to the CPU impl
+
+	let prod_evaluators = compositions
+		.iter()
+		.map(|composition| {
+			let [idx0, idx1] = composition.indices();
+			let prod_expr = ArithExpr::Var(*idx0) * ArithExpr::Var(*idx1);
+			hal.compile_expr(&prod_expr)
+		})
+		.collect::<Result<Vec<_>, _>>()?;
+
+	// n_vars - 1 is the number of variables in the halves of the split multilinear.
+	let split_n_vars = n_vars - 1;
+	let kernel_mappings = multilins
+		.iter()
+		.copied()
+		.flat_map(|multilin| {
+			let (lo_half, hi_half) = HAL::DevMem::split_at(multilin, 1 << split_n_vars);
+			[
+				KernelMemMap::Chunked {
+					data: lo_half,
+					log_min_chunk_size: 0,
+				},
+				KernelMemMap::Chunked {
+					data: hi_half,
+					log_min_chunk_size: 0,
+				},
+				// Evaluations of the multilinear at the extra evaluation point
+				KernelMemMap::Local {
+					log_size: split_n_vars,
+				},
+			]
+		})
+		.collect();
+
+	let batch_coeffs = powers(batch_coeff)
+		.take(compositions.len())
+		.collect::<Vec<_>>();
+
+	let evals = hal.execute(|exec| {
+		hal.accumulate_kernels(
+			exec,
+			|local_exec, log_chunks, mut buffers| {
+				let log_chunk_size = split_n_vars - log_chunks;
+
+				// Compute the composite evaluations at the point ONE.
+				let mut acc_1 = hal.kernel_decl_value(local_exec, F::ZERO)?;
+				let eval_1s = (0..multilins.len())
+					.map(|i| {
+						let KernelBuffer::Ref(buffer) = &buffers[i * 3 + 1] else {
+							panic!(
+								"exec_kernels did not create the mapped buffers struct according to the mapping"
+							)
+						};
+						*buffer
+					})
+					.collect::<Vec<_>>();
+				for (&batch_coeff, evaluator) in iter::zip(&batch_coeffs, &prod_evaluators) {
+					hal.sum_composition_evals(
+						local_exec,
+						log_chunk_size,
+						&eval_1s,
+						evaluator,
+						batch_coeff,
+						&mut acc_1,
+					)?;
+				}
+
+				// Extrapolate the multilinear evaluations at the point Infinity.
+				for group in buffers.chunks_mut(3) {
+					let Ok(
+						[
+							KernelBuffer::Ref(evals_0),
+							KernelBuffer::Ref(evals_1),
+							KernelBuffer::Mut(evals_inf),
+						],
+					) = TryInto::<&mut [_; 3]>::try_into(group)
+					else {
+						panic!(
+							"exec_kernels did not create the mapped buffers struct according to the mapping"
+						);
+					};
+					hal.kernel_add(local_exec, log_chunk_size, *evals_0, *evals_1, evals_inf)?;
+				}
+
+				// Compute the composite evaluations at the point Infinity.
+				let mut acc_inf = hal.kernel_decl_value(local_exec, F::ZERO)?;
+				let eval_infs = (0..multilins.len())
+					.map(|i| buffers[i * 3 + 2].to_ref())
+					.collect::<Vec<_>>();
+				for (&batch_coeff, evaluator) in iter::zip(&batch_coeffs, &prod_evaluators) {
+					hal.sum_composition_evals(
+						local_exec,
+						log_chunk_size,
+						&eval_infs,
+						evaluator,
+						batch_coeff,
+						&mut acc_inf,
+					)?;
+				}
+
+				Ok(vec![acc_1, acc_inf])
+			},
+			kernel_mappings,
+		)
+	})?;
+	let evals = TryInto::<[F; 2]>::try_into(evals).expect("kernel returns two values");
+	Ok(evals)
+}
+
+#[cfg(test)]
+mod tests {
+	use std::iter::repeat_with;
+
+	use binius_compute::cpu::CpuLayer;
+	use binius_field::{
+		BinaryField1b, BinaryField128b, Field, PackedBinaryField1x128b, PackedField,
+		PackedFieldIndexable, tower::CanonicalTowerFamily, util::inner_product_unchecked,
+	};
+	use binius_hal::make_portable_backend;
+	use binius_math::{
+		CompositionPoly, DefaultEvaluationDomainFactory, EvaluationDomain, EvaluationOrder,
+		InterpolationDomain, MLEDirectAdapter, MultilinearExtension, MultilinearPoly,
+	};
+	use rand::{SeedableRng, rngs::StdRng};
+
+	use super::*;
+	use crate::{
+		composition::BivariateProduct,
+		polynomial::MultilinearComposite,
+		protocols::sumcheck::{
+			CompositeSumClaim, immediate_switchover_heuristic,
+			prove::{RegularSumcheckProver, SumcheckProver},
+		},
+	};
+
+	fn compute_composite_sum<P, M, Composition>(
+		multilinears: &[M],
+		composition: Composition,
+	) -> P::Scalar
+	where
+		P: PackedField,
+		M: MultilinearPoly<P> + Send + Sync,
+		Composition: CompositionPoly<P>,
+	{
+		let n_vars = multilinears
+			.first()
+			.map(|multilinear| multilinear.n_vars())
+			.unwrap_or_default();
+		for multilinear in multilinears {
+			assert_eq!(multilinear.n_vars(), n_vars);
+		}
+
+		let multilinears = multilinears.iter().collect::<Vec<_>>();
+		let witness = MultilinearComposite::new(n_vars, composition, multilinears.clone()).unwrap();
+		(0..(1 << n_vars))
+			.map(|j| witness.evaluate_on_hypercube(j).unwrap())
+			.sum()
+	}
+
+	#[test]
+	fn test_calculate_round_evals() {
+		type Hal = CpuLayer<CanonicalTowerFamily>;
+		type F = BinaryField128b;
+
+		let hal = Hal::default();
+		let n_vars = 8;
+		let mut rng = StdRng::seed_from_u64(0);
+		let evals_1 = repeat_with(|| PackedBinaryField1x128b::random(&mut rng))
+			.take(1 << n_vars)
+			.collect::<Vec<_>>();
+		let evals_2 = repeat_with(|| PackedBinaryField1x128b::random(&mut rng))
+			.take(1 << n_vars)
+			.collect::<Vec<_>>();
+		let evals_3 = repeat_with(|| PackedBinaryField1x128b::random(&mut rng))
+			.take(1 << n_vars)
+			.collect::<Vec<_>>();
+		let mle_1 = MultilinearExtension::new(n_vars, evals_1.as_slice()).unwrap();
+		let mle_2 = MultilinearExtension::new(n_vars, evals_2.as_slice()).unwrap();
+		let mle_3 = MultilinearExtension::new(n_vars, evals_3.as_slice()).unwrap();
+		let multilins = [mle_1, mle_2, mle_3].map(MLEDirectAdapter::from).to_vec();
+
+		let batch_coeff = <F as Field>::random(&mut rng);
+
+		let indexed_compositions = [
+			IndexComposition::new(3, [0, 1], BivariateProduct::default()).unwrap(),
+			IndexComposition::new(3, [1, 2], BivariateProduct::default()).unwrap(),
+		];
+
+		let sums = indexed_compositions
+			.iter()
+			.map(|composition| compute_composite_sum(&multilins, composition))
+			.collect::<Vec<_>>();
+		let sum = inner_product_unchecked(powers(batch_coeff), sums.iter().copied());
+
+		let result = calculate_round_evals(
+			&hal,
+			n_vars,
+			batch_coeff,
+			&[
+				PackedFieldIndexable::unpack_scalars(&evals_1),
+				PackedFieldIndexable::unpack_scalars(&evals_2),
+				PackedFieldIndexable::unpack_scalars(&evals_3),
+			],
+			&indexed_compositions,
+		);
+		assert!(result.is_ok());
+		let evals = result.unwrap();
+		assert_eq!(evals.len(), 2);
+
+		let interpolation_domain = InterpolationDomain::from(
+			EvaluationDomain::<BinaryField1b>::from_points(
+				vec![BinaryField1b::ZERO, BinaryField1b::ONE],
+				true,
+			)
+			.expect("domain is valid"),
+		);
+
+		let evals = [sum - evals[0], evals[0], evals[1]];
+		let coeffs = interpolation_domain.interpolate(&evals).unwrap();
+
+		let backend = make_portable_backend();
+		let mut prover = RegularSumcheckProver::<BinaryField1b, _, _, _, _>::new(
+			EvaluationOrder::HighToLow,
+			multilins,
+			iter::zip(indexed_compositions, sums)
+				.map(|(composition, sum)| CompositeSumClaim { composition, sum }),
+			DefaultEvaluationDomainFactory::default(),
+			immediate_switchover_heuristic,
+			&backend,
+		)
+		.unwrap();
+		let expected_coeffs = prover.execute(batch_coeff).unwrap();
+
+		assert_eq!(coeffs, expected_coeffs.0);
+	}
+}

--- a/crates/core/src/protocols/sumcheck/v3/bivariate_product.rs
+++ b/crates/core/src/protocols/sumcheck/v3/bivariate_product.rs
@@ -31,14 +31,15 @@ use crate::composition::{BivariateProduct, IndexComposition};
 /// values:
 ///
 /// $$
-/// z_1 = \sum_{i=0}^{k-1} \alpha^i \sum_{v \in B_{m-1}} P_{t_{0,i}}(v || 0) P_{t_{1,i}}(v || 0)
-/// \\\\ z_\infty = \sum_{i=0}^{k-1} \alpha^i \sum_{v \in B_{m-1}} P_{t_{0,i}}(v || \infty)
-/// P_{t_{1,i}}(v || \infty) \\
+/// z_1 = \sum_{i=0}^{k-1} \alpha^i \sum_{v \in B_{m-1}} P_{t_{0,i}}(v || 1) P_{t_{1,i}}(v || 1)
+/// \\\\
+/// z_\infty = \sum_{i=0}^{k-1} \alpha^i \sum_{v \in B_{m-1}} P_{t_{0,i}}(v || \infty)
+/// P_{t_{1,i}}(v || \infty)
 /// $$
 ///
 /// ## Returns
 ///
-/// Returns the batched, summed evaluations at 0 and infinity.
+/// Returns the batched, summed evaluations at 1 and infinity.
 pub fn calculate_round_evals<'a, F: TowerField, HAL: ComputeLayer<F>>(
 	hal: &HAL,
 	n_vars: usize,

--- a/crates/core/src/protocols/sumcheck/v3/bivariate_product.rs
+++ b/crates/core/src/protocols/sumcheck/v3/bivariate_product.rs
@@ -52,7 +52,7 @@ pub fn calculate_round_evals<'a, F: TowerField, HAL: ComputeLayer<F>>(
 		.iter()
 		.map(|composition| {
 			let [idx0, idx1] = composition.indices();
-			let prod_expr = ArithExpr::Var(*idx0) * ArithExpr::Var(*idx1);
+			let prod_expr = composition.expression();
 			hal.compile_expr(&prod_expr)
 		})
 		.collect::<Result<Vec<_>, _>>()?;

--- a/crates/core/src/protocols/sumcheck/v3/error.rs
+++ b/crates/core/src/protocols/sumcheck/v3/error.rs
@@ -1,0 +1,9 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_compute::Error as ComputeError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	#[error("compute error: {0}")]
+	Compute(#[from] ComputeError),
+}

--- a/crates/core/src/protocols/sumcheck/v3/mod.rs
+++ b/crates/core/src/protocols/sumcheck/v3/mod.rs
@@ -1,0 +1,13 @@
+// Copyright 2025 Irreducible Inc.
+
+//! The V3 sumcheck module contains implementations of the sumcheck prover using the
+//! [`binius_compute`] crate.
+//!
+//! The V3 prover is fully compatible with the existing sumcheck protocol verifier, and is a change
+//! to the prover implementation. Once the V3 prover is fully integrated throughout the codebase,
+//! the current V2 prover will be removed.
+
+pub mod bivariate_product;
+mod error;
+
+pub use error::Error;

--- a/crates/field/src/tower.rs
+++ b/crates/field/src/tower.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 /// A trait that groups a family of related [`TowerField`]s as associated types.
-pub trait TowerFamily: Sized {
+pub trait TowerFamily: Sized + 'static {
 	type B1: TowerField + TryFrom<Self::B128>;
 	type B8: TowerField + TryFrom<Self::B128> + ExtensionField<Self::B1>;
 	type B16: TowerField + TryFrom<Self::B128> + ExtensionField<Self::B1> + ExtensionField<Self::B8>;


### PR DESCRIPTION
This PR adds a new `v3` module to the sumcheck protocol implementation, which contains a specialized function for calculating round evaluations for bivariate product compositions. The implementation leverages the `binius_compute` crate for hardware acceleration.

Key changes:
- Add new `calculate_round_evals` function that computes batched evaluations of products of pairs of partially specialized multilinear polynomials
- Re-export `layer` and `memory` modules from the compute crate
- Add `binius_compute` dependency to the core crate
- Add getters for the `indices` field in `IndexComposition`

This is the first step toward a V3 sumcheck prover implementation that will eventually replace the current V2 prover.