### PR TITLE
[core] Introduce structured oracle type

### DIFF
--- a/crates/core/src/constraint_system/error.rs
+++ b/crates/core/src/constraint_system/error.rs
@@ -41,10 +41,11 @@ pub enum Error {
 	},
 
 	#[error(
-		"{oracle} witness has unexpected n_vars={witness_num_vars}. Expected n_vars={oracle_num_vars}"
+		"{oracle} witness has unexpected n_vars={witness_num_vars}. Expected n_vars{condition}{oracle_num_vars}"
 	)]
 	VirtualOracleNvarsMismatch {
 		oracle: String,
+		condition: char,
 		oracle_num_vars: usize,
 		witness_num_vars: usize,
 	},

--- a/crates/core/src/constraint_system/validate.rs
+++ b/crates/core/src/constraint_system/validate.rs
@@ -91,12 +91,24 @@ where
 	let n_vars = oracle.n_vars();
 	let poly = witness.get_multilin_poly(oracle.id())?;
 
-	if poly.n_vars() != n_vars {
-		bail!(Error::VirtualOracleNvarsMismatch {
-			oracle: oracle_label.into(),
-			oracle_num_vars: n_vars,
-			witness_num_vars: poly.n_vars(),
-		})
+	match oracle.variant {
+		MultilinearPolyVariant::Structured(_) if poly.n_vars() > n_vars => {
+			bail!(Error::VirtualOracleNvarsMismatch {
+				oracle: oracle_label.into(),
+				condition: '<',
+				oracle_num_vars: n_vars,
+				witness_num_vars: poly.n_vars(),
+			})
+		}
+		_ if poly.n_vars() != n_vars => {
+			bail!(Error::VirtualOracleNvarsMismatch {
+				oracle: oracle_label.into(),
+				condition: '=',
+				oracle_num_vars: n_vars,
+				witness_num_vars: poly.n_vars(),
+			})
+		}
+		_ => (),
 	}
 
 	match &oracle.variant {
@@ -110,6 +122,16 @@ where
 				let expected = inner
 					.poly()
 					.evaluate(&decompose_index_to_hypercube_point(n_vars, i))?;
+				check_eval(oracle_label, i, expected, got)?;
+			}
+		}
+		MultilinearPolyVariant::Structured(inner) => {
+			for i in 0..1 << n_vars {
+				let got = poly.evaluate_on_hypercube(i)?;
+				// NOTE: that the arith circuit can have more query parameters than `n_vars`, that's
+				//       the reason we use the arith circuit's n_vars here.
+				let eval_point = decompose_index_to_hypercube_point(inner.n_vars(), i);
+				let expected = inner.evaluate(&eval_point)?;
 				check_eval(oracle_label, i, expected, got)?;
 			}
 		}

--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -500,7 +500,7 @@ where
 		let multilinear = self.oracles.oracle(id);
 
 		match multilinear.variant {
-			MultilinearPolyVariant::Transparent { .. } => {}
+			MultilinearPolyVariant::Transparent { .. } | MultilinearPolyVariant::Structured(_) => {}
 			MultilinearPolyVariant::Committed => {
 				self.committed_eval_claims.push(EvalcheckMultilinearClaim {
 					id: multilinear.id,

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -637,10 +637,11 @@ fn add_oracle_for_column<F: TowerField>(
 			oracle_lookup.register_transparent(*column_id, oracle_id_original, oracle_id_repeating);
 		}
 		ColumnDef::StructuredDynSize(structured) => {
-			let expr = structured.expr(n_vars)?;
+			structured.check_nvars(n_vars)?;
+			let expr = structured.expr()?;
 			let oracle_id = oracles
 				.add_named(name)
-				.transparent(ArithCircuit::from(&expr))?;
+				.structured(n_vars, ArithCircuit::from(&expr))?;
 			oracle_lookup.register_regular(*column_id, oracle_id);
 		}
 		ColumnDef::StructuredFixedSize { expr } => {

--- a/crates/m3/tests/flush_multiple_selectors.rs
+++ b/crates/m3/tests/flush_multiple_selectors.rs
@@ -26,8 +26,10 @@ pub fn test_flush_multiple_selectors() {
 
 	table.require_power_of_two_size();
 
-	let structured_col =
-		table.add_structured::<B32>("incrementing", StructuredDynSize::Incrementing);
+	let structured_col = table.add_structured::<B32>(
+		"incrementing",
+		StructuredDynSize::Incrementing { max_size_log: 32 },
+	);
 
 	let selector1_col = table.add_committed::<B1, 1>("selector1");
 


### PR DESCRIPTION
Structured is an oracle type that is very similar to Transparent, but is
defined by an ArithCircuit of some upper bound of n_vars.

This oracle type is mainly motivated by the needs of structured columns. The
idea is that such a structured column will define an arith expression up to some
maximum size. The frontend can supply any table size up to that maximum.

See [CRY-396] for more details.

[CRY-396]: https://linear.app/irreducible/issue/CRY-396/transparent-oracle-type-based-on-arithcircuit