### PR TITLE
[Evalcheck] first draft evalcheck squaring

### DIFF
--- a/crates/core/src/constraint_system/validate.rs
+++ b/crates/core/src/constraint_system/validate.rs
@@ -242,6 +242,15 @@ where
 				});
 			}
 		}
+		MultilinearPolyVariant::Squared(inner_id) => {
+			let inner_poly = witness.get_multilin_poly(*inner_id)?;
+			let squared = witness.get_multilin_poly(oracle.id())?;
+			for i in 1..1 << n_vars {
+				let inner_poly_value = inner_poly.evaluate_on_hypercube(i)?;
+				let squared_value = squared.evaluate_on_hypercube(i)?;
+				check_eval(oracle_label, i, inner_poly_value * inner_poly_value, squared_value)?;
+			}
+		}
 		MultilinearPolyVariant::Composite(composite_mle) => {
 			let inner_polys = composite_mle
 				.polys()

--- a/crates/core/src/constraint_system/validate.rs
+++ b/crates/core/src/constraint_system/validate.rs
@@ -245,7 +245,7 @@ where
 		MultilinearPolyVariant::Squared(inner_id) => {
 			let inner_poly = witness.get_multilin_poly(*inner_id)?;
 			let squared = witness.get_multilin_poly(oracle.id())?;
-			for i in 1..1 << n_vars {
+			for i in 0..1 << n_vars {
 				let inner_poly_value = inner_poly.evaluate_on_hypercube(i)?;
 				let squared_value = squared.evaluate_on_hypercube(i)?;
 				check_eval(oracle_label, i, inner_poly_value * inner_poly_value, squared_value)?;

--- a/crates/core/src/oracle/multilinear.rs
+++ b/crates/core/src/oracle/multilinear.rs
@@ -263,6 +263,19 @@ impl<F: TowerField> MultilinearOracleSetAddition<'_, F> {
 		Ok(self.mut_ref.add_to_set(oracle))
 	}
 
+	pub fn squared(self, inner_id: OracleId) -> OracleId {
+		let inner = self.mut_ref.get_from_set(inner_id);
+
+		let oracle = |id: OracleId| MultilinearPolyOracle {
+			id,
+			n_vars: inner.n_vars,
+			tower_level: inner.binary_tower_level(),
+			name: self.name,
+			variant: MultilinearPolyVariant::Squared(inner_id),
+		};
+		self.mut_ref.add_to_set(oracle)
+	}
+
 	pub fn composite_mle(
 		self,
 		n_vars: usize,
@@ -505,6 +518,10 @@ impl<F: TowerField> MultilinearOracleSet<F> {
 			.zero_padded(id, n_pad_vars, nonzero_index, start_index)
 	}
 
+	pub fn add_squared(&mut self, id: OracleId) -> OracleId {
+		self.add().squared(id)
+	}
+
 	pub fn add_composite_mle(
 		&mut self,
 		n_vars: usize,
@@ -580,6 +597,7 @@ pub enum MultilinearPolyVariant<F: TowerField> {
 	Packed(Packed),
 	LinearCombination(LinearCombination<F>),
 	ZeroPadded(ZeroPadded),
+	Squared(OracleId),
 	Composite(CompositeMLE<F>),
 }
 
@@ -932,6 +950,7 @@ impl<F: TowerField> MultilinearPolyOracle<F> {
 			MultilinearPolyVariant::Packed(_) => "Packed",
 			MultilinearPolyVariant::LinearCombination(_) => "LinearCombination",
 			MultilinearPolyVariant::ZeroPadded(_) => "ZeroPadded",
+			MultilinearPolyVariant::Squared(_) => "Squared",
 			MultilinearPolyVariant::Composite(_) => "CompositeMLE",
 		}
 	}

--- a/crates/core/src/protocols/evalcheck/error.rs
+++ b/crates/core/src/protocols/evalcheck/error.rs
@@ -41,8 +41,22 @@ pub enum VerificationError {
 	IncorrectCompositePolyEvaluation(String),
 	#[error("subproof type or shape does not match the claim")]
 	SubproofMismatch,
-	#[error("Advised MLECheck ConstraintSet positios must has the same eval_point")]
+	#[error("`position` in SquareRoot case must be no more than `square_roots_memoization.len()`")]
+	SquareRootPositionMismatch,
+	#[error(
+		"`position` in SquareRoot case must point to a triple `(eval_point', _, sqrt_eval)` in `square_roots_memoization` with `eval_point' = eval_point` and `sqrt_eval^2 = eval`"
+	)]
+	SquareRootEvalPointMismatch,
+	#[error(
+		"when `position = square_roots_memoization.len()`, transcript must yield the square root of `eval_point` and `eval`"
+	)]
+	SquareRootWrongSqrtEvalPoint,
+	#[error("`position` in Composite case must be no more than `new_mlechecks_constraints.len()`")]
 	MLECheckConstraintSetPositionMismatch,
+	#[error(
+		"`position` in Composite case must point to an identical eval point in `new_mlechecks_constraints`"
+	)]
+	MLECheckConstraintSetEvalPointMismatch,
 	#[error("LinearCombination must contain an eval")]
 	MissingLinearCombinationEval,
 	#[error("The referenced duplicate claim is different from expected")]

--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -572,44 +572,44 @@ where
 				)?;
 			}
 			MultilinearPolyVariant::Squared(id) => {
-				let (sqrt_eval_point, sqrt_eval) = if let Some(position) = self
+				let position = if let Some(position) = self
 					.square_roots_memoization
 					.iter()
 					.position(|(ep, _, _)| *ep == eval_point)
 				{
 					transcript.message().write(&(position as u32));
-					let (_, sqrt_eval_point, sqrt_eval) = &self.square_roots_memoization[position];
-					(sqrt_eval_point.clone(), *sqrt_eval)
+					position
 				} else {
-					transcript
-						.message()
-						.write(&(self.square_roots_memoization.len() as u32));
+					let position = self.square_roots_memoization.len();
+					transcript.message().write(&(position as u32));
 
-					let sqrt_eval_point_values = eval_point
+					let sqrt_eval_point = eval_point
 						.iter()
 						.map(|x| x.square_root())
 						.collect::<Vec<_>>();
 					transcript
 						.message()
-						.write_scalar_slice(sqrt_eval_point_values.as_slice());
-					let sqrt_eval_point = EvalPoint::from(sqrt_eval_point_values);
+						.write_scalar_slice(sqrt_eval_point.as_slice());
 
 					let sqrt_eval = eval.square_root();
 					transcript.message().write_scalar(sqrt_eval);
 
 					self.square_roots_memoization.push((
 						eval_point.clone(),
-						sqrt_eval_point.clone(),
+						sqrt_eval_point.into(),
 						sqrt_eval,
 					));
-					(sqrt_eval_point, sqrt_eval)
+
+					position
 				};
+
+				let (_, sqrt_eval_point, sqrt_eval) = &self.square_roots_memoization[position];
 
 				self.prove_multilinear(
 					EvalcheckMultilinearClaim {
 						id,
-						eval_point: sqrt_eval_point,
-						eval: sqrt_eval,
+						eval_point: sqrt_eval_point.clone(),
+						eval: *sqrt_eval,
 					},
 					transcript,
 				)?;

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -88,7 +88,7 @@ where
 	/// Inefficiently computes the unique square root of the input.
 	fn square_root(self) -> Self {
 		let exponent: u128 = 1 << (Self::DEGREE - 1);
-		<Self as crate::field::Field>::pow(&self, [exponent as u64, (exponent >> 64) as u64])
+		<Self as Field>::pow(&self, [exponent as u64, (exponent >> 64) as u64])
 	}
 }
 

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -84,6 +84,12 @@ where
 	fn mul_primitive(self, iota: usize) -> Result<Self, Error> {
 		Ok(self * <Self as ExtensionField<BinaryField1b>>::basis_checked(1 << iota)?)
 	}
+
+	/// Inefficiently computes the unique square root of the input.
+	fn square_root(self) -> Self {
+		let exponent: u128 = 1 << (Self::DEGREE - 1);
+		<Self as crate::field::Field>::pow(&self, [exponent as u64, (exponent >> 64) as u64])
+	}
 }
 
 /// Returns the i'th basis element of `FExt` as a field extension of `FSub`.

--- a/crates/m3/src/builder/column.rs
+++ b/crates/m3/src/builder/column.rs
@@ -153,6 +153,9 @@ pub enum ColumnDef<F: TowerField = B128> {
 		col: ColumnId,
 		log_degree: usize,
 	},
+	Squared {
+		col: ColumnId,
+	},
 	Computed {
 		cols: Vec<ColumnId>,
 		expr: ArithCircuit<F>,

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -598,6 +598,11 @@ fn add_oracle_for_column<F: TowerField>(
 			let oracle_id = oracles.add_named(name).packed(source, *log_degree)?;
 			oracle_lookup.register_regular(*column_id, oracle_id);
 		}
+		ColumnDef::Squared { col } => {
+			let source = oracle_lookup[*col];
+			let oracle_id = oracles.add_named(name).squared(source);
+			oracle_lookup.register_regular(*column_id, oracle_id);
+		}
 		ColumnDef::Computed { cols, expr } => {
 			if let Ok(LinearNormalForm {
 				constant: offset,

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -188,6 +188,24 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		)
 	}
 
+	/// Adds a derived column that is computed as the square of the input column.
+	///
+	/// The derived column has the same vertical stacking factor as the input column and its
+	/// values are squared independently. The cost of the column's evaluations are minimal
+	/// and independent of the table height. This is a special case of a computed column.
+	pub fn add_squared<FSub, const V: usize>(
+		&mut self,
+		name: impl ToString,
+		col: Col<FSub, V>,
+	) -> Col<FSub, V>
+	where
+		FSub: TowerField,
+		F: ExtensionField<FSub>,
+	{
+		self.table
+			.new_column(self.namespaced_name(name), ColumnDef::Squared { col: col.id() })
+	}
+
 	/// Adds a derived column that is computed as an expression over other columns in the table.
 	///
 	/// The derived column has the same vertical stacking factor as the input columns and its

--- a/crates/m3/tests/squared.rs
+++ b/crates/m3/tests/squared.rs
@@ -1,0 +1,97 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_field::{
+	PackedExtension, PackedFieldIndexable, arch::OptimalUnderlier128b, as_packed_field::PackedType,
+};
+use binius_m3::builder::{
+	B16, B128, Col, ConstraintSystem, TableFiller, TableId, TableWitnessSegment, WitnessIndex,
+	test_utils::validate_system_witness,
+};
+use bumpalo::Bump;
+
+const VALUES_PER_ROW: usize = 32;
+const N_ROWS: usize = 8;
+
+pub struct MyTable {
+	id: TableId,
+	committed_b128: Col<B128, VALUES_PER_ROW>,
+	squared_b128: Col<B128, VALUES_PER_ROW>,
+	committed_b16: Col<B16, VALUES_PER_ROW>,
+	squared_b16: Col<B16, VALUES_PER_ROW>,
+}
+
+impl MyTable {
+	pub fn new(cs: &mut ConstraintSystem) -> Self {
+		let mut table = cs.add_table("table_1");
+		let committed_b128 = table.add_committed::<B128, VALUES_PER_ROW>("committed b128");
+		let squared_b128 = table.add_squared("squared b128", committed_b128);
+
+		let committed_b16 = table.add_committed::<B16, VALUES_PER_ROW>("committed b16");
+		let squared_b16 = table.add_squared("squared b16", committed_b16);
+
+		table.assert_zero(
+			"squared_b128 = committed_b128^2",
+			squared_b128 - committed_b128 * committed_b128,
+		);
+		table.assert_zero(
+			"squared_b16 = committed_b16^2",
+			squared_b16 - committed_b16 * committed_b16,
+		);
+
+		Self {
+			id: table.id(),
+			committed_b128,
+			squared_b128,
+			committed_b16,
+			squared_b16,
+		}
+	}
+}
+
+impl<P> TableFiller<P> for MyTable
+where
+	P: PackedFieldIndexable<Scalar = B128> + PackedExtension<B128> + PackedExtension<B16>,
+{
+	type Event = u128;
+
+	fn id(&self) -> TableId {
+		self.id
+	}
+
+	fn fill<'a>(
+		&'a self,
+		rows: impl Iterator<Item = &'a Self::Event>,
+		witness: &'a mut TableWitnessSegment<P>,
+	) -> Result<(), anyhow::Error> {
+		let mut committed_b128 = witness.get_mut_as(self.committed_b128)?;
+		let mut squared_b128 = witness.get_mut_as(self.squared_b128)?;
+
+		let mut committed_b16 = witness.get_mut_as(self.committed_b16)?;
+		let mut squared_b16 = witness.get_mut_as(self.squared_b16)?;
+
+		for (i, &com) in rows.enumerate() {
+			for j in 0..VALUES_PER_ROW {
+				committed_b128[i * VALUES_PER_ROW + j] = com;
+				squared_b128[i * VALUES_PER_ROW + j] = B128::from(com) * B128::from(com);
+
+				committed_b16[i * VALUES_PER_ROW + j] = com as u16;
+				squared_b16[i * VALUES_PER_ROW + j] = B16::from(com as u16) * B16::from(com as u16);
+			}
+		}
+		Ok(())
+	}
+}
+
+#[test]
+fn test_squared() {
+	let allocator = Bump::new();
+	let mut cs = ConstraintSystem::<B128>::new();
+	let table = MyTable::new(&mut cs);
+
+	let mut witness = WitnessIndex::<PackedType<OptimalUnderlier128b, B128>>::new(&cs, &allocator);
+	witness
+		.fill_table_sequential(&table, &(0..N_ROWS as u128).collect::<Vec<_>>())
+		.unwrap();
+
+	validate_system_witness::<OptimalUnderlier128b>(&cs, witness, vec![]);
+}


### PR DESCRIPTION
### TL;DR

Added support for squared multilinear polynomials in the constraint system, allowing for efficient representation and verification of squared columns.

@GraDKh I imagine the square root operation should be implemented similar to the square operation, which I see is involved so I leave it to you (in this or another PR). I can discuss with you how to efficiently implement square root (not the way I have it). The important difference between square root and squaring is that square root must be confined to binary fields.

@djadjka let me know where you'd like any documentation. Hope for other feedback too. The change I made to `compositeMLE` in evalcheck is because I need to avoid `position > self.new_mlechecks_constraints.len()` in the recursive verifier, and I see no downside to enforcing it in Binius. 

### What changed?

- Added a new `Squared` variant to `MultilinearPolyVariant` that represents the square of another polynomial
- Implemented validation logic for squared polynomials in the constraint system
- Added methods to create squared polynomials in the oracle set
- Updated the evalcheck prover and verifier to handle squared polynomials, including memoization of square roots
- Added a `square_root` method to binary fields for computing square roots
- Extended the M3 builder with support for squared columns in tables

### How to test?

A new test file `crates/m3/tests/squared.rs` was added that demonstrates the functionality:
- Creates a table with committed columns and their squared variants
- Adds constraints to verify that squared columns equal the square of the original columns
- Fills the witness with values and their squares
- Validates the constraint system with the witness

### Why make this change?

Squared polynomials are a common operation in cryptographic protocols and constraint systems. This change provides a more efficient way to represent and verify squared values without having to use the more general composite or computed columns. The implementation includes optimizations like memoization of square roots during verification, which improves performance when working with squared values.