### PR TITLE
Stacked Allocation Pattern for ComputeLayer memory

### DIFF
--- a/crates/compute/src/alloc.rs
+++ b/crates/compute/src/alloc.rs
@@ -125,24 +125,17 @@ mod tests {
 	fn test_stack_alloc() {
 		let mut data = (0..256u128).collect::<Vec<_>>();
 		let mut bump = BumpAllocator::<u128, CpuMemory>::new(&mut data);
-		println!("got here");
 		assert_eq!(bump.alloc(100).unwrap().len(), 100);
-		println!("got here");
-
 		assert_matches!(bump.alloc(200), Err(Error::OutOfMemory));
 
 		{
 			let next_layer_memory = bump.remaining();
 			let bump2 = BumpAllocator::<u128, CpuMemory>::new(next_layer_memory);
-			let _ = bump2.alloc(100);
-			println!("got here");
-
-			// let _ = bump.alloc(100);
-			println!("got here");
+			let _ = bump2.alloc(100).unwrap();
+			assert_matches!(bump2.alloc(57), Err(Error::OutOfMemory));
+			let _ = bump2.alloc(56).unwrap();
 		}
-		// Release memory all at once.
 
-		let data = bump.alloc(100).unwrap();
-		assert_eq!(data.len(), 100);
+		let _ = bump.alloc(100).unwrap();
 	}
 }

--- a/crates/compute/src/alloc.rs
+++ b/crates/compute/src/alloc.rs
@@ -72,8 +72,10 @@ impl<'a, F, Mem: ComputeMemory<F>> ComputeAllocator<'a, F, Mem> for BumpAllocato
 	}
 
 	fn remaining(&mut self) -> &mut Mem::FSliceMut<'a> {
-		let buffer = self.buffer.get_mut().as_mut().expect("");
-		buffer
+		self.buffer
+			.get_mut()
+			.as_mut()
+			.expect("buffer is always Some by invariant")
 	}
 
 	fn capacity(&self) -> usize {

--- a/crates/compute/src/alloc.rs
+++ b/crates/compute/src/alloc.rs
@@ -5,7 +5,7 @@ use std::cell::Cell;
 use super::memory::{ComputeMemory, SizedSlice};
 use crate::cpu::CpuMemory;
 
-pub trait ComputeAllocator<'a, F, Mem: ComputeMemory<F>> {
+pub trait ComputeAllocator<F, Mem: ComputeMemory<F>> {
 	/// Allocates a slice of elements.
 	///
 	/// This method operates on an immutable self reference so that multiple allocator references
@@ -52,7 +52,7 @@ where
 	}
 }
 
-impl<'a, F, Mem: ComputeMemory<F>> ComputeAllocator<'a, F, Mem> for BumpAllocator<'a, F, Mem> {
+impl<'a, F, Mem: ComputeMemory<F>> ComputeAllocator<F, Mem> for BumpAllocator<'a, F, Mem> {
 	fn alloc(&self, n: usize) -> Result<Mem::FSliceMut<'_>, Error> {
 		let buffer = self
 			.buffer

--- a/crates/compute/src/alloc.rs
+++ b/crates/compute/src/alloc.rs
@@ -18,9 +18,9 @@ pub trait ComputeAllocator<F, Mem: ComputeMemory<F>> {
 	fn alloc(&self, n: usize) -> Result<Mem::FSliceMut<'_>, Error>;
 
 	/// Allocates the remaining elements in the slice
-	/// 
-	/// This allows another allocator to have unique mutable access to the rest of the elements in this
-	/// allocator until it gets dropped, at which point this allocator can be used again
+	///
+	/// This allows another allocator to have unique mutable access to the rest of the elements in
+	/// this allocator until it gets dropped, at which point this allocator can be used again
 	fn remaining(&mut self) -> Mem::FSliceMut<'_>;
 
 	/// Returns the remaining number of elements that can be allocated.
@@ -31,6 +31,7 @@ pub trait ComputeAllocator<F, Mem: ComputeMemory<F>> {
 /// construction.
 pub struct BumpAllocator<'a, F, Mem: ComputeMemory<F>> {
 	buffer: Cell<Option<Mem::FSliceMut<'a>>>,
+	
 }
 
 impl<'a, F, Mem> BumpAllocator<'a, F, Mem>
@@ -76,7 +77,6 @@ impl<'a, F, Mem: ComputeMemory<F>> ComputeAllocator<F, Mem> for BumpAllocator<'a
 			.buffer
 			.take()
 			.expect("buffer is always Some by invariant");
-
 		Mem::narrow_mut(buffer)
 	}
 
@@ -129,14 +129,21 @@ mod tests {
 	fn test_stack_alloc() {
 		let mut data = (0..256u128).collect::<Vec<_>>();
 		let mut bump = BumpAllocator::<u128, CpuMemory>::new(&mut data);
+		println!("got here");
 		assert_eq!(bump.alloc(100).unwrap().len(), 100);
+		println!("got here");
+
 		assert_matches!(bump.alloc(200), Err(Error::OutOfMemory));
 
 		{
 			let next_layer_memory = bump.remaining();
 			let bump2 = BumpAllocator::<u128, CpuMemory>::new(next_layer_memory);
 			let _ = bump2.alloc(100);
-			let _ = bump.alloc(100);
+			println!("got here");
+
+			// let _ = bump.alloc(100);
+			println!("got here");
+
 		}
 		// Release memory all at once.
 

--- a/crates/compute/src/alloc.rs
+++ b/crates/compute/src/alloc.rs
@@ -21,7 +21,7 @@ pub trait ComputeAllocator<'a, F, Mem: ComputeMemory<F>> {
 	///
 	/// This allows another allocator to have unique mutable access to the rest of the elements in
 	/// this allocator until it gets dropped, at which point this allocator can be used again
-	fn remaining(&mut self) -> &mut Mem::FSliceMut<'a>;
+	fn remaining(&mut self) -> Mem::FSliceMut<'_>;
 
 	/// Returns the remaining number of elements that can be allocated.
 	fn capacity(&self) -> usize;
@@ -71,11 +71,13 @@ impl<'a, F, Mem: ComputeMemory<F>> ComputeAllocator<'a, F, Mem> for BumpAllocato
 		}
 	}
 
-	fn remaining(&mut self) -> &mut Mem::FSliceMut<'a> {
-		self.buffer
-			.get_mut()
-			.as_mut()
-			.expect("buffer is always Some by invariant")
+	fn remaining(&mut self) -> Mem::FSliceMut<'_> {
+		Mem::to_owned_mut(
+			self.buffer
+				.get_mut()
+				.as_mut()
+				.expect("buffer is always Some by invariant"),
+		)
 	}
 
 	fn capacity(&self) -> usize {

--- a/crates/compute/src/alloc.rs
+++ b/crates/compute/src/alloc.rs
@@ -17,7 +17,7 @@ pub trait ComputeAllocator<F, Mem: ComputeMemory<F>> {
 	/// - `n` must be a multiple of `Mem::MIN_SLICE_LEN`
 	fn alloc(&self, n: usize) -> Result<Mem::FSliceMut<'_>, Error>;
 
-	/// Allocates the remaining elements in the slice
+	/// Borrow the remaining unallocated capacity.
 	///
 	/// This allows another allocator to have unique mutable access to the rest of the elements in
 	/// this allocator until it gets dropped, at which point this allocator can be used again

--- a/crates/compute/src/cpu/memory.rs
+++ b/crates/compute/src/cpu/memory.rs
@@ -59,6 +59,10 @@ impl<F: 'static> ComputeMemory<F> for CpuMemory {
 	) -> (Self::FSliceMut<'_>, Self::FSliceMut<'_>) {
 		data.split_at_mut(mid)
 	}
+
+	fn to_owned_mut<'a>(data: &'a mut &mut [F]) -> &'a mut [F] {
+		data
+	}
 }
 
 #[cfg(test)]

--- a/crates/compute/src/memory.rs
+++ b/crates/compute/src/memory.rs
@@ -38,6 +38,9 @@ pub trait ComputeMemory<F> {
 	/// Borrows a mutable memory slice, narrowing the lifetime.
 	fn narrow_mut<'a, 'b: 'a>(data: Self::FSliceMut<'b>) -> Self::FSliceMut<'a>;
 
+	// Converts a reference to an FSliceMut to an FSliceMut
+	fn to_owned_mut<'a>(data: &'a mut Self::FSliceMut<'_>) -> Self::FSliceMut<'a>;
+
 	/// Borrows a mutable memory slice as immutable.
 	///
 	/// This allows the immutable reference to be copied.

--- a/crates/fast_compute/src/memory.rs
+++ b/crates/fast_compute/src/memory.rs
@@ -58,9 +58,9 @@ impl<P: PackedField> ComputeMemory<P::Scalar> for PackedMemory<P> {
 		data
 	}
 
-	fn to_owned_mut<'a>(data: &'a mut Self::FSliceMut<'_>) -> Self::FSliceMut<'a>{
-        Self::FSliceMut::new(data.data)
-    }
+	fn to_owned_mut<'a>(data: &'a mut Self::FSliceMut<'_>) -> Self::FSliceMut<'a> {
+		Self::FSliceMut::new(data.data)
+	}
 }
 
 impl<P: PackedField> PackedMemory<P> {

--- a/crates/fast_compute/src/memory.rs
+++ b/crates/fast_compute/src/memory.rs
@@ -57,6 +57,10 @@ impl<P: PackedField> ComputeMemory<P::Scalar> for PackedMemory<P> {
 	fn narrow_mut<'a, 'b: 'a>(data: Self::FSliceMut<'b>) -> Self::FSliceMut<'a> {
 		data
 	}
+
+	fn to_owned_mut<'a>(data: &'a mut Self::FSliceMut<'_>) -> Self::FSliceMut<'a>{
+        Self::FSliceMut::new(data.data)
+    }
 }
 
 impl<P: PackedField> PackedMemory<P> {


### PR DESCRIPTION
Added ```remaining``` method to ComputeLayer allocators to create stack frames of ComputeLayer memory that are freed once the memory returned by ```remaining``` goes out of scope.