### PR TITLE
[core] introduce SizedConstraintSet

### DIFF
--- a/crates/core/src/oracle/constraint.rs
+++ b/crates/core/src/oracle/constraint.rs
@@ -33,6 +33,31 @@ pub enum ConstraintPredicate<F: Field> {
 }
 
 /// Constraint set is a group of constraints that operate over the same set of oracle-identified
+/// multilinears.
+///
+/// The difference from the [`ConstraintSet`] is that the latter is for the public API and this
+/// one should is supposed to be used within the core only.
+#[derive(Debug, Clone, SerializeBytes, DeserializeBytes)]
+pub struct SizedConstraintSet<F: Field> {
+	pub n_vars: usize,
+	pub oracle_ids: Vec<OracleId>,
+	pub constraints: Vec<Constraint<F>>,
+}
+
+impl<F: Field> SizedConstraintSet<F> {
+	pub fn new(n_vars: usize, u: ConstraintSet<F>) -> Self {
+		let oracle_ids = u.oracle_ids;
+		let constraints = u.constraints;
+
+		Self {
+			n_vars,
+			oracle_ids,
+			constraints,
+		}
+	}
+}
+
+/// Constraint set is a group of constraints that operate over the same set of oracle-identified
 /// multilinears
 #[derive(Debug, Clone, SerializeBytes, DeserializeBytes)]
 pub struct ConstraintSet<F: Field> {
@@ -98,7 +123,7 @@ impl<F: Field> ConstraintSetBuilder<F> {
 	pub fn build_one(
 		self,
 		oracles: &MultilinearOracleSet<impl TowerField>,
-	) -> Result<ConstraintSet<F>, Error> {
+	) -> Result<SizedConstraintSet<F>, Error> {
 		let mut oracle_ids = self
 			.constraints
 			.iter()
@@ -147,7 +172,7 @@ impl<F: Field> ConstraintSetBuilder<F> {
 				})
 				.collect();
 
-		Ok(ConstraintSet {
+		Ok(SizedConstraintSet {
 			n_vars,
 			oracle_ids,
 			constraints,

--- a/crates/core/src/protocols/evalcheck/prove.rs
+++ b/crates/core/src/protocols/evalcheck/prove.rs
@@ -22,8 +22,8 @@ use super::{
 use crate::{
 	fiat_shamir::Challenger,
 	oracle::{
-		ConstraintSet, ConstraintSetBuilder, Error as OracleError, MultilinearOracleSet,
-		MultilinearPolyVariant, OracleId,
+		ConstraintSetBuilder, Error as OracleError, MultilinearOracleSet, MultilinearPolyVariant,
+		OracleId, SizedConstraintSet,
 	},
 	polynomial::MultivariatePoly,
 	protocols::evalcheck::{
@@ -129,7 +129,7 @@ where
 	/// A helper method to move out bivariate sumcheck constraints
 	pub fn take_new_bivariate_sumchecks_constraints(
 		&mut self,
-	) -> Result<Vec<ConstraintSet<F>>, OracleError> {
+	) -> Result<Vec<SizedConstraintSet<F>>, OracleError> {
 		self.new_bivariate_sumchecks_constraints
 			.iter_mut()
 			.map(|builder| std::mem::take(builder).build_one(self.oracles))
@@ -881,5 +881,5 @@ where
 
 pub struct ConstraintSetEqIndPoint<F: Field> {
 	pub eq_ind_challenges: EvalPoint<F>,
-	pub constraint_set: ConstraintSet<F>,
+	pub constraint_set: SizedConstraintSet<F>,
 }

--- a/crates/core/src/protocols/evalcheck/subclaims.rs
+++ b/crates/core/src/protocols/evalcheck/subclaims.rs
@@ -27,8 +27,8 @@ use super::{EvalPoint, EvalPointOracleIdMap, error::Error, evalcheck::EvalcheckM
 use crate::{
 	fiat_shamir::Challenger,
 	oracle::{
-		CompositeMLE, ConstraintSet, ConstraintSetBuilder, Error as OracleError,
-		MultilinearOracleSet, OracleId, Packed, Shifted,
+		CompositeMLE, ConstraintSetBuilder, Error as OracleError, MultilinearOracleSet, OracleId,
+		Packed, Shifted, SizedConstraintSet,
 	},
 	polynomial::MultivariatePoly,
 	protocols::sumcheck::{
@@ -548,7 +548,7 @@ type SumcheckProofEvalcheckClaims<F> = Vec<EvalcheckMultilinearClaim<F>>;
 
 pub fn prove_bivariate_sumchecks_with_switchover<F, P, DomainField, Transcript, Backend>(
 	witness: &MultilinearExtensionIndex<P>,
-	constraint_sets: Vec<ConstraintSet<F>>,
+	constraint_sets: Vec<SizedConstraintSet<F>>,
 	transcript: &mut ProverTranscript<Transcript>,
 	switchover_fn: impl Fn(usize) -> usize + 'static,
 	domain_factory: impl EvaluationDomainFactory<DomainField>,
@@ -588,7 +588,7 @@ where
 #[allow(clippy::too_many_arguments)]
 pub fn prove_mlecheck_with_switchover<'a, F, P, DomainField, Transcript, Backend>(
 	witness: &MultilinearExtensionIndex<P>,
-	constraint_set: ConstraintSet<F>,
+	constraint_set: SizedConstraintSet<F>,
 	eq_ind_challenges: EvalPoint<F>,
 	memoized_data: &mut MemoizedData<'a, P>,
 	transcript: &mut ProverTranscript<Transcript>,

--- a/crates/core/src/protocols/evalcheck/verify.rs
+++ b/crates/core/src/protocols/evalcheck/verify.rs
@@ -19,8 +19,8 @@ use super::{
 use crate::{
 	fiat_shamir::Challenger,
 	oracle::{
-		ConstraintSet, ConstraintSetBuilder, Error as OracleError, MultilinearOracleSet,
-		MultilinearPolyVariant, OracleId,
+		ConstraintSetBuilder, Error as OracleError, MultilinearOracleSet, MultilinearPolyVariant,
+		OracleId, SizedConstraintSet,
 	},
 	polynomial::MultivariatePoly,
 	transcript::VerifierTranscript,
@@ -70,7 +70,9 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 	}
 
 	/// A helper method to move out sumcheck constraints
-	pub fn take_new_sumcheck_constraints(&mut self) -> Result<Vec<ConstraintSet<F>>, OracleError> {
+	pub fn take_new_sumcheck_constraints(
+		&mut self,
+	) -> Result<Vec<SizedConstraintSet<F>>, OracleError> {
 		self.new_sumcheck_constraints
 			.iter_mut()
 			.map(|builder| mem::take(builder).build_one(self.oracles))
@@ -350,5 +352,5 @@ impl<'a, F: TowerField> EvalcheckVerifier<'a, F> {
 
 pub struct ConstraintSetsEqIndPoints<F: Field> {
 	pub eq_ind_challenges: Vec<Vec<F>>,
-	pub constraint_sets: Vec<ConstraintSet<F>>,
+	pub constraint_sets: Vec<SizedConstraintSet<F>>,
 }

--- a/crates/core/src/protocols/greedy_evalcheck/logging.rs
+++ b/crates/core/src/protocols/greedy_evalcheck/logging.rs
@@ -7,7 +7,7 @@ use binius_utils::impl_debug_with_json;
 use serde::Serialize;
 use serde_json_any_key::any_key_map;
 
-use crate::oracle::ConstraintSet;
+use crate::oracle::SizedConstraintSet;
 
 #[derive(Serialize)]
 pub(super) struct RegularSumcheckDimensionsData {
@@ -17,7 +17,7 @@ pub(super) struct RegularSumcheckDimensionsData {
 
 impl RegularSumcheckDimensionsData {
 	pub(super) fn new<'a, F: Field>(
-		constraints: impl IntoIterator<Item = &'a ConstraintSet<F>>,
+		constraints: impl IntoIterator<Item = &'a SizedConstraintSet<F>>,
 	) -> Self {
 		let mut claim_n_vars = HashMap::new();
 		for constraint in constraints {

--- a/crates/core/src/protocols/sumcheck/oracles.rs
+++ b/crates/core/src/protocols/sumcheck/oracles.rs
@@ -12,7 +12,9 @@ use super::{
 	SumcheckClaim, ZerocheckClaim,
 };
 use crate::{
-	oracle::{Constraint, ConstraintPredicate, ConstraintSet, OracleId, TypeErasedComposition},
+	oracle::{
+		Constraint, ConstraintPredicate, OracleId, SizedConstraintSet, TypeErasedComposition,
+	},
 	protocols::evalcheck::EvalcheckMultilinearClaim,
 };
 
@@ -31,7 +33,7 @@ pub struct OracleClaimMeta {
 /// zerochecks. Returns claim and metadata used for evalcheck claim construction.
 #[allow(clippy::type_complexity)]
 pub fn constraint_set_sumcheck_claim<F: TowerField>(
-	constraint_set: ConstraintSet<F>,
+	constraint_set: SizedConstraintSet<F>,
 ) -> Result<(SumcheckClaim<F, ArithCircuitPoly<F>>, OracleClaimMeta), Error> {
 	let (constraints, meta) = split_constraint_set(constraint_set);
 	let n_multilinears = meta.oracle_ids.len();
@@ -60,7 +62,7 @@ pub fn constraint_set_sumcheck_claim<F: TowerField>(
 /// sumchecks. Returns claim and metadata used for evalcheck claim construction.
 #[allow(clippy::type_complexity)]
 pub fn constraint_set_zerocheck_claim<F: TowerField>(
-	constraint_set: ConstraintSet<F>,
+	constraint_set: SizedConstraintSet<F>,
 ) -> Result<(ZerocheckClaim<F, ArithCircuitPoly<F>>, OracleClaimMeta), Error> {
 	let (constraints, meta) = split_constraint_set(constraint_set);
 	let n_multilinears = meta.oracle_ids.len();
@@ -86,7 +88,7 @@ pub fn constraint_set_zerocheck_claim<F: TowerField>(
 
 #[allow(clippy::type_complexity)]
 pub fn constraint_set_mlecheck_claim<F: TowerField>(
-	constraint_set: ConstraintSet<F>,
+	constraint_set: SizedConstraintSet<F>,
 ) -> Result<(EqIndSumcheckClaim<F, ArithCircuitPoly<F>>, OracleClaimMeta), Error> {
 	let (constraints, meta) = split_constraint_set(constraint_set);
 	let n_multilinears = meta.oracle_ids.len();
@@ -112,9 +114,9 @@ pub fn constraint_set_mlecheck_claim<F: TowerField>(
 }
 
 fn split_constraint_set<F: Field>(
-	constraint_set: ConstraintSet<F>,
+	constraint_set: SizedConstraintSet<F>,
 ) -> (Vec<Constraint<F>>, OracleClaimMeta) {
-	let ConstraintSet {
+	let SizedConstraintSet {
 		oracle_ids,
 		constraints,
 		n_vars,
@@ -236,9 +238,9 @@ pub struct SumcheckClaimsWithMeta<F: TowerField, C> {
 	pub metas: Vec<OracleClaimMeta>,
 }
 
-/// Constructs sumcheck claims and metas from the vector of [`ConstraintSet`]
+/// Constructs sumcheck claims and metas from the vector of [`SizedConstraintSet`]
 pub fn constraint_set_sumcheck_claims<F: TowerField>(
-	constraint_sets: Vec<ConstraintSet<F>>,
+	constraint_sets: Vec<SizedConstraintSet<F>>,
 ) -> Result<SumcheckClaimsWithMeta<F, ArithCircuitPoly<F>>, Error> {
 	let mut claims = Vec::with_capacity(constraint_sets.len());
 	let mut metas = Vec::with_capacity(constraint_sets.len());
@@ -256,9 +258,9 @@ pub struct MLEcheckClaimsWithMeta<F: TowerField, C> {
 	pub metas: Vec<OracleClaimMeta>,
 }
 
-/// Constructs sumcheck claims and metas from the vector of [`ConstraintSet`]
+/// Constructs sumcheck claims and metas from the vector of [`SizedConstraintSet`]
 pub fn constraint_set_mlecheck_claims<F: TowerField>(
-	constraint_sets: Vec<ConstraintSet<F>>,
+	constraint_sets: Vec<SizedConstraintSet<F>>,
 ) -> Result<MLEcheckClaimsWithMeta<F, ArithCircuitPoly<F>>, Error> {
 	let mut claims = Vec::with_capacity(constraint_sets.len());
 	let mut metas = Vec::with_capacity(constraint_sets.len());

--- a/crates/core/src/protocols/sumcheck/prove/oracles.rs
+++ b/crates/core/src/protocols/sumcheck/prove/oracles.rs
@@ -11,7 +11,7 @@ use super::{
 	eq_ind::{EqIndSumcheckProver, EqIndSumcheckProverBuilder},
 };
 use crate::{
-	oracle::{Constraint, ConstraintPredicate, ConstraintSet},
+	oracle::{Constraint, ConstraintPredicate, SizedConstraintSet},
 	protocols::{
 		evalcheck::{EvalPoint, subclaims::MemoizedData},
 		sumcheck::{
@@ -110,7 +110,7 @@ where
 /// zerochecks.
 pub fn constraint_set_sumcheck_prover<'a, F, P, FDomain, Backend>(
 	evaluation_order: EvaluationOrder,
-	constraint_set: ConstraintSet<F>,
+	constraint_set: SizedConstraintSet<F>,
 	witness: &MultilinearExtensionIndex<'a, P>,
 	evaluation_domain_factory: impl EvaluationDomainFactory<FDomain>,
 	switchover_fn: impl Fn(usize) -> usize + Clone,
@@ -158,7 +158,7 @@ where
 #[allow(clippy::too_many_arguments)]
 pub fn constraint_set_mlecheck_prover<'a, 'b, F, P, FDomain, Backend>(
 	evaluation_order: EvaluationOrder,
-	constraint_set: ConstraintSet<F>,
+	constraint_set: SizedConstraintSet<F>,
 	eq_ind_challenges: &[F],
 	memoized_data: &mut MemoizedData<'b, P>,
 	witness: &MultilinearExtensionIndex<'a, P>,
@@ -172,7 +172,7 @@ where
 	FDomain: Field,
 	Backend: ComputationBackend,
 {
-	let ConstraintSet {
+	let SizedConstraintSet {
 		oracle_ids,
 		constraints,
 		n_vars,
@@ -236,7 +236,7 @@ type ConstraintsAndMultilinears<'a, F, P> = (Vec<Constraint<F>>, Vec<Multilinear
 
 #[allow(clippy::type_complexity)]
 pub fn split_constraint_set<'a, F, P>(
-	constraint_set: ConstraintSet<F>,
+	constraint_set: SizedConstraintSet<F>,
 	witness: &MultilinearExtensionIndex<'a, P>,
 ) -> Result<ConstraintsAndMultilinears<'a, F, P>, Error>
 where
@@ -244,7 +244,7 @@ where
 	P: PackedField,
 	P::Scalar: ExtensionField<F>,
 {
-	let ConstraintSet {
+	let SizedConstraintSet {
 		oracle_ids,
 		constraints,
 		n_vars,
@@ -275,10 +275,10 @@ where
 	pub metas: Vec<OracleClaimMeta>,
 }
 
-/// Constructs sumcheck provers and metas from the vector of [`ConstraintSet`]
+/// Constructs sumcheck provers and metas from the vector of [`SizedConstraintSet`]
 pub fn constraint_sets_sumcheck_provers_metas<'a, P, FDomain, Backend>(
 	evaluation_order: EvaluationOrder,
-	constraint_sets: Vec<ConstraintSet<P::Scalar>>,
+	constraint_sets: Vec<SizedConstraintSet<P::Scalar>>,
 	witness: &MultilinearExtensionIndex<'a, P>,
 	evaluation_domain_factory: impl EvaluationDomainFactory<FDomain>,
 	switchover_fn: impl Fn(usize) -> usize,
@@ -319,11 +319,11 @@ where
 	pub meta: OracleClaimMeta,
 }
 
-/// Constructs sumcheck provers and metas from the vector of [`ConstraintSet`]
+/// Constructs sumcheck provers and metas from the vector of [`SizedConstraintSet`]
 #[allow(clippy::too_many_arguments)]
 pub fn constraint_sets_mlecheck_prover_meta<'a, 'b, P, FDomain, Backend>(
 	evaluation_order: EvaluationOrder,
-	constraint_set: ConstraintSet<P::Scalar>,
+	constraint_set: SizedConstraintSet<P::Scalar>,
 	eq_ind_challenges: EvalPoint<P::Scalar>,
 	memoized_data: &mut MemoizedData<'b, P>,
 	witness: &MultilinearExtensionIndex<'a, P>,


### PR DESCRIPTION
As part of
[CRY-363: Table-Aware Constraint System](https://linear.app/irreducible/issue/CRY-363/table-aware-constraint-system)
we want to make the constraint system description into the transcript. What
prevents us from doing so is that the sizes of a particular instance are
embedded in the constraint system. Besides MultilinearOracleSet the sizes
are present in the ConstraintSet. The changeset presented here aims to
reduce the scope of n_vars usage just to the proving/verifying, where the
newly introduced SizedConstraintSet is used now.

Note that we still have the n_vars in the ConstraintSet, but removing it should
be pretty straightforward in a follow-up PR that will actually switch over to
passing the table sizes through the transcript.