### PR TITLE
BivariateProductSumcheck Borrows Host Allocator

### DIFF
--- a/crates/core/src/protocols/sumcheck/v3/bivariate_product.rs
+++ b/crates/core/src/protocols/sumcheck/v3/bivariate_product.rs
@@ -27,7 +27,7 @@ use crate::{
 pub struct BivariateSumcheckProver<'a, 'alloc, F: Field, Hal: ComputeLayer<F>> {
 	hal: &'a Hal,
 	dev_alloc: &'a BumpAllocator<'alloc, F, Hal::DevMem>,
-	host_alloc: HostBumpAllocator<'a, F>,
+	host_alloc: &'a HostBumpAllocator<'a, F>,
 	n_vars_initial: usize,
 	n_vars_remaining: usize,
 	multilins: Vec<SumcheckMultilinear<'a, F, Hal::DevMem>>,
@@ -43,7 +43,7 @@ where
 	pub fn new(
 		hal: &'a Hal,
 		dev_alloc: &'a BumpAllocator<'alloc, F, Hal::DevMem>,
-		host_alloc: HostBumpAllocator<'a, F>,
+		host_alloc: &'a HostBumpAllocator<'a, F>,
 		claim: &SumcheckClaim<F, IndexComposition<BivariateProduct, 2>>,
 		multilins: Vec<FSlice<'a, F, Hal>>,
 	) -> Result<Self, Error> {
@@ -659,7 +659,7 @@ mod tests {
 		);
 
 		let prover =
-			BivariateSumcheckProver::new(hal, &dev_alloc, host_alloc, &claim, dev_multilins)
+			BivariateSumcheckProver::new(hal, &dev_alloc, &host_alloc, &claim, dev_multilins)
 				.unwrap();
 
 		let mut transcript = ProverTranscript::<HasherChallenger<Groestl256>>::new();


### PR DESCRIPTION
The host allocator is no longer consumed, by the BivariateSumcheckProver on creation.