### PR TITLE
[compute] Workaround for host allocation issue in bivariate sumcheck test

### DIFF
--- a/crates/compute_test_utils/src/bivariate_sumcheck.rs
+++ b/crates/compute_test_utils/src/bivariate_sumcheck.rs
@@ -182,10 +182,13 @@ pub fn generic_test_bivariate_sumcheck_prove_verify<F, Hal>(
 	)
 	.unwrap();
 
-	let mut host_mem =
-		hal.host_alloc(<BivariateSumcheckProver<F, Hal>>::required_host_memory(&claim));
+	// TODO[SYS-275]: Remove this once we can allocate less than 512 words on host in HW.
+	const MIN_DEVICE_TRANSFER_SIZE: usize = 1 << 9;
+	let claim_req_mem = <BivariateSumcheckProver<F, Hal>>::required_host_memory(&claim);
+	let mut host_mem = hal.host_alloc(std::cmp::max(claim_req_mem, MIN_DEVICE_TRANSFER_SIZE));
+	let host_mem = &mut host_mem.as_mut()[..claim_req_mem];
 
-	let host_alloc = HostBumpAllocator::new(host_mem.as_mut());
+	let host_alloc = HostBumpAllocator::new(host_mem);
 	let dev_alloc = BumpAllocator::new(dev_mem);
 
 	let dev_multilins = evals


### PR DESCRIPTION
Host memory allocation on the HW Compute Layer currently fails if the requested allocation size is less than 512 elements. As a temporary workaround, the test for bivariate sumcheck has been modified to always allocate at least 512 words, even if fewer are actually needed. This change can be removed once the HW Compute Layer no longer has this limitation.