### PR TITLE
[prove] Eliminate mistake data copy

### DIFF
--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -295,7 +295,8 @@ where
 		gkr_gpa::construct_grand_product_claims(&flush_oracle_ids, &oracles, &flush_products)?;
 
 	// Prove grand products
-	let all_gpa_witnesses = [flush_prodcheck_witnesses, non_zero_prodcheck_witnesses].concat();
+	let all_gpa_witnesses =
+		chain!(flush_prodcheck_witnesses, non_zero_prodcheck_witnesses).collect::<Vec<_>>();
 	let all_gpa_claims = chain!(flush_prodcheck_claims, non_zero_prodcheck_claims)
 		.map(|claim| claim.isomorphic())
 		.collect::<Vec<_>>();


### PR DESCRIPTION
This previously did an expensive copy of witness data because `concat` clones. Instead we just recollect the vector elements.