### PR TITLE
[compute] Create low-to-high Bivariate sumcheck prover

### DIFF
--- a/crates/compute/src/cpu/layer.rs
+++ b/crates/compute/src/cpu/layer.rs
@@ -384,6 +384,23 @@ impl<T: TowerFamily> ComputeLayer<T::B128> for CpuLayer<T> {
 		}
 		Ok(())
 	}
+
+	fn deinterleaved(&self, evals: &mut FSliceMut<T::B128, Self>) -> Result<(), Error> {
+		if evals.len() % 2 != 0 {
+			return Err(Error::InputValidation("evals length is not even".into()));
+		}
+
+		let half = evals.len() / 2;
+
+		let odds = evals.iter().skip(1).step_by(2).copied().collect::<Vec<_>>();
+
+		for i in 0..half {
+			evals[i] = evals[2 * i];
+		}
+
+		evals[half..].copy_from_slice(&odds[..]);
+		Ok(())
+	}
 }
 
 // Note: shortcuts for kernel memory so that clippy does not complain about the type complexity in

--- a/crates/compute/src/layer.rs
+++ b/crates/compute/src/layer.rs
@@ -406,6 +406,32 @@ pub trait ComputeLayer<F: Field>: 'static + Sync {
 		evals_1: FSlice<F, Self>,
 		z: F,
 	) -> Result<(), Error>;
+
+	/// Reorders a buffer of interleaved values into a deinterleaved format.
+	///
+	/// This operation assumes the input buffer contains values in an interleaved layout:
+	/// even-indexed elements followed by odd-indexed elements. It rearranges the elements
+	/// in-place so that the first half of the buffer contains all even-indexed elements,
+	/// and the second half contains all odd-indexed elements.
+	///
+	/// The transformation is performed as follows:
+	/// - For each `i` in `[0, half)`, `evals[i]` is set to `evals[2 * i]` (even indices).
+	/// - The remaining half is filled with the odd-indexed values of the original buffer.
+	///
+	/// # Arguments
+	///
+	/// * `evals` - A mutable buffer containing `2n` interleaved values. After the call, the first
+	///   `n` elements will be the even-indexed elements, and the last `n` will be the odd-indexed
+	///   elements from the original buffer.
+	///
+	/// # Errors
+	///
+	/// Returns an error if any invariant is violated during the operation.
+	///
+	/// # Panics
+	///
+	/// This function will panic if `evals.len()` is not even.
+	fn deinterleaved(&self, evals: &mut FSliceMut<F, Self>) -> Result<(), Error>;
 }
 
 /// A memory mapping specification for a kernel execution.

--- a/crates/fast_compute/src/layer.rs
+++ b/crates/fast_compute/src/layer.rs
@@ -485,4 +485,29 @@ impl<T: TowerFamily, P: PackedTop<T>> ComputeLayer<T::B128> for FastCpuLayer<T, 
 			.for_each(|(x0, x1)| *x0 += (*x1 - *x0) * z);
 		Ok(())
 	}
+
+	fn deinterleaved(&self, evals: &mut FSliceMut<T::B128, Self>) -> Result<(), Error> {
+		unpack_if_possible_mut(
+			evals.data,
+			|evals| {
+				if evals.len() % 2 != 0 {
+					return Err(Error::InputValidation("evals length is not even".into()));
+				}
+
+				let half = evals.len() / 2;
+
+				let odds = evals.iter().skip(1).step_by(2).copied().collect::<Vec<_>>();
+
+				for i in 0..half {
+					evals[i] = evals[2 * i];
+				}
+
+				evals[half..].copy_from_slice(&odds[..]);
+				Ok(())
+			},
+			|_packed| {
+				todo!();
+			},
+		)
+	}
 }


### PR DESCRIPTION
While this is a straightforward solution that avoids significant changes to hal,
it’s probably not efficient, and there’s likely a better way to iterate without memory reordering.