### PR TITLE
[merkle tree example] Add Copy trait to MerklePathEvent and MerkleRootEvent structs

### DIFF
--- a/crates/m3/tests/merkle_tree.rs
+++ b/crates/m3/tests/merkle_tree.rs
@@ -65,7 +65,7 @@ mod model {
 	}
 	/// A table representing a step in verifying a merkle path for inclusion.
 
-	#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+	#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 	pub struct MerklePathEvent {
 		pub root_id: u8,
 		pub left: [u8; 32],
@@ -79,7 +79,7 @@ mod model {
 
 	/// A table representing the final step of comparing the claimed root.
 
-	#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+	#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 	pub struct MerkleRootEvent {
 		pub root_id: u8,
 		pub digest: [u8; 32],


### PR DESCRIPTION
### TL;DR

Added `Copy` trait to Merkle tree event structs.

### What changed?

Added the `Copy` trait to the `MerklePathEvent` and `MerkleRootEvent` structs in the Merkle tree tests. These structs already derive other traits like `Debug`, `Clone`, `PartialEq`, `Eq`, and `Hash`.

