### PR TITLE
[compute] Introduce ComputeLayer::extrapolate_line operation

### DIFF
--- a/crates/compute/src/cpu/layer.rs
+++ b/crates/compute/src/cpu/layer.rs
@@ -369,6 +369,16 @@ impl<T: TowerFamily> ComputeLayer<T::B128> for CpuLayer<T> {
 
 		Ok(())
 	}
+
+	fn extrapolate_line(
+		&self,
+		exec: &mut Self::Exec,
+		evals_0: &mut &mut [T::B128],
+		evals_1: &[T::B128],
+		z: T::B128,
+	) -> Result<(), Error> {
+		todo!()
+	}
 }
 
 // Note: shortcuts for kernel memory so that clippy does not complain about the type complexity in

--- a/crates/compute/src/cpu/layer.rs
+++ b/crates/compute/src/cpu/layer.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-use std::marker::PhantomData;
+use std::{iter, marker::PhantomData};
 
 use binius_field::{
 	BinaryField, ExtensionField, Field, TowerField, tower::TowerFamily,
@@ -372,12 +372,20 @@ impl<T: TowerFamily> ComputeLayer<T::B128> for CpuLayer<T> {
 
 	fn extrapolate_line(
 		&self,
-		exec: &mut Self::Exec,
+		_exec: &mut Self::Exec,
 		evals_0: &mut &mut [T::B128],
 		evals_1: &[T::B128],
 		z: T::B128,
 	) -> Result<(), Error> {
-		todo!()
+		if evals_0.len() != evals_1.len() {
+			return Err(Error::InputValidation(
+				"evals_0 and evals_1 must be the same length".into(),
+			));
+		}
+		for (x0, x1) in iter::zip(&mut **evals_0, evals_1) {
+			*x0 += (*x1 - *x0) * z
+		}
+		Ok(())
 	}
 }
 

--- a/crates/compute/src/layer.rs
+++ b/crates/compute/src/layer.rs
@@ -368,6 +368,33 @@ pub trait ComputeLayer<F: Field>: 'static {
 	where
 		FSub: BinaryField,
 		F: ExtensionField<FSub>;
+
+	/// Extrapolates a line between a vector of evaluations at 0 and evaluations at 1.
+	///
+	/// Given two values $y_0, y_1$, this operation computes the value $y_z = y_0 + (y_1 - y_0) z$,
+	/// which is the value of the line that interpolates $(0, y_0), (1, y_1)$ at $z$. This computes
+	/// this operation in parallel over two vectors of big field elements of equal sizes.
+	///
+	/// The operation writes the result back in-place into the `evals_0` buffer.
+	///
+	/// ## Args
+	///
+	/// * `evals_0` - this is both an input and output buffer. As in input, it is populated with the
+	///   values $y_0$, which are the line's values at 0.
+	/// * `evals_1` - an input buffer with the values $y_1$, which are the line's values at 1.
+	/// * `z` - the scalar evaluation point.
+	///
+	/// ## Throws
+	///
+	/// * if `evals_0` and `evals_1` are not equal sizes.
+	/// * if the sizes of `evals_0` and `evals_1` are not powers of two.
+	fn extrapolate_line(
+		&self,
+		exec: &mut Self::Exec,
+		evals_0: &mut FSliceMut<F, Self>,
+		evals_1: FSlice<F, Self>,
+		z: F,
+	) -> Result<(), Error>;
 }
 
 /// A memory mapping specification for a kernel execution.

--- a/crates/compute/tests/layer.rs
+++ b/crates/compute/tests/layer.rs
@@ -132,3 +132,12 @@ fn test_exec_kernel_add() {
 	let mut device_memory = vec![F::ZERO; 1 << (log_len + 3)];
 	test_generic_kernel_add::<F, _>(compute, &mut device_memory, log_len);
 }
+
+#[test]
+fn test_extrapolate_line() {
+	type F = BinaryField128b;
+	let log_len = 10;
+	let compute = <CpuLayer<CanonicalTowerFamily>>::default();
+	let mut device_memory = vec![F::ZERO; 1 << (log_len + 3)];
+	binius_compute_test_utils::layer::test_extrapolate_line(&compute, &mut device_memory, log_len);
+}


### PR DESCRIPTION
# Introduce ComputeLayer::extrapolate_line operation

This PR adds a new `extrapolate_line` operation to the `ComputeLayer` trait. This operation extrapolates a line between evaluations at 0 and evaluations at 1, computing `y_z = y_0 + (y_1 - y_0) * z` for a given point `z`. The operation is performed in parallel over vectors of field elements.

The implementation includes:
- Adding the `extrapolate_line` method to the `ComputeLayer` trait
- Implementing the method for `CpuLayer<T>`
- Adding test utilities and a test case to verify correctness
- Making `ComputeLayer<F: Field>` and `TowerFamily` require `'static`

The operation is useful for interpolating between two points on a line and evaluating at arbitrary positions.