### PR TITLE
[Evalcheck] use partial_evals to improve evalcheck performance

### DIFF
--- a/crates/core/src/protocols/evalcheck/evalcheck.rs
+++ b/crates/core/src/protocols/evalcheck/evalcheck.rs
@@ -119,14 +119,19 @@ impl<T: Clone, F: Field> EvalPointOracleIdMap<T, F> {
 	}
 
 	/// Insert a new evaluation point for a given oracle id.
-	///
-	/// We do not replace existing values.
 	pub fn insert(&mut self, id: OracleId, eval_point: EvalPoint<F>, val: T) {
 		if id.index() >= self.data.len() {
 			self.data.resize(id.index() + 1, Vec::new());
 		}
 
-		self.data[id.index()].push((eval_point, val))
+		if self.get(id, &eval_point).is_none() {
+			self.data[id.index()].push((eval_point, val))
+		}
+	}
+
+	/// Returns `true` if the map contains a value.
+	pub fn contains(&self, id: OracleId, eval_point: &EvalPoint<F>) -> bool {
+		self.get(id, eval_point).is_some()
 	}
 
 	/// Flatten the data structure into a vector of values.

--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -255,9 +255,7 @@ where
 			partial_eval,
 		} in partial_evals.into_iter().flatten()
 		{
-			if self.partial_evals.get(id, &suffix).is_none() {
-				self.partial_evals.insert(id, suffix, partial_eval)
-			}
+			self.partial_evals.insert(id, suffix, partial_eval);
 		}
 
 		for subclaim in &subclaims {
@@ -346,11 +344,7 @@ where
 		eval_point: EvalPoint<F>,
 		eval: Option<F>,
 	) {
-		if self
-			.visited_claims
-			.get(multilinear_id, &eval_point)
-			.is_some()
-		{
+		if self.visited_claims.contains(multilinear_id, &eval_point) {
 			return;
 		}
 
@@ -358,25 +352,15 @@ where
 			.insert(multilinear_id, eval_point.clone(), ());
 
 		if let Some(eval) = eval {
-			if self
-				.evals_memoization
-				.get(multilinear_id, &eval_point)
-				.is_none()
-			{
-				self.evals_memoization
-					.insert(multilinear_id, eval_point.clone(), eval);
-			}
+			self.evals_memoization
+				.insert(multilinear_id, eval_point.clone(), eval);
 		}
 
 		let multilinear = self.oracles.oracle(multilinear_id);
 
 		match multilinear.variant {
 			MultilinearPolyVariant::Shifted(_) => {
-				if self
-					.evals_memoization
-					.get(multilinear_id, &eval_point)
-					.is_none()
-				{
+				if !self.evals_memoization.contains(multilinear_id, &eval_point) {
 					self.collect_suffixes(multilinear_id, eval_point.clone());
 
 					self.claims_to_be_evaluated
@@ -463,11 +447,7 @@ where
 				self.collect_subclaims_for_memoization(id, inner_eval_point, None);
 			}
 			_ => {
-				if self
-					.evals_memoization
-					.get(multilinear_id, &eval_point)
-					.is_none()
-				{
+				if !self.evals_memoization.contains(multilinear_id, &eval_point) {
 					self.claims_to_be_evaluated
 						.insert((multilinear_id, eval_point));
 				}

--- a/crates/core/src/protocols/evalcheck/subclaims.rs
+++ b/crates/core/src/protocols/evalcheck/subclaims.rs
@@ -362,9 +362,7 @@ where
 		partial_eval,
 	} in new_partial_evals?.into_iter().flatten()
 	{
-		if partial_evals.get(id, &suffix).is_none() {
-			partial_evals.insert(id, suffix, partial_eval)
-		}
+		partial_evals.insert(id, suffix, partial_eval)
 	}
 
 	Ok(())


### PR DESCRIPTION
### TL;DR

Optimize Evalcheck prover by implementing partial evaluation caching for multilinear polynomials with shared suffixes.

### What changed?

- Added `try_get_prefix` method to `EvalPoint` to extract prefix when a suffix is known
- Implemented a caching system for partial evaluations of multilinear polynomials
- Added tracking of oracle suffixes to identify opportunities for reusing partial evaluations
- Modified `make_new_eval_claim` to leverage cached partial evaluations when available
- Refactored `calculate_projected_mles` to `collect_projected_mles` to better reflect its purpose
- Updated the bivariate sumcheck processing to use the partial evaluation cache

This optimization reduces redundant computation by caching partial evaluations of multilinear polynomials. When multiple evaluation points share the same suffix, we can compute the partial evaluation for the suffix once and reuse it across all points with that suffix. This is particularly beneficial for shifted and projected polynomial variants, where the same suffix appears frequently in different evaluation contexts.

### Singlehanded evalcheck results:
keccak: 22s -> 5s
groestl  36s ->6.49s
sha256: 5s -> 5s
