### PR TITLE
[constraint_system] Optimize make_masked_flush_witnesses

### DIFF
--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -588,8 +588,7 @@ where
 		.par_iter()
 		.zip(flushes)
 		.map(|(&flush_oracle, flush)| {
-			let oracle = oracles.oracle(flush_oracle);
-			let n_vars = oracle.n_vars();
+			let n_vars = oracles.n_vars(flush_oracle);
 
 			let const_term = flush
 				.oracles

--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -716,7 +716,14 @@ fn count_zero_suffixes<P: PackedField, M: MultilinearPoly<P>>(poly: &M) -> usize
 			.rev()
 			.position(|&packed_eval| packed_eval != zeros)
 			.unwrap_or(packed_evals.len());
-		packed_zero_suffix_len << (P::LOG_WIDTH + poly.log_extension_degree())
+
+		let log_scalars_per_elem = P::LOG_WIDTH + poly.log_extension_degree();
+		if poly.n_vars() < log_scalars_per_elem {
+			debug_assert_eq!(packed_evals.len(), 1, "invariant of MultilinearPoly");
+			packed_zero_suffix_len << poly.n_vars()
+		} else {
+			packed_zero_suffix_len << log_scalars_per_elem
+		}
 	} else {
 		0
 	}

--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -624,7 +624,7 @@ where
 				.map(|id| witness_index.get_index_entry(*id))
 				.collect::<Result<Vec<_>, _>>()?;
 
-			// Get the number of entries before any selector column is disabled.
+			// Get the number of entries before any selector column is fully disabled.
 			let selector_prefix_len = selector_entries
 				.iter()
 				.map(|selector_entry| selector_entry.nonzero_scalars_prefix)
@@ -675,7 +675,9 @@ where
 				MultilinearExtension::new(n_vars, witness_data)
 					.expect("witness_data created with correct n_vars"),
 			);
-			Ok((witness, 0))
+			// TODO: This is sketchy. The field on witness index is called "nonzero_prefix", but
+			// I'm setting it when the suffix is 1, not zero.
+			Ok((witness, selector_prefix_len))
 		})
 		.collect::<Result<Vec<_>, Error>>()?;
 

--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -654,7 +654,7 @@ where
 						});
 
 						if selector_off {
-							// If all selectors are zero, the result is 1
+							// If any selector is zero, the result is 1
 							<FExt<Tower>>::ONE
 						} else {
 							// Otherwise, compute the linear combination

--- a/crates/maybe_rayon/src/iter/indexed_parallel_iterator.rs
+++ b/crates/maybe_rayon/src/iter/indexed_parallel_iterator.rs
@@ -39,6 +39,12 @@ pub(crate) trait IndexedParallelIteratorInner: ParallelIteratorInner {
 	}
 
 	#[inline]
+	fn collect_into_vec(self, target: &mut Vec<Self::Item>) {
+		target.clear();
+		target.extend(self);
+	}
+
+	#[inline]
 	fn zip<Z>(self, zip_op: Z) -> std::iter::Zip<Self, Z>
 	where
 		Z: IndexedParallelIteratorInner,
@@ -143,6 +149,11 @@ pub trait IndexedParallelIterator: ParallelIterator {
 		ParallelWrapper::new(IndexedParallelIteratorInner::enumerate(
 			IndexedParallelIterator::into_inner(self),
 		))
+	}
+
+	#[inline]
+	fn collect_into_vec(self, target: &mut Vec<Self::Item>) {
+		IndexedParallelIterator::into_inner(self).collect_into_vec(target)
 	}
 
 	#[inline]


### PR DESCRIPTION
# [prove] Optimize make_masked_flush_witnesses

This PR optimizes the `make_masked_flush_witnesses` function by replacing the general composition function evaluation with a more direct approach. Since we know the evaluation is a selected value, we can compute it more efficiently.

Key improvements:
- Directly computes the linear combination of oracles with mixing powers
- Handles constant terms separately from oracle terms
- Optimizes the case where selectors are zero (returning ONE)
- Avoids unnecessary computations when selectors disable parts of the computation

For PetraVM on Fibonacci example, this reduced single-threaded operation latency by ~75%.