### PR TITLE
[merkle tree example] Add `root()` method to MerkleTree 

### DIFF
--- a/crates/m3/tests/merkle_tree.rs
+++ b/crates/m3/tests/merkle_tree.rs
@@ -402,7 +402,7 @@ mod model {
 		];
 		let tree = MerkleTree::new(&leaves);
 		let path = tree.merkle_path(0);
-		let root = tree.root;
+		let root = tree.root();
 		let leaf = leaves[0];
 		MerkleTree::verify_path(&path, root, leaf, 0);
 
@@ -419,7 +419,7 @@ mod model {
 			.collect::<Vec<_>>();
 
 		let tree = MerkleTree::new(&leaves);
-		let root = tree.root;
+		let root = tree.root();
 		let path = tree.merkle_path(path_index);
 		let path_root_id = 0;
 		let merkle_tree_trace = MerkleTreeTrace::generate(
@@ -443,7 +443,7 @@ mod model {
 			.collect::<Vec<_>>();
 
 		let tree = MerkleTree::new(&leaves);
-		let root = tree.root;
+		let root = tree.root();
 		let paths = (0..2)
 			.map(|_| {
 				let path_index = rng.gen_range(0..1 << 4);
@@ -474,7 +474,7 @@ mod model {
 		let trees = (0..3)
 			.map(|i| MerkleTree::new(&leaves[i]))
 			.collect::<Vec<_>>();
-		let roots = (0..3).map(|i| trees[i].root).collect::<Vec<_>>();
+		let roots = (0..3).map(|i| trees[i].root()).collect::<Vec<_>>();
 		let paths = trees
 			.iter()
 			.enumerate()

--- a/crates/m3/tests/merkle_tree.rs
+++ b/crates/m3/tests/merkle_tree.rs
@@ -182,6 +182,11 @@ mod model {
 			}
 			assert_eq!(current_hash, root);
 		}
+
+		// Returns the root of the merkle tree.
+		pub fn root(&self) -> [u8; 32] {
+			self.root
+		}
 	}
 
 	impl MerklePathEvent {

--- a/crates/m3/tests/merkle_tree.rs
+++ b/crates/m3/tests/merkle_tree.rs
@@ -402,7 +402,7 @@ mod model {
 		];
 		let tree = MerkleTree::new(&leaves);
 		let path = tree.merkle_path(0);
-		let root = tree.root();
+		let root = tree.root;
 		let leaf = leaves[0];
 		MerkleTree::verify_path(&path, root, leaf, 0);
 
@@ -419,7 +419,7 @@ mod model {
 			.collect::<Vec<_>>();
 
 		let tree = MerkleTree::new(&leaves);
-		let root = tree.root();
+		let root = tree.root;
 		let path = tree.merkle_path(path_index);
 		let path_root_id = 0;
 		let merkle_tree_trace = MerkleTreeTrace::generate(
@@ -443,7 +443,7 @@ mod model {
 			.collect::<Vec<_>>();
 
 		let tree = MerkleTree::new(&leaves);
-		let root = tree.root();
+		let root = tree.root;
 		let paths = (0..2)
 			.map(|_| {
 				let path_index = rng.gen_range(0..1 << 4);
@@ -474,7 +474,7 @@ mod model {
 		let trees = (0..3)
 			.map(|i| MerkleTree::new(&leaves[i]))
 			.collect::<Vec<_>>();
-		let roots = (0..3).map(|i| trees[i].root()).collect::<Vec<_>>();
+		let roots = (0..3).map(|i| trees[i].root).collect::<Vec<_>>();
 		let paths = trees
 			.iter()
 			.enumerate()


### PR DESCRIPTION
# Add `root()` method to MerkleTree

Added a public method to get the root of the merkle tree and updated all tests to use this method instead of accessing the root field directly.