### PR TITLE
evalcheck mle position switch advice to message

### DIFF
--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -511,7 +511,7 @@ where
 					.position(|(ep, _)| *ep == eval_point)
 					.unwrap_or(self.new_mlechecks_constraints.len());
 
-				transcript.decommitment().write(&(position as u32));
+				transcript.message().write(&(position as u32));
 
 				add_composite_sumcheck_to_constraints(
 					position,

--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -273,7 +273,7 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 				)?;
 			}
 			MultilinearPolyVariant::Composite(composite) => {
-				let position = transcript.decommitment().read::<u32>()? as usize;
+				let position = transcript.message().read::<u32>()? as usize;
 
 				if let Some((constraints_eval_point, _)) =
 					self.new_mlechecks_constraints.get(position)


### PR DESCRIPTION
### TL;DR

Changed transcript method from `decommitment()` to `message()` in evalcheck protocol.

### What changed?

Updated the transcript handling in the evalcheck protocol implementation:
- In `prove.rs`, changed `transcript.decommitment().write(&(position as u32))` to `transcript.message().write(&(position as u32))`
- In `verify.rs`, changed `transcript.decommitment().read::<u32>()?` to `transcript.message().read::<u32>()?`

### How to test?

Run the existing test suite for the evalcheck protocol to ensure that the protocol still functions correctly with the updated transcript method calls.

### Why make this change?

Nitpicking, but this change is necessary for maintaining a deterministic verifier. Otherwise the prover has control over how sumcheck claims are grouped together which influences other parts of the protocol.