### PR TITLE
SYS-258: fix `test_generic_fri_fold` host buffer

### DIFF
--- a/crates/compute_test_utils/src/layer.rs
+++ b/crates/compute_test_utils/src/layer.rs
@@ -505,7 +505,6 @@ pub fn test_generic_fri_fold<'a, F, FSub, C>(
 	for x_i in data_in.iter_mut() {
 		*x_i = <F as Field>::random(&mut rng);
 	}
-	let data_in = data_in.to_vec();
 
 	// Copy the buffer to device slice
 	let device_allocator =

--- a/crates/compute_test_utils/src/layer.rs
+++ b/crates/compute_test_utils/src/layer.rs
@@ -510,7 +510,7 @@ pub fn test_generic_fri_fold<'a, F, FSub, C>(
 	let device_allocator =
 		BumpAllocator::<'a, F, <C as ComputeLayer<F>>::DevMem>::new(device_memory);
 	let mut data_in_slice = device_allocator.alloc(data_in.len()).unwrap();
-	compute.copy_h2d(&data_in, &mut data_in_slice).unwrap();
+	compute.copy_h2d(data_in, &mut data_in_slice).unwrap();
 	let data_in_slice = C::DevMem::as_const(&data_in_slice);
 
 	let mut data_out = compute.host_alloc(1 << (log_len - log_fold_challenges));
@@ -548,7 +548,7 @@ pub fn test_generic_fri_fold<'a, F, FSub, C>(
 	compute.copy_d2h(data_out_slice, data_out).unwrap();
 
 	// Compute the expected result and compare
-	let expected_result = fold_interleaved(&ntt, &data_in, &challenges, log_len, log_batch_size);
+	let expected_result = fold_interleaved(&ntt, data_in, &challenges, log_len, log_batch_size);
 	assert_eq!(data_out, &expected_result);
 }
 


### PR DESCRIPTION
The prior version invoked `copy_h2d` with a host buffer that was not allocated with the host allocator. Using a buffer allocated with the default allocator results in incorrect behavior if the hardware implementation derives additional addressing information during copies from the provided slice assuming that the slice was allocated by the implementation's host allocator.