### PR TITLE
[compute] Fix allocation lifetime issue

### DIFF
--- a/crates/compute/src/cpu/memory.rs
+++ b/crates/compute/src/cpu/memory.rs
@@ -17,6 +17,10 @@ impl<F: 'static> ComputeMemory<F> for CpuMemory {
 		data
 	}
 
+	fn narrow_mut<'a, 'b: 'a>(data: Self::FSliceMut<'b>) -> Self::FSliceMut<'a> {
+		data
+	}
+
 	fn as_const<'a>(data: &'a &mut [F]) -> &'a [F] {
 		data
 	}

--- a/crates/compute/src/memory.rs
+++ b/crates/compute/src/memory.rs
@@ -35,6 +35,9 @@ pub trait ComputeMemory<F> {
 	/// Borrows an immutable memory slice, narrowing the lifetime.
 	fn narrow<'a>(data: &'a Self::FSlice<'_>) -> Self::FSlice<'a>;
 
+	/// Borrows a mutable memory slice, narrowing the lifetime.
+	fn narrow_mut<'a, 'b: 'a>(data: Self::FSliceMut<'b>) -> Self::FSliceMut<'a>;
+
 	/// Borrows a mutable memory slice as immutable.
 	///
 	/// This allows the immutable reference to be copied.


### PR DESCRIPTION
Objects allocated by an allocator must not outlive the allocator. This precludes allocators from owning data and allocating parts of it. The new interface matches the bumpalo [alloc](https://docs.rs/bumpalo/latest/bumpalo/struct.Bump.html#method.alloc) method now.