### PR TITLE
Replace MIN_SLICE_LEN with ALIGNMENT in the device memory

### DIFF
--- a/crates/compute/src/alloc.rs
+++ b/crates/compute/src/alloc.rs
@@ -14,7 +14,7 @@ pub trait ComputeAllocator<F, Mem: ComputeMemory<F>> {
 	///
 	/// ## Pre-conditions
 	///
-	/// - `n` must be a multiple of `Mem::MIN_SLICE_LEN`
+	/// - `n` must be a multiple of `Mem::ALIGNMENT`
 	fn alloc(&self, n: usize) -> Result<Mem::FSliceMut<'_>, Error>;
 
 	/// Borrow the remaining unallocated capacity.
@@ -64,7 +64,7 @@ impl<'a, F, Mem: ComputeMemory<F>> ComputeAllocator<F, Mem> for BumpAllocator<'a
 			// buffer contains Some, invariant restored
 			Err(Error::OutOfMemory)
 		} else {
-			let (lhs, rhs) = Mem::split_at_mut(buffer, n.max(Mem::MIN_SLICE_LEN));
+			let (lhs, rhs) = Mem::split_at_mut(buffer, n.max(Mem::ALIGNMENT));
 			self.buffer.set(Some(rhs));
 			// buffer contains Some, invariant restored
 			Ok(Mem::narrow_mut(lhs))

--- a/crates/compute/src/cpu/memory.rs
+++ b/crates/compute/src/cpu/memory.rs
@@ -8,7 +8,7 @@ use crate::memory::ComputeMemory;
 pub struct CpuMemory;
 
 impl<F: 'static + Sync> ComputeMemory<F> for CpuMemory {
-	const MIN_SLICE_LEN: usize = 1;
+	const ALIGNMENT: usize = 1;
 
 	type FSlice<'a> = &'a [F];
 	type FSliceMut<'a> = &'a mut [F];

--- a/crates/compute/src/memory.rs
+++ b/crates/compute/src/memory.rs
@@ -67,6 +67,7 @@ impl<Slice: SizedSlice> SlicesBatch<Slice> {
 
 /// Interface for manipulating handles to memory in a compute device.
 pub trait ComputeMemory<F> {
+	/// The required alignment of indices for the split methods. This must be a power of two.
 	const ALIGNMENT: usize;
 
 	/// An opaque handle to an immutable slice of elements stored in a compute memory.

--- a/crates/compute_test_utils/src/bivariate_sumcheck.rs
+++ b/crates/compute_test_utils/src/bivariate_sumcheck.rs
@@ -443,9 +443,9 @@ where
 	let mut eq_ind_partial_evals_buffer = dev_alloc.alloc(1 << n_vars).unwrap();
 
 	{
-		let mut host_min_slice = zeroed_vec(Hal::DevMem::MIN_SLICE_LEN);
+		let mut host_min_slice = zeroed_vec(Hal::DevMem::ALIGNMENT);
 		let mut dev_min_slice =
-			Hal::DevMem::slice_mut(&mut eq_ind_partial_evals_buffer, 0..Hal::DevMem::MIN_SLICE_LEN);
+			Hal::DevMem::slice_mut(&mut eq_ind_partial_evals_buffer, 0..Hal::DevMem::ALIGNMENT);
 		host_min_slice[0] = F::ONE;
 
 		hal.copy_h2d(&host_min_slice, &mut dev_min_slice).unwrap();

--- a/crates/core/src/protocols/sumcheck/v3/bivariate_mlecheck.rs
+++ b/crates/core/src/protocols/sumcheck/v3/bivariate_mlecheck.rs
@@ -60,7 +60,7 @@ where
 		eq_ind_partial_evals: FSlice<'a, F, Hal>,
 		eq_ind_challenges: Vec<F>,
 	) -> Result<Self, Error> {
-		if Hal::DevMem::MIN_SLICE_LEN != 1 {
+		if Hal::DevMem::ALIGNMENT != 1 {
 			todo!("support non-trivial minimum slice lengths");
 		}
 

--- a/crates/core/src/protocols/sumcheck/v3/bivariate_product.rs
+++ b/crates/core/src/protocols/sumcheck/v3/bivariate_product.rs
@@ -46,7 +46,7 @@ where
 		claim: &SumcheckClaim<F, IndexComposition<BivariateProduct, 2>>,
 		multilins: Vec<FSlice<'a, F, Hal>>,
 	) -> Result<Self, Error> {
-		if Hal::DevMem::MIN_SLICE_LEN != 1 {
+		if Hal::DevMem::ALIGNMENT != 1 {
 			todo!("support non-trivial minimum slice lengths");
 		}
 

--- a/crates/fast_compute/src/memory.rs
+++ b/crates/fast_compute/src/memory.rs
@@ -6,27 +6,35 @@ use std::{
 };
 
 use binius_compute::memory::{ComputeMemory, SizedSlice};
-use binius_field::PackedField;
+use binius_field::{PackedField, packed::iter_packed_slice_with_offset};
 
 /// A packed memory implementation that uses slices of packed fields.
 pub struct PackedMemory<P>(PhantomData<P>);
 
 impl<P: PackedField> ComputeMemory<P::Scalar> for PackedMemory<P> {
-	const MIN_SLICE_LEN: usize = P::WIDTH;
+	const ALIGNMENT: usize = P::WIDTH;
 
 	type FSlice<'a> = PackedMemorySlice<'a, P>;
 
 	type FSliceMut<'a> = PackedMemorySliceMut<'a, P>;
 
 	fn as_const<'a>(data: &'a Self::FSliceMut<'_>) -> Self::FSlice<'a> {
-		PackedMemorySlice { data: data.data }
+		match data {
+			PackedMemorySliceMut::Slice(slice) => PackedMemorySlice::Slice(slice),
+			PackedMemorySliceMut::Owned(chunk) => PackedMemorySlice::Owned(*chunk),
+		}
 	}
 
 	fn slice(data: Self::FSlice<'_>, range: impl std::ops::RangeBounds<usize>) -> Self::FSlice<'_> {
 		let (start, end) = Self::to_packed_range(data.len(), range);
-		Self::FSlice {
-			data: &data.data[start..end],
+		if start == 0 && end == data.len() {
+			return data;
 		}
+
+		let PackedMemorySlice::Slice(slice) = data else {
+			panic!("splitting slices of length less than `Self::ALIGNMENT` is not supported");
+		};
+		PackedMemorySlice::Slice(&slice[start..end])
 	}
 
 	fn slice_mut<'a>(
@@ -34,10 +42,14 @@ impl<P: PackedField> ComputeMemory<P::Scalar> for PackedMemory<P> {
 		range: impl std::ops::RangeBounds<usize>,
 	) -> Self::FSliceMut<'a> {
 		let (start, end) = Self::to_packed_range(data.len(), range);
-
-		Self::FSliceMut {
-			data: &mut data.data[start..end],
+		if start == 0 && end == data.len() {
+			return Self::to_owned_mut(data);
 		}
+
+		let PackedMemorySliceMut::Slice(slice) = data else {
+			panic!("splitting slices of length less than `Self::ALIGNMENT` is not supported");
+		};
+		PackedMemorySliceMut::Slice(&mut slice[start..end])
 	}
 
 	fn split_at_mut(
@@ -46,12 +58,18 @@ impl<P: PackedField> ComputeMemory<P::Scalar> for PackedMemory<P> {
 	) -> (Self::FSliceMut<'_>, Self::FSliceMut<'_>) {
 		assert_eq!(mid % P::WIDTH, 0, "mid must be a multiple of {}", P::WIDTH);
 		let mid = mid >> P::LOG_WIDTH;
-		let (left, right) = data.data.split_at_mut(mid);
-		(Self::FSliceMut { data: left }, Self::FSliceMut { data: right })
+		let PackedMemorySliceMut::Slice(slice) = data else {
+			panic!("splitting slices of length less than `Self::ALIGNMENT` is not supported");
+		};
+		let (left, right) = slice.split_at_mut(mid);
+		(PackedMemorySliceMut::Slice(left), PackedMemorySliceMut::Slice(right))
 	}
 
 	fn narrow<'a>(data: &'a Self::FSlice<'_>) -> Self::FSlice<'a> {
-		Self::FSlice { data: data.data }
+		match data {
+			PackedMemorySlice::Slice(slice) => PackedMemorySlice::Slice(slice),
+			PackedMemorySlice::Owned(chunk) => PackedMemorySlice::Owned(*chunk),
+		}
 	}
 
 	fn narrow_mut<'a, 'b: 'a>(data: Self::FSliceMut<'b>) -> Self::FSliceMut<'a> {
@@ -59,7 +77,10 @@ impl<P: PackedField> ComputeMemory<P::Scalar> for PackedMemory<P> {
 	}
 
 	fn to_owned_mut<'a>(data: &'a mut Self::FSliceMut<'_>) -> Self::FSliceMut<'a> {
-		Self::FSliceMut::new(data.data)
+		match data {
+			PackedMemorySliceMut::Slice(slice) => PackedMemorySliceMut::Slice(slice),
+			PackedMemorySliceMut::Owned(chunk) => PackedMemorySliceMut::Owned(*chunk),
+		}
 	}
 
 	fn slice_chunks_mut<'a>(
@@ -71,9 +92,74 @@ impl<P: PackedField> ComputeMemory<P::Scalar> for PackedMemory<P> {
 
 		let chunk_len = chunk_len >> P::LOG_WIDTH;
 
-		data.data
+		let PackedMemorySliceMut::Slice(slice) = data else {
+			panic!("splitting slices of length less than `Self::ALIGNMENT` is not supported");
+		};
+
+		slice
 			.chunks_mut(chunk_len)
-			.map(|chunk| Self::FSliceMut { data: chunk })
+			.map(|chunk| Self::FSliceMut::new_slice(chunk))
+	}
+
+	fn split_half<'a>(data: Self::FSlice<'a>) -> (Self::FSlice<'a>, Self::FSlice<'a>) {
+		assert!(
+			data.len().is_power_of_two() && data.len() > 1,
+			"data.len() must be a power of two greater than 1"
+		);
+
+		match data {
+			PackedMemorySlice::Slice(slice) => match slice.len() {
+				len if len > 1 => {
+					let mid = slice.len() / 2;
+					let left = &slice[..mid];
+					let right = &slice[mid..];
+					(PackedMemorySlice::Slice(left), PackedMemorySlice::Slice(right))
+				}
+				1 => (
+					PackedMemorySlice::new_owned(slice, 0, P::WIDTH / 2),
+					PackedMemorySlice::new_owned(slice, P::WIDTH / 2, P::WIDTH / 2),
+				),
+				_ => {
+					unreachable!()
+				}
+			},
+			PackedMemorySlice::Owned(chunk) => {
+				let mid = chunk.len / 2;
+				let left = chunk.subrange(0, mid);
+				let right = chunk.subrange(mid, chunk.len);
+				(PackedMemorySlice::Owned(left), PackedMemorySlice::Owned(right))
+			}
+		}
+	}
+
+	fn split_half_mut<'a>(data: Self::FSliceMut<'a>) -> (Self::FSliceMut<'a>, Self::FSliceMut<'a>) {
+		assert!(
+			data.len().is_power_of_two() && data.len() > 1,
+			"data.len() must be a power of two greater than 1"
+		);
+
+		match data {
+			PackedMemorySliceMut::Slice(slice) => match slice.len() {
+				len if len > 1 => {
+					let mid = slice.len() / 2;
+					let (left, right) = slice.split_at_mut(mid);
+					(PackedMemorySliceMut::Slice(left), PackedMemorySliceMut::Slice(right))
+				}
+				1 => (
+					PackedMemorySliceMut::new_owned(slice, 0, P::WIDTH / 2),
+					PackedMemorySliceMut::new_owned(slice, P::WIDTH / 2, P::WIDTH / 2),
+				),
+				_ => {
+					unreachable!()
+				}
+			},
+			PackedMemorySliceMut::Owned(chunk) => {
+				let mid = chunk.len / 2;
+				let left = chunk.subrange(0, mid);
+				let right = chunk.subrange(mid, chunk.len);
+				(PackedMemorySliceMut::Owned(left), PackedMemorySliceMut::Owned(right))
+			}
+		}
 	}
 }
 
@@ -90,68 +176,178 @@ impl<P: PackedField> PackedMemory<P> {
 			Bound::Unbounded => len,
 		};
 
-		assert_eq!(start % P::WIDTH, 0, "start must be a multiple of {}", P::WIDTH);
-		assert_eq!(end % P::WIDTH, 0, "end must be a multiple of {}", P::WIDTH);
+		if (start, end) == (0, len) {
+			(0, len)
+		} else {
+			assert_eq!(start % P::WIDTH, 0, "start must be a multiple of {}", P::WIDTH);
+			assert_eq!(end % P::WIDTH, 0, "end must be a multiple of {}", P::WIDTH);
 
-		(start >> P::LOG_WIDTH, end >> P::LOG_WIDTH)
+			(start >> P::LOG_WIDTH, end >> P::LOG_WIDTH)
+		}
 	}
 }
 
-#[derive(Clone, Copy)]
-pub struct PackedMemorySlice<'a, P: PackedField> {
-	pub(crate) data: &'a [P],
+/// An in-place storage for the chunk of elements smaller than `P::WIDTH`.
+#[derive(Clone, Copy, Debug)]
+pub struct SmallOwnedChunk<P: PackedField> {
+	data: P,
+	len: usize,
+}
+
+impl<P: PackedField> SmallOwnedChunk<P> {
+	#[inline(always)]
+	fn new_from_slice(data: &[P], offset: usize, len: usize) -> Self {
+		debug_assert!(len < P::WIDTH, "len must be less than {}", P::WIDTH);
+
+		let iter = iter_packed_slice_with_offset(data, offset);
+		let data = P::from_scalars(iter.take(len));
+		Self { data, len }
+	}
+
+	#[inline]
+	fn subrange(&self, start: usize, end: usize) -> Self {
+		assert!(end <= self.len, "range out of bounds");
+
+		let data = if start == 0 {
+			self.data
+		} else {
+			P::from_scalars(self.data.iter().skip(start).take(end - start))
+		};
+		Self {
+			data,
+			len: end - start,
+		}
+	}
+
+	/// Used for tests only
+	#[cfg(test)]
+	fn iter_scalars(&self) -> impl Iterator<Item = P::Scalar> {
+		self.data.iter().take(self.len)
+	}
+}
+
+/// Memory slice that can be either a borrowed slice or an owned small chunk (with length <
+/// `P::WIDTH`).
+#[derive(Clone, Copy, Debug)]
+pub enum PackedMemorySlice<'a, P: PackedField> {
+	Slice(&'a [P]),
+	Owned(SmallOwnedChunk<P>),
 }
 
 impl<'a, P: PackedField> PackedMemorySlice<'a, P> {
 	#[inline(always)]
-	pub fn new(data: &'a [P]) -> Self {
-		Self { data }
+	pub fn new_slice(data: &'a [P]) -> Self {
+		Self::Slice(data)
+	}
+
+	#[inline(always)]
+	pub fn new_owned(data: &[P], offset: usize, len: usize) -> Self {
+		let chunk = SmallOwnedChunk::new_from_slice(data, offset, len);
+		Self::Owned(chunk)
+	}
+
+	#[inline(always)]
+	pub fn as_slice(&'a self) -> &'a [P] {
+		match self {
+			Self::Slice(data) => data,
+			Self::Owned(chunk) => std::slice::from_ref(&chunk.data),
+		}
+	}
+
+	/// Used for tests only
+	#[cfg(test)]
+	fn iter_scalars(&self) -> impl Iterator<Item = P::Scalar> {
+		use itertools::Either;
+
+		match self {
+			Self::Slice(data) => Either::Left(data.iter().flat_map(|p| p.iter())),
+			Self::Owned(chunk) => Either::Right(chunk.iter_scalars()),
+		}
 	}
 }
 
 impl<'a, P: PackedField> SizedSlice for PackedMemorySlice<'a, P> {
 	#[inline(always)]
 	fn is_empty(&self) -> bool {
-		self.data.is_empty()
+		match self {
+			Self::Slice(data) => data.is_empty(),
+			Self::Owned(chunk) => chunk.len == 0,
+		}
 	}
 
 	#[inline(always)]
 	fn len(&self) -> usize {
-		self.data.len() << P::LOG_WIDTH
+		match self {
+			Self::Slice(data) => data.len() << P::LOG_WIDTH,
+			Self::Owned(chunk) => chunk.len,
+		}
 	}
 }
 
-pub struct PackedMemorySliceMut<'a, P: PackedField> {
-	pub(crate) data: &'a mut [P],
+pub enum PackedMemorySliceMut<'a, P: PackedField> {
+	Slice(&'a mut [P]),
+	Owned(SmallOwnedChunk<P>),
 }
 
 impl<'a, P: PackedField> PackedMemorySliceMut<'a, P> {
 	#[inline(always)]
-	pub fn new(data: &'a mut [P]) -> Self {
-		Self { data }
+	pub fn new_slice(data: &'a mut [P]) -> Self {
+		Self::Slice(data)
+	}
+
+	#[inline(always)]
+	pub fn new_owned(data: &mut [P], offset: usize, len: usize) -> Self {
+		let chunk = SmallOwnedChunk::new_from_slice(data, offset, len);
+		Self::Owned(chunk)
 	}
 
 	#[inline(always)]
 	pub fn as_const(&self) -> PackedMemorySlice<'_, P> {
-		PackedMemorySlice::new(self.data)
+		match self {
+			Self::Slice(data) => PackedMemorySlice::Slice(data),
+			Self::Owned(chunk) => PackedMemorySlice::Owned(*chunk),
+		}
+	}
+
+	#[inline(always)]
+	pub fn as_slice(&'a self) -> &'a [P] {
+		match self {
+			Self::Slice(data) => data,
+			Self::Owned(chunk) => std::slice::from_ref(&chunk.data),
+		}
+	}
+
+	#[inline(always)]
+	pub fn as_slice_mut(&mut self) -> &mut [P] {
+		match self {
+			Self::Slice(data) => data,
+			Self::Owned(chunk) => std::slice::from_mut(&mut chunk.data),
+		}
 	}
 }
 
 impl<'a, P: PackedField> SizedSlice for PackedMemorySliceMut<'a, P> {
 	#[inline(always)]
 	fn is_empty(&self) -> bool {
-		self.data.is_empty()
+		match self {
+			Self::Slice(data) => data.is_empty(),
+			Self::Owned(chunk) => chunk.len == 0,
+		}
 	}
 
 	#[inline(always)]
 	fn len(&self) -> usize {
-		self.data.len() << P::LOG_WIDTH
+		match self {
+			Self::Slice(data) => data.len() << P::LOG_WIDTH,
+			Self::Owned(chunk) => chunk.len,
+		}
 	}
 }
 
 #[cfg(test)]
 mod tests {
 	use binius_field::PackedBinaryField4x32b;
+	use itertools::Itertools;
 	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
@@ -170,12 +366,12 @@ mod tests {
 	fn test_try_slice_on_mem_slice() {
 		let data = make_random_vec(3);
 		let data_clone = data.clone();
-		let memory = PackedMemorySlice::new(&data);
+		let memory = PackedMemorySlice::new_slice(&data);
 
-		assert_eq!(PackedMemory::slice(memory, 0..2 * Packed::WIDTH).data, &data_clone[0..2]);
-		assert_eq!(PackedMemory::slice(memory, ..2 * Packed::WIDTH).data, &data_clone[..2]);
-		assert_eq!(PackedMemory::slice(memory, Packed::WIDTH..).data, &data_clone[1..]);
-		assert_eq!(PackedMemory::slice(memory, ..).data, &data_clone[..]);
+		assert_eq!(PackedMemory::slice(memory, 0..2 * Packed::WIDTH).as_slice(), &data_clone[0..2]);
+		assert_eq!(PackedMemory::slice(memory, ..2 * Packed::WIDTH).as_slice(), &data_clone[..2]);
+		assert_eq!(PackedMemory::slice(memory, Packed::WIDTH..).as_slice(), &data_clone[1..]);
+		assert_eq!(PackedMemory::slice(memory, ..).as_slice(), &data_clone[..]);
 
 		// check panic on non-aligned slice
 		let result = std::panic::catch_unwind(|| {
@@ -194,40 +390,60 @@ mod tests {
 			PackedMemory::slice(memory, 1..);
 		});
 		assert!(result.is_err());
+
+		// check panic on owned slice
+		let memory_owned = PackedMemorySlice::new_owned(&data, 0, Packed::WIDTH - 1);
+		let result = std::panic::catch_unwind(|| {
+			PackedMemory::slice(memory_owned, 0..1);
+		});
+		assert!(result.is_err());
 	}
 
 	#[test]
 	fn test_convert_mut_mem_slice_to_const() {
 		let mut data = make_random_vec(3);
 		let data_clone = data.clone();
-		let memory = PackedMemorySliceMut::new(&mut data);
+		let memory = PackedMemorySliceMut::new_slice(&mut data);
 
-		assert_eq!(PackedMemory::as_const(&memory).data, &data_clone[..]);
+		assert_eq!(PackedMemory::as_const(&memory).as_slice(), &data_clone[..]);
+
+		let owned_memory = PackedMemorySliceMut::new_owned(&mut data, 0, Packed::WIDTH - 1);
+		assert_eq!(
+			PackedMemory::as_const(&owned_memory)
+				.iter_scalars()
+				.collect_vec(),
+			PackedMemorySlice::new_owned(&data, 0, Packed::WIDTH - 1)
+				.iter_scalars()
+				.collect_vec()
+		);
 	}
 
 	#[test]
 	fn test_slice_on_mut_mem_slice() {
 		let mut data = make_random_vec(3);
 		let data_clone = data.clone();
-		let mut memory = PackedMemorySliceMut::new(&mut data);
+		let mut memory = PackedMemorySliceMut::new_slice(&mut data);
 
 		assert_eq!(
-			PackedMemory::slice_mut(&mut memory, 0..2 * Packed::WIDTH).data,
+			PackedMemory::slice_mut(&mut memory, 0..2 * Packed::WIDTH).as_slice(),
 			&data_clone[0..2]
 		);
 		assert_eq!(
-			PackedMemory::slice_mut(&mut memory, ..2 * Packed::WIDTH).data,
+			PackedMemory::slice_mut(&mut memory, ..2 * Packed::WIDTH).as_slice(),
 			&data_clone[..2]
 		);
-		assert_eq!(PackedMemory::slice_mut(&mut memory, Packed::WIDTH..).data, &data_clone[1..]);
-		assert_eq!(PackedMemory::slice_mut(&mut memory, ..).data, &data_clone[..]);
+		assert_eq!(
+			PackedMemory::slice_mut(&mut memory, Packed::WIDTH..).as_slice(),
+			&data_clone[1..]
+		);
+		assert_eq!(PackedMemory::slice_mut(&mut memory, ..).as_slice(), &data_clone[..]);
 	}
 
 	#[test]
 	#[should_panic]
 	fn test_slice_mut_on_mem_slice_panic_1() {
 		let mut data = make_random_vec(3);
-		let mut memory = PackedMemorySliceMut::new(&mut data);
+		let mut memory = PackedMemorySliceMut::new_slice(&mut data);
 
 		// `&mut T` can't cross the catch unwind boundary, so we have to use several tests
 		// to test the panic cases.
@@ -238,7 +454,7 @@ mod tests {
 	#[should_panic]
 	fn test_slice_mut_on_mem_slice_panic_2() {
 		let mut data = make_random_vec(3);
-		let mut memory = PackedMemorySliceMut::new(&mut data);
+		let mut memory = PackedMemorySliceMut::new_slice(&mut data);
 
 		PackedMemory::slice_mut(&mut memory, ..1);
 	}
@@ -247,7 +463,7 @@ mod tests {
 	#[should_panic]
 	fn test_slice_mut_on_mem_slice_panic_3() {
 		let mut data = make_random_vec(3);
-		let mut memory = PackedMemorySliceMut::new(&mut data);
+		let mut memory = PackedMemorySliceMut::new_slice(&mut data);
 
 		PackedMemory::slice_mut(&mut memory, 1..Packed::WIDTH);
 	}
@@ -256,7 +472,16 @@ mod tests {
 	#[should_panic]
 	fn test_slice_mut_on_mem_slice_panic_4() {
 		let mut data = make_random_vec(3);
-		let mut memory = PackedMemorySliceMut::new(&mut data);
+		let mut memory = PackedMemorySliceMut::new_slice(&mut data);
+
+		PackedMemory::slice_mut(&mut memory, 1..);
+	}
+
+	#[test]
+	#[should_panic]
+	fn test_slice_mut_on_mem_slice_panic_5() {
+		let mut data = make_random_vec(3);
+		let mut memory = PackedMemorySliceMut::new_owned(&mut data, 0, Packed::WIDTH - 1);
 
 		PackedMemory::slice_mut(&mut memory, 1..);
 	}
@@ -265,21 +490,73 @@ mod tests {
 	fn test_split_at_mut() {
 		let mut data = make_random_vec(3);
 		let data_clone = data.clone();
-		let memory = PackedMemorySliceMut::new(&mut data);
+		let memory = PackedMemorySliceMut::new_slice(&mut data);
 
 		let (left, right) = PackedMemory::split_at_mut(memory, 2 * Packed::WIDTH);
-		assert_eq!(left.data, &data_clone[0..2]);
-		assert_eq!(right.data, &data_clone[2..]);
+		assert_eq!(left.as_slice(), &data_clone[0..2]);
+		assert_eq!(right.as_slice(), &data_clone[2..]);
 	}
 
 	#[test]
 	#[should_panic]
-	fn test_split_at_mut_panic() {
+	fn test_split_at_mut_panic_1() {
 		let mut data = make_random_vec(3);
-		let memory = PackedMemorySliceMut::new(&mut data);
+		let memory = PackedMemorySliceMut::new_slice(&mut data);
 
 		// `&mut T` can't cross the catch unwind boundary, so we have to use several tests
 		// to test the panic cases.
 		PackedMemory::split_at_mut(memory, 1);
+	}
+
+	#[test]
+	#[should_panic]
+	fn test_split_at_mut_panic_2() {
+		let mut data = make_random_vec(3);
+		let memory = PackedMemorySliceMut::new_owned(&mut data, 0, Packed::WIDTH - 1);
+
+		// `&mut T` can't cross the catch unwind boundary, so we have to use several tests
+		// to test the panic cases.
+		PackedMemory::split_at_mut(memory, 1);
+	}
+
+	#[test]
+	fn test_split_half() {
+		let data = make_random_vec(2);
+		let data_clone = data.clone();
+		let memory = PackedMemorySlice::new_slice(&data);
+
+		let (left, right) = PackedMemory::split_half(memory);
+		assert_eq!(left.as_slice(), &data_clone[0..1]);
+		assert_eq!(right.as_slice(), &data_clone[1..]);
+
+		let memory = PackedMemorySlice::new_slice(&data[0..1]);
+		let (left, right) = PackedMemory::split_half(memory);
+		assert_eq!(
+			left.iter_scalars().collect_vec(),
+			PackedMemorySlice::new_owned(&data, 0, Packed::WIDTH / 2)
+				.iter_scalars()
+				.collect_vec()
+		);
+		assert_eq!(
+			right.iter_scalars().collect_vec(),
+			PackedMemorySlice::new_owned(&data, Packed::WIDTH / 2, Packed::WIDTH / 2)
+				.iter_scalars()
+				.collect_vec()
+		);
+
+		let memory = PackedMemorySlice::new_owned(&data, 0, Packed::WIDTH / 2);
+		let (left, right) = PackedMemory::split_half(memory);
+		assert_eq!(
+			left.iter_scalars().collect_vec(),
+			PackedMemorySlice::new_owned(&data, 0, Packed::WIDTH / 4)
+				.iter_scalars()
+				.collect_vec()
+		);
+		assert_eq!(
+			right.iter_scalars().collect_vec(),
+			PackedMemorySlice::new_owned(&data, Packed::WIDTH / 4, Packed::WIDTH / 4)
+				.iter_scalars()
+				.collect_vec()
+		);
 	}
 }

--- a/crates/fast_compute/tests/layer.rs
+++ b/crates/fast_compute/tests/layer.rs
@@ -19,7 +19,7 @@ fn test_exec_single_tensor_expand() {
 	let mut device_memory = vec![P::zero(); 1 << n_vars];
 	test_generic_single_tensor_expand(
 		compute,
-		PackedMemorySliceMut::new(&mut device_memory),
+		PackedMemorySliceMut::new_slice(&mut device_memory),
 		n_vars,
 	);
 }
@@ -34,7 +34,7 @@ fn test_exec_single_left_fold() {
 	let compute = <FastCpuLayer<CanonicalTowerFamily, P>>::default();
 	test_generic_single_left_fold::<F, F2, _>(
 		&compute,
-		PackedMemorySliceMut::new(&mut device_memory),
+		PackedMemorySliceMut::new_slice(&mut device_memory),
 		n_vars / 2,
 		n_vars / 8,
 	);
@@ -50,7 +50,7 @@ fn test_exec_single_right_fold() {
 	let compute = <FastCpuLayer<CanonicalTowerFamily, P>>::default();
 	test_generic_single_right_fold::<F, F2, _>(
 		&compute,
-		PackedMemorySliceMut::new(&mut device_memory),
+		PackedMemorySliceMut::new_slice(&mut device_memory),
 		n_vars / 2,
 		n_vars / 8,
 	);
@@ -65,7 +65,7 @@ fn test_exec_single_inner_product() {
 	let mut device_memory = vec![P::zero(); 1 << (n_vars + 1 - P::LOG_WIDTH)];
 	test_generic_single_inner_product::<F2, _, _>(
 		compute,
-		PackedMemorySliceMut::new(&mut device_memory),
+		PackedMemorySliceMut::new_slice(&mut device_memory),
 		n_vars,
 	);
 }
@@ -79,7 +79,7 @@ fn test_exec_single_inner_product_using_kernel_accumulator() {
 	let mut device_memory = vec![P::zero(); 1 << (n_vars + 1 - P::LOG_WIDTH)];
 	test_generic_single_inner_product_using_kernel_accumulator::<F, _>(
 		compute,
-		PackedMemorySliceMut::new(&mut device_memory),
+		PackedMemorySliceMut::new_slice(&mut device_memory),
 		n_vars,
 	);
 }
@@ -96,7 +96,7 @@ fn test_exec_fri_fold_non_zero_log_batch() {
 	let mut device_memory = vec![P::zero(); 1 << (log_len + log_batch_size + 1 - P::LOG_WIDTH)];
 	test_generic_fri_fold::<F, FSub, _>(
 		compute,
-		PackedMemorySliceMut::new(&mut device_memory),
+		PackedMemorySliceMut::new_slice(&mut device_memory),
 		log_len,
 		log_batch_size,
 		log_fold_challenges,
@@ -115,7 +115,7 @@ fn test_exec_fri_fold_zero_log_batch() {
 	let mut device_memory = vec![P::zero(); 1 << (log_len + log_batch_size + 1 - P::LOG_WIDTH)];
 	test_generic_fri_fold::<F, FSub, _>(
 		compute,
-		PackedMemorySliceMut::new(&mut device_memory),
+		PackedMemorySliceMut::new_slice(&mut device_memory),
 		log_len,
 		log_batch_size,
 		log_fold_challenges,
@@ -131,7 +131,7 @@ fn test_exec_kernel_add() {
 	let mut device_memory = vec![P::zero(); 1 << (log_len + 3 - P::LOG_WIDTH)];
 	test_generic_kernel_add::<F, _>(
 		compute,
-		PackedMemorySliceMut::new(&mut device_memory),
+		PackedMemorySliceMut::new_slice(&mut device_memory),
 		log_len,
 	);
 }
@@ -144,7 +144,7 @@ fn test_extrapolate_line() {
 	let mut device_memory = vec![P::zero(); 1 << (log_len + 3 - P::LOG_WIDTH)];
 	binius_compute_test_utils::layer::test_extrapolate_line(
 		&compute,
-		PackedMemorySliceMut::new(&mut device_memory),
+		PackedMemorySliceMut::new_slice(&mut device_memory),
 		log_len,
 	);
 }
@@ -157,7 +157,7 @@ fn test_compute_composite() {
 	let mut device_memory = vec![P::zero(); 1 << (log_len + 3 - P::LOG_WIDTH)];
 	binius_compute_test_utils::layer::test_generic_compute_composite(
 		&compute,
-		PackedMemorySliceMut::new(&mut device_memory),
+		PackedMemorySliceMut::new_slice(&mut device_memory),
 		log_len,
 	);
 }


### PR DESCRIPTION
This main purpose of this change to support arbitrary small slices of the "device" memory in `FastCpuComputeLayer`.

The main idea is to represent `FSlice`/`FSliceMut` as an enum with two options:
 - Borrowed slice, when the number of elements is a multiple of `P::WIDTH`
 - Owned storage with a single packed element for the case when the length is strictly less than `P::WIDTH`.

We still can't represent slices bigger than `P::WIDTH` which aren't aligned by the `P::WIDTH` border but that seems to be sufficient for our needs, e.g. we are always able to split pow of two length slices by half.

The changes introduced by this PR:
 - replace `ComputeMemory::MIN_SLICE_LEN` with `ComputeMemory::ALIGNMENT`
 - relax conditions for all the slice spliting method, now the slices with the non-aligned length are allowed when their length is strictly less than the alignment
 - change the implementation of `FSlice` and `FSliceMut` in the `binius_fast_compute` crate.

The HW and `CPULayer` implementations of the memory do not need to change anything apart from applying the renaming.