### PR TITLE
fix calculation of fold arities. add larger test

### DIFF
--- a/crates/core/src/piop/tests.rs
+++ b/crates/core/src/piop/tests.rs
@@ -286,7 +286,7 @@ fn test_commit_prove_verify_small() {
 
 #[test]
 fn test_commit_prove_verify() {
-	let commit_meta = CommitMeta::with_vars([6, 6, 8, 13]);
+	let commit_meta = CommitMeta::with_vars([6, 6, 8, 9]);
 	let merkle_prover = BinaryMerkleTreeProver::<_, Groestl256, _>::new(Groestl256ByteCompression);
 	let n_transparents = 2;
 	let log_inv_rate = 1;

--- a/crates/core/src/piop/tests.rs
+++ b/crates/core/src/piop/tests.rs
@@ -255,6 +255,21 @@ fn test_with_one_n_vars() {
 }
 
 #[test]
+fn test_commit_prove_verify_extreme_rate() {
+	let commit_meta = CommitMeta::with_vars([3, 3, 5, 6]);
+	let merkle_prover = BinaryMerkleTreeProver::<_, Groestl256, _>::new(Groestl256ByteCompression);
+	let n_transparents = 2;
+	let log_inv_rate = 8;
+
+	commit_prove_verify::<_, BinaryField8b, BinaryField16b, PackedBinaryField2x128b, _>(
+		&commit_meta,
+		n_transparents,
+		&merkle_prover,
+		log_inv_rate,
+	);
+}
+
+#[test]
 fn test_commit_prove_verify_small() {
 	let commit_meta = CommitMeta::with_vars([4, 4, 6, 7]);
 	let merkle_prover = BinaryMerkleTreeProver::<_, Groestl256, _>::new(Groestl256ByteCompression);

--- a/crates/core/src/piop/tests.rs
+++ b/crates/core/src/piop/tests.rs
@@ -255,8 +255,23 @@ fn test_with_one_n_vars() {
 }
 
 #[test]
-fn test_commit_prove_verify() {
+fn test_commit_prove_verify_small() {
 	let commit_meta = CommitMeta::with_vars([4, 4, 6, 7]);
+	let merkle_prover = BinaryMerkleTreeProver::<_, Groestl256, _>::new(Groestl256ByteCompression);
+	let n_transparents = 2;
+	let log_inv_rate = 1;
+
+	commit_prove_verify::<_, BinaryField8b, BinaryField16b, PackedBinaryField2x128b, _>(
+		&commit_meta,
+		n_transparents,
+		&merkle_prover,
+		log_inv_rate,
+	);
+}
+
+#[test]
+fn test_commit_prove_verify() {
+	let commit_meta = CommitMeta::with_vars([6, 6, 8, 13]);
 	let merkle_prover = BinaryMerkleTreeProver::<_, Groestl256, _>::new(Groestl256ByteCompression);
 	let n_transparents = 2;
 	let log_inv_rate = 1;

--- a/crates/core/src/piop/verify.rs
+++ b/crates/core/src/piop/verify.rs
@@ -134,7 +134,7 @@ where
 	let cap_height = log2_ceil_usize(n_test_queries);
 	let fold_arities = std::iter::repeat_n(
 		arity,
-		(commit_meta.total_vars + log_inv_rate).saturating_sub(cap_height) / arity,
+		(commit_meta.total_vars).saturating_sub(cap_height.saturating_sub(log_inv_rate)) / arity,
 	)
 	.collect::<Vec<_>>();
 	// here is the down-to-earth explanation of what we're doing: we want the terminal codeword's


### PR DESCRIPTION
there is a very subtle issue in the current calculation of `fold_arities`; see the recent PR https://github.com/IrreducibleOSS/binius/pull/300.

the issue only arises in an essentially impossible-case---i.e., in which the `log_inv_rate` is strictly more than the `merkle_cap_height`, i.e., $\mathcal{R} > c$, where $c$ is the Merkle cap height. this will virtually never happen in real life, unless $\mathcal{R}$ is enormous---7 or 8 or so.

if this _were_ the case, then the current implementation can lead to a nonsensical scenario where sum(fold_arities) is > total_vars. this makes no sense, since we need to ship the terminal codeword before or equal to the point at which the message has become fully folded, and not after. in fact this gets caught in the current codebase, with a `InvalidFoldAritySequence`.

I've added a test which triggers this error in the current codebase but doesn't once the present proposed update is in place.

the way we fix this is by replacing
```rust
(commit_meta.total_vars + log_inv_rate).saturating_sub(cap_height) / arity,
```
with
```rust
(commit_meta.total_vars).saturating_sub(cap_height.saturating_sub(log_inv_rate)) / arity,
```
when `cap_height >= log_inv_rate`, these are equivalent. in the opposite case `cap_height < log_inv_rate`, this has the effect of setting `fold_arities` to be `arity` repeated `floor(total_vars / arity)` times, which is a safe choice.