### PR TITLE
Change ComputeLayer::compile_expr method to accept ArithCircuit

### DIFF
--- a/crates/compute/src/cpu/layer.rs
+++ b/crates/compute/src/cpu/layer.rs
@@ -6,7 +6,7 @@ use binius_field::{
 	BinaryField, ExtensionField, Field, TowerField, tower::TowerFamily,
 	util::inner_product_unchecked,
 };
-use binius_math::{ArithCircuit, ArithExpr, extrapolate_line_scalar};
+use binius_math::{ArithCircuit, extrapolate_line_scalar};
 use binius_ntt::AdditiveNTT;
 use binius_utils::checked_arithmetics::checked_log_2;
 use bytemuck::zeroed_vec;
@@ -86,8 +86,8 @@ impl<T: TowerFamily> ComputeLayer<T::B128> for CpuLayer<T> {
 		f(&mut CpuExecutor)
 	}
 
-	fn compile_expr(&self, expr: &ArithExpr<T::B128>) -> Result<Self::ExprEval, Error> {
-		Ok(expr.into())
+	fn compile_expr(&self, expr: &ArithCircuit<T::B128>) -> Result<Self::ExprEval, Error> {
+		Ok(expr.clone())
 	}
 
 	fn accumulate_kernels(

--- a/crates/compute/src/layer.rs
+++ b/crates/compute/src/layer.rs
@@ -3,7 +3,7 @@
 use std::ops::Range;
 
 use binius_field::{BinaryField, ExtensionField, Field};
-use binius_math::ArithExpr;
+use binius_math::ArithCircuit;
 use binius_ntt::AdditiveNTT;
 use binius_utils::checked_arithmetics::{checked_int_div, checked_log_2};
 use itertools::Either;
@@ -109,7 +109,7 @@ pub trait ComputeLayer<F: Field>: 'static + Sync {
 	}
 
 	/// Compiles an arithmetic expression to the evaluator.
-	fn compile_expr(&self, expr: &ArithExpr<F>) -> Result<Self::ExprEval, Error>;
+	fn compile_expr(&self, expr: &ArithCircuit<F>) -> Result<Self::ExprEval, Error>;
 
 	/// Launch many kernels in parallel and accumulate the scalar results with field addition.
 	///

--- a/crates/compute_test_utils/src/layer.rs
+++ b/crates/compute_test_utils/src/layer.rs
@@ -12,7 +12,7 @@ use binius_compute::{
 use binius_core::composition::BivariateProduct;
 use binius_field::{BinaryField, ExtensionField, Field, PackedExtension, PackedField, TowerField};
 use binius_math::{
-	ArithExpr, CompositionPoly, MultilinearExtension, MultilinearQuery, extrapolate_line_scalar,
+	ArithCircuit, CompositionPoly, MultilinearExtension, MultilinearQuery, extrapolate_line_scalar,
 	tensor_prod_eq_ind,
 };
 use binius_ntt::fri::fold_interleaved;
@@ -352,7 +352,7 @@ pub fn test_generic_single_inner_product_using_kernel_accumulator<F: Field, C: C
 	let b_slice = C::DevMem::as_const(&b_slice);
 
 	// Run the HAL operation to compute the inner product
-	let arith = ArithExpr::Var(0) * ArithExpr::Var(1);
+	let arith = ArithCircuit::var(0) * ArithCircuit::var(1);
 	let eval = compute.compile_expr(&arith).unwrap();
 	let [actual] = compute
 		.execute(|exec| {
@@ -433,7 +433,7 @@ pub fn test_generic_kernel_add<'a, F: Field, C: ComputeLayer<F>>(
 	let b_slice = C::DevMem::as_const(&b_slice);
 
 	// Run the HAL operation to compute the a + b
-	let arith = ArithExpr::Var(0);
+	let arith = ArithCircuit::var(0);
 	let eval = compute.compile_expr(&arith).unwrap();
 	let [actual] = compute
 		.execute(|exec| {
@@ -789,9 +789,7 @@ pub fn test_generic_compute_composite<'a, F: Field, Hal: ComputeLayer<F>>(
 	let input_1_dev = Hal::DevMem::as_const(&input_1_dev);
 
 	let bivariate_product_expr = hal
-		.compile_expr(&ArithExpr::from(CompositionPoly::<F>::expression(
-			&BivariateProduct::default(),
-		)))
+		.compile_expr(&CompositionPoly::<F>::expression(&BivariateProduct::default()))
 		.unwrap();
 
 	let inputs = SlicesBatch::new(vec![input_0_dev, input_1_dev], 1 << log_len);

--- a/crates/core/src/protocols/sumcheck/v3/bivariate_product.rs
+++ b/crates/core/src/protocols/sumcheck/v3/bivariate_product.rs
@@ -7,7 +7,7 @@ use binius_compute::{
 	alloc::{BumpAllocator, ComputeAllocator, HostBumpAllocator},
 };
 use binius_field::{Field, TowerField, util::powers};
-use binius_math::{ArithExpr, CompositionPoly, EvaluationOrder, evaluate_univariate};
+use binius_math::{CompositionPoly, EvaluationOrder, evaluate_univariate};
 use binius_utils::bail;
 
 use crate::{
@@ -284,10 +284,7 @@ pub fn calculate_round_evals<'a, F: TowerField, HAL: ComputeLayer<F>>(
 ) -> Result<[F; 2], Error> {
 	let prod_evaluators = compositions
 		.iter()
-		.map(|composition| {
-			let prod_expr = CompositionPoly::<F>::expression(&composition);
-			hal.compile_expr(&ArithExpr::from(prod_expr))
-		})
+		.map(|composition| hal.compile_expr(&CompositionPoly::<F>::expression(&composition)))
 		.collect::<Result<Vec<_>, _>>()?;
 
 	// n_vars - 1 is the number of variables in the halves of the split multilinear.

--- a/crates/fast_compute/src/layer.rs
+++ b/crates/fast_compute/src/layer.rs
@@ -15,7 +15,7 @@ use binius_field::{
 	unpack_if_possible, unpack_if_possible_mut,
 	util::inner_product_par,
 };
-use binius_math::{ArithExpr, CompositionPoly, RowsBatchRef, tensor_prod_eq_ind};
+use binius_math::{ArithCircuit, CompositionPoly, RowsBatchRef, tensor_prod_eq_ind};
 use binius_maybe_rayon::{
 	iter::{
 		IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator,
@@ -191,8 +191,8 @@ impl<T: TowerFamily, P: PackedTop<T>> ComputeLayer<T::B128> for FastCpuLayer<T, 
 		Ok(init)
 	}
 
-	fn compile_expr(&self, expr: &ArithExpr<T::B128>) -> Result<Self::ExprEval, Error> {
-		let expr = ArithCircuitPoly::new(expr.into());
+	fn compile_expr(&self, expr: &ArithCircuit<T::B128>) -> Result<Self::ExprEval, Error> {
+		let expr = ArithCircuitPoly::new(expr.clone());
 		Ok(expr)
 	}
 


### PR DESCRIPTION
### TL;DR

Replace `ArithExpr` with `ArithCircuit` throughout the codebase.

### What changed?

- Updated function signatures in `ComputeLayer` trait to use `ArithCircuit` instead of `ArithExpr`
- Modified implementations in CPU and FastCPU layers to work with `ArithCircuit`
- Updated test utilities and protocol implementations to use the new type
- Changed how expressions are compiled and handled in various compute layers

### How to test?

Run the existing test suite to ensure all functionality continues to work with the new `ArithCircuit` type. The changes should be transparent to users of the API, so no specific test cases need to be added.

### Why make this change?

This change standardizes the codebase on `ArithCircuit` as the primary representation for arithmetic expressions. This likely provides better consistency and may offer improved capabilities compared to the previous `ArithExpr` type. The change is part of an effort to unify the expression handling across the codebase.