### PR TITLE
[circuits] deprecate binius_circuits

### DIFF
--- a/crates/circuits/src/lib.rs
+++ b/crates/circuits/src/lib.rs
@@ -6,6 +6,10 @@
 //! [`crate::builder`] module. Most other modules contain circuit gadgets that can be used to build
 //! more complex constraint systems.
 
+#![deprecated = "use binius_m3 instead"]
+// This is because there are quite some arith_expr! in this codebase and it's acceptable to blanket
+// allow(deprecated) here since it's going away anyway.
+#![allow(deprecated)]
 #![allow(clippy::module_inception)]
 
 pub mod arithmetic;

--- a/crates/core/benches/composition_poly.rs
+++ b/crates/core/benches/composition_poly.rs
@@ -83,6 +83,7 @@ fn benchmark_evaluate(c: &mut Criterion) {
 		});
 	});
 	group.bench_function("composition_poly_128x1b", |bench| {
+		#[allow(deprecated)]
 		let poly = composition_poly!([h4, h5, h6, ch] = (h4 * h5 + (1 - h4) * h6) - ch);
 		bench.iter(|| {
 			evaluate_arith_circuit_poly(&query128x1b, &poly);
@@ -100,6 +101,7 @@ fn benchmark_evaluate(c: &mut Criterion) {
 		});
 	});
 	group.bench_function("composition_poly_16x8b", |bench| {
+		#[allow(deprecated)]
 		let poly = composition_poly!([h4, h5, h6, ch] = (h4 * h5 + (1 - h4) * h6) - ch);
 		bench.iter(|| {
 			evaluate_arith_circuit_poly(&query16x8b, &poly);
@@ -117,6 +119,7 @@ fn benchmark_evaluate(c: &mut Criterion) {
 		});
 	});
 	group.bench_function("composition_poly_1x128b", |bench| {
+		#[allow(deprecated)]
 		let poly = composition_poly!([h4, h5, h6, ch] = (h4 * h5 + (1 - h4) * h6) - ch);
 		bench.iter(|| {
 			evaluate_arith_circuit_poly(&query1x128b, &poly);
@@ -141,6 +144,7 @@ fn benchmark_evaluate(c: &mut Criterion) {
 		});
 	});
 	group.bench_function("composition_poly_128x1b", |bench| {
+		#[allow(deprecated)]
 		let poly = composition_poly!([h4, h5, h6, ch] = (h4 * h5 + (1 - h4) * h6) - ch);
 		bench.iter(|| {
 			poly.batch_evaluate(&batch_query128x1b, &mut results128x1b)
@@ -163,6 +167,7 @@ fn benchmark_evaluate(c: &mut Criterion) {
 		});
 	});
 	group.bench_function("composition_poly_16x8b", |bench| {
+		#[allow(deprecated)]
 		let poly = composition_poly!([h4, h5, h6, ch] = (h4 * h5 + (1 - h4) * h6) - ch);
 		bench.iter(|| {
 			poly.batch_evaluate(&batch_query16x8b, &mut results16x8b)
@@ -185,6 +190,7 @@ fn benchmark_evaluate(c: &mut Criterion) {
 		});
 	});
 	group.bench_function("composition_poly_1x128b", |bench| {
+		#[allow(deprecated)]
 		let poly = composition_poly!([h4, h5, h6, ch] = (h4 * h5 + (1 - h4) * h6) - ch);
 		bench.iter(|| {
 			poly.batch_evaluate(&batch_query1x128b, &mut results1x128b)

--- a/crates/core/src/protocols/evalcheck/tests.rs
+++ b/crates/core/src/protocols/evalcheck/tests.rs
@@ -409,6 +409,7 @@ where
 	let select_row2_oracle_id = oracles.add_transparent(select_row2.clone()).unwrap();
 	let select_row3_oracle_id = oracles.add_transparent(select_row3.clone()).unwrap();
 
+	#[allow(deprecated)]
 	let comp = arith_expr!(FExtension[x, y, z] = x * y + z * y + z);
 
 	let values: [FExtension; 4] = array::from_fn(|_| <FExtension as Field>::random(&mut rng));

--- a/crates/core/src/protocols/greedy_evalcheck/tests.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/tests.rs
@@ -78,6 +78,7 @@ where
 	let select_row2_oracle_id = oracles.add_transparent(select_row2.clone()).unwrap();
 	let select_row3_oracle_id = oracles.add_transparent(select_row3.clone()).unwrap();
 
+	#[allow(deprecated)]
 	let comp = arith_expr!(FExtension[x, y, z] = x*y + x*z +  z);
 
 	let composite_id = oracles

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -38,6 +38,7 @@ use crate::{
 ///     F::ZERO
 /// );
 /// ```
+#[deprecated]
 #[proc_macro]
 pub fn composition_poly(input: TokenStream) -> TokenStream {
 	parse_macro_input!(input as CompositionPolyItem)
@@ -62,6 +63,7 @@ pub fn composition_poly(input: TokenStream) -> TokenStream {
 ///     (Expr::Const(BinaryField8b::new(3)) * Expr::Var(0) + Expr::Const(BinaryField8b::new(15))).into()
 /// );
 /// ```
+#[deprecated]
 #[proc_macro]
 pub fn arith_expr(input: TokenStream) -> TokenStream {
 	parse_macro_input!(input as ArithExprItem)

--- a/crates/macros/tests/composition_poly.rs
+++ b/crates/macros/tests/composition_poly.rs
@@ -17,6 +17,7 @@ macro_rules! test_arithmetic_poly {
             #[allow(non_snake_case)]
             #[test]
             fn [<evaluate _ $field _ $packed>] () {
+            	#[allow(deprecated)]
                 let circuit = composition_poly!([x0, x1] = x0 + x0 * x1 + 1, $field);
 
                 let mut rng = StdRng::seed_from_u64(0);

--- a/examples/b32_mul.rs
+++ b/examples/b32_mul.rs
@@ -1,5 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+// Uses binius_circuits which is being phased out.
+#![allow(deprecated)]
+
 use anyhow::Result;
 use binius_circuits::builder::{ConstraintSystemBuilder, types::U};
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger};

--- a/examples/bitwise_ops.rs
+++ b/examples/bitwise_ops.rs
@@ -1,5 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+// Uses binius_circuits which is being phased out.
+#![allow(deprecated)]
+
 use std::{fmt::Display, str::FromStr};
 
 use anyhow::Result;

--- a/examples/blake3_circuit.rs
+++ b/examples/blake3_circuit.rs
@@ -1,5 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+// Uses binius_circuits which is being phased out.
+#![allow(deprecated)]
+
 use std::array;
 
 use anyhow::Result;

--- a/examples/collatz.rs
+++ b/examples/collatz.rs
@@ -1,5 +1,10 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+// Uses binius_circuits which is being phased out.
+//
+// See crates/m3/tests/collatz.rs
+#![allow(deprecated)]
+
 use anyhow::Result;
 use binius_circuits::{
 	builder::{ConstraintSystemBuilder, types::U},

--- a/examples/groestl.rs
+++ b/examples/groestl.rs
@@ -1,5 +1,10 @@
 // Copyright 2025 Irreducible Inc.
 
+// Uses binius_circuits which is being phased out.
+//
+// See crates/m3/tests/groestl.rs
+#![allow(deprecated)]
+
 use std::{array, iter::repeat_with};
 
 use anyhow::Result;

--- a/examples/keccak.rs
+++ b/examples/keccak.rs
@@ -1,5 +1,8 @@
 // Copyright 2025 Irreducible Inc.
 
+// Uses binius_circuits which is being phased out.
+#![allow(deprecated)]
+
 use std::iter::repeat_with;
 
 use anyhow::Result;

--- a/examples/modular_mul.rs
+++ b/examples/modular_mul.rs
@@ -1,5 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+// Uses binius_circuits which is being phased out.
+#![allow(deprecated)]
+
 use std::array;
 
 use alloy_primitives::U512;

--- a/examples/sha256_circuit.rs
+++ b/examples/sha256_circuit.rs
@@ -1,5 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+// Uses binius_circuits which is being phased out.
+#![allow(deprecated)]
+
 use anyhow::Result;
 use binius_circuits::{
 	builder::{ConstraintSystemBuilder, types::U},

--- a/examples/sha256_circuit_with_lookup.rs
+++ b/examples/sha256_circuit_with_lookup.rs
@@ -1,5 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+// Uses binius_circuits which is being phased out.
+#![allow(deprecated)]
+
 use anyhow::Result;
 use binius_circuits::{
 	builder::{ConstraintSystemBuilder, types::U},

--- a/examples/u32_add.rs
+++ b/examples/u32_add.rs
@@ -1,5 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+// Uses binius_circuits which is being phased out.
+#![allow(deprecated)]
+
 use anyhow::Result;
 use binius_circuits::{
 	arithmetic::Flags,

--- a/examples/u32_mul.rs
+++ b/examples/u32_mul.rs
@@ -1,5 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+// Uses binius_circuits which is being phased out.
+#![allow(deprecated)]
+
 use std::array;
 
 use anyhow::Result;

--- a/examples/u32_mul_gkr.rs
+++ b/examples/u32_mul_gkr.rs
@@ -1,5 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+// Uses binius_circuits which is being phased out.
+#![allow(deprecated)]
+
 use std::iter::repeat_with;
 
 use anyhow::Result;

--- a/examples/u32add_with_lookup.rs
+++ b/examples/u32add_with_lookup.rs
@@ -1,5 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+// Uses binius_circuits which is being phased out.
+#![allow(deprecated)]
+
 use anyhow::Result;
 use binius_circuits::builder::{ConstraintSystemBuilder, types::U};
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger};

--- a/examples/u64_mul.rs
+++ b/examples/u64_mul.rs
@@ -1,5 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+// Uses binius_circuits which is being phased out.
+#![allow(deprecated)]
+
 use std::iter::repeat_with;
 
 use anyhow::Result;

--- a/examples/u8mul.rs
+++ b/examples/u8mul.rs
@@ -1,5 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+// Uses binius_circuits which is being phased out.
+#![allow(deprecated)]
+
 use anyhow::Result;
 use binius_circuits::{
 	builder::{ConstraintSystemBuilder, types::U},

--- a/examples/vision32b_circuit.rs
+++ b/examples/vision32b_circuit.rs
@@ -7,6 +7,9 @@
 //!
 //! [Vision Mark-32]: https://eprint.iacr.org/2024/633
 
+// Uses binius_circuits which is being phased out.
+#![allow(deprecated)]
+
 use std::array;
 
 use anyhow::Result;


### PR DESCRIPTION
`binius_circuits` is the legacy frontend for binius and is now being phased out
in favor of the newer `binius_m3` library.