### PR TITLE
[CODEOWNERS] Destroy it

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,0 @@
-# Code owners for the entire repository
-* @jimpo @onesk @GraDKh
-
-# Code owners for specific crates
-/crates/m3 @jimpo @bergkvist
-
-# Code owners for the .github path
-/.github/ @IrreducibleOSS/Infrastructure


### PR DESCRIPTION
We are removing the CODEOWNERS file. Pull requests still require one approval to be merged, but there are no specially designated "code owners" who are given the rights to approve.

All Binius developers are now entrusted to act as code owners. They means we will all monitor new PRs against the repo. Any PRs that we believe we are capable of reviewing well, we will assign ourselves to. If it looks good, every developer has permission to approve and merge.