### PR TITLE
[merkle tree example] Make generate and validate methods public

### DIFF
--- a/crates/m3/tests/merkle_tree.rs
+++ b/crates/m3/tests/merkle_tree.rs
@@ -275,7 +275,7 @@ mod model {
 		/// Method to generate the trace given the witness values. The function assumes that the
 		/// root_id is the index of the root in the roots vector and that the paths and leaves are
 		/// passed in with their assigned root_id.
-		fn generate(roots: Vec<[u8; 32]>, paths: &[MerklePath]) -> Self {
+		pub fn generate(roots: Vec<[u8; 32]>, paths: &[MerklePath]) -> Self {
 			let mut path_nodes = Vec::new();
 			let mut root_nodes = HashSet::new();
 			let mut boundaries = MerkleBoundaries::new();
@@ -367,7 +367,7 @@ mod model {
 			}
 		}
 
-		fn validate(&self) {
+		pub fn validate(&self) {
 			let mut channels = MerkleTreeChannels::new();
 
 			// Push the boundary values to the nodes and roots channels.


### PR DESCRIPTION
# Make `generate` and `validate` methods public in `MerkleTreeTrace`

This PR changes the visibility of two methods in the `MerkleTreeTrace` struct from private to public:
- `generate`: Creates a trace from roots and paths
- `validate`: Validates the trace

These changes allow these methods to be accessed from outside the module for the arithmetisation.