### PR TITLE
[evalcheck] Avoid redundant evaluations

### DIFF
--- a/crates/core/src/protocols/evalcheck/evalcheck.rs
+++ b/crates/core/src/protocols/evalcheck/evalcheck.rs
@@ -95,6 +95,7 @@ pub fn deserialize_evalcheck_proof<B: Buf>(
 /// Equivalent to a `HashMap<(OracleId, EvalPoint<F>), T>` but uses vectors of vectors to store the
 /// data. This data structure is more memory efficient for small number of evaluation points and
 /// OracleIds which are grouped together.
+#[derive(Clone, Debug)]
 pub struct EvalPointOracleIdMap<T: Clone, F: Field> {
 	data: Vec<Vec<(EvalPoint<F>, T)>>,
 }

--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -62,10 +62,10 @@ where
 	#[getset(get = "pub", get_mut = "pub")]
 	committed_eval_claims: Vec<EvalcheckMultilinearClaim<F>>,
 
-	// Claim that we need to evaluate
-	claims_that_must_be_evaluated: HashSet<(OracleId, EvalPoint<F>)>,
+	// Claims that need to be evaluated.
+	claims_to_be_evaluated: HashSet<(OracleId, EvalPoint<F>)>,
 
-	// Claims that we can evaluate using internal_eval's
+	// Claims that can be evaluated using internal_evals.
 	claims_without_evals: HashSet<(OracleId, EvalPoint<F>)>,
 
 	// The list of claims that reduces to a bivariate sumcheck in a round.
@@ -111,7 +111,7 @@ where
 			new_bivariate_sumchecks_constraints: Vec::new(),
 			new_mlechecks_constraints: Vec::new(),
 			claims_without_evals: HashSet::new(),
-			claims_that_must_be_evaluated: HashSet::new(),
+			claims_to_be_evaluated: HashSet::new(),
 			projected_bivariate_claims: Vec::new(),
 			memoized_data: MemoizedData::new(),
 			backend,
@@ -195,7 +195,7 @@ where
 		}
 
 		let eval_points = self
-			.claims_that_must_be_evaluated
+			.claims_to_be_evaluated
 			.iter()
 			.map(|(_, eval_point)| eval_point.as_ref())
 			.collect::<Vec<_>>();
@@ -203,7 +203,7 @@ where
 		self.memoized_data
 			.memoize_query_par(eval_points, self.backend)?;
 
-		let subclaims = std::mem::take(&mut self.claims_that_must_be_evaluated)
+		let subclaims = std::mem::take(&mut self.claims_to_be_evaluated)
 			.into_par_iter()
 			.map(|(id, eval_point)| {
 				Self::make_new_eval_claim(id, eval_point, self.witness_index, &self.memoized_data)
@@ -404,7 +404,7 @@ where
 					.get(multilinear_id, &eval_point)
 					.is_none()
 				{
-					self.claims_that_must_be_evaluated
+					self.claims_to_be_evaluated
 						.insert((multilinear_id, eval_point));
 				}
 			}


### PR DESCRIPTION
This PR refactors the evaluation logic for `Repeating`, `Projected`, `LinearCombination`, and `ZeroPadded` polys.

Instead of evaluating this poly directly, we now first evaluate their descendants.
After all descendants are evaluated, the top-level node is computed using internal_evals.

Imrovments:

- Significant performance gains for large numbers of Repeating, Projected, LinearCombination, and ZeroPadded
- More evaluations can now be deduplicated than before
- Descendants can have fewer variables and therefore be evaluated faster.


single-threaded keccakf evalcheck : 27s -> 23s 

