### PR TITLE
[core] Add Rayon cargo feature

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -68,8 +68,9 @@ name = "sumcheck"
 harness = false
 
 [features]
-debug_validate_sumcheck = []
 default = ["nightly_features"]
+debug_validate_sumcheck = []
+rayon = ["binius_maybe_rayon/rayon"]
 nightly_features = [
     "binius_field/nightly_features",
     "binius_hal/nightly_features",


### PR DESCRIPTION
This will let us run benchmarks in the `binius_core` package with multithreading.