### PR TITLE
[m3] ensure committed bits per row for keccak arithmetization

### DIFF
--- a/crates/m3/src/gadgets/hash/keccak/stacked.rs
+++ b/crates/m3/src/gadgets/hash/keccak/stacked.rs
@@ -579,6 +579,16 @@ mod tests {
 	};
 
 	#[test]
+	fn ensure_committed_bits_per_row() {
+		let mut cs = ConstraintSystem::new();
+		let mut table = cs.add_table("stacked permutation");
+		let _ = Keccakf::new(&mut table);
+		let id = table.id();
+		let stat = cs.tables[id].stat();
+		assert_eq!(stat.bits_per_row_committed(), 51200);
+	}
+
+	#[test]
 	fn test_round_gadget() {
 		const N_ROWS: usize = 1;
 


### PR DESCRIPTION
Used for experiments like here.
https://linear.app/irreducible/issue/CRY-411/keccak-f-arithmetization-without-shifts#comment-86121c91
This is not necessary to land.
