### PR TITLE
[ring_switch] Remove usage of TowerFamily

### DIFF
--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -70,7 +70,7 @@ pub fn prove<U, Tower, Hash, Compress, Challenger_, Backend>(
 where
 	U: ProverTowerUnderlier<Tower>,
 	Tower: ProverTowerFamily,
-	Tower::B128: PackedTop<Tower>,
+	Tower::B128: binius_math::TowerTop + binius_math::PackedTop + PackedTop<Tower>,
 	Hash: Digest + BlockSizeUser + FixedOutputReset + Send + Sync + Clone,
 	Compress: PseudoCompressionFunction<Output<Hash>, 2> + Default + Sync,
 	Challenger_: Challenger + Default,
@@ -83,7 +83,8 @@ where
 		+ RepackedExtension<PackedType<U, Tower::B32>>
 		+ RepackedExtension<PackedType<U, Tower::B64>>
 		+ RepackedExtension<PackedType<U, Tower::B128>>
-		+ PackedTransformationFactory<PackedType<U, Tower::FastB128>>,
+		+ PackedTransformationFactory<PackedType<U, Tower::FastB128>>
+		+ binius_math::PackedTop,
 	PackedType<U, Tower::FastB128>: PackedTransformationFactory<PackedType<U, Tower::B128>>,
 {
 	tracing::debug!(
@@ -452,12 +453,7 @@ where
 	let ring_switch::ReducedWitness {
 		transparents: transparent_multilins,
 		sumcheck_claims: piop_sumcheck_claims,
-	} = ring_switch::prove::<_, _, _, Tower, _>(
-		&system,
-		&committed_multilins,
-		&mut transcript,
-		memoized_data,
-	)?;
+	} = ring_switch::prove(&system, &committed_multilins, &mut transcript, memoized_data)?;
 	drop(ring_switch_span);
 
 	// Prove evaluation claims using PIOP compiler

--- a/crates/core/src/constraint_system/verify.rs
+++ b/crates/core/src/constraint_system/verify.rs
@@ -48,7 +48,7 @@ pub fn verify<U, Tower, Hash, Compress, Challenger_>(
 where
 	U: TowerUnderlier<Tower>,
 	Tower: TowerFamily,
-	Tower::B128: PackedTop<Tower>,
+	Tower::B128: binius_math::TowerTop + binius_math::PackedTop + PackedTop<Tower>,
 	Hash: Digest + BlockSizeUser,
 	Compress: PseudoCompressionFunction<Output<Hash>, 2> + Default + Sync,
 	Challenger_: Challenger + Default,
@@ -190,7 +190,7 @@ where
 	let ring_switch::ReducedClaim {
 		transparents,
 		sumcheck_claims: piop_sumcheck_claims,
-	} = ring_switch::verify::<_, Tower, _>(&system, &mut transcript)?;
+	} = ring_switch::verify(&system, &mut transcript)?;
 
 	// Prove evaluation claims using PIOP compiler
 	piop::verify(

--- a/crates/core/src/ring_switch/prove.rs
+++ b/crates/core/src/ring_switch/prove.rs
@@ -2,7 +2,7 @@
 
 use std::{iter, sync::Arc};
 
-use binius_field::{PackedField, PackedFieldIndexable, TowerField};
+use binius_field::{PackedField, PackedFieldIndexable};
 use binius_math::{
 	B1, B8, B16, B32, B64, B128, MLEDirectAdapter, MultilinearPoly, MultilinearQuery, PackedTop,
 	TowerTop,
@@ -257,7 +257,7 @@ fn make_ring_switch_eq_inds<F, P>(
 	mixing_coeffs: &[F],
 ) -> Result<Vec<MultilinearWitness<'static, P>>, Error>
 where
-	F: TowerField + PackedTop,
+	F: TowerTop,
 	P: PackedFieldIndexable<Scalar = F> + PackedTop,
 {
 	sumcheck_claim_descs

--- a/crates/core/src/ring_switch/tests.rs
+++ b/crates/core/src/ring_switch/tests.rs
@@ -248,13 +248,13 @@ fn test_prove_verify_claim_reduction_with_naive_validation() {
 		let ReducedWitness {
 			transparents: transparent_witnesses,
 			sumcheck_claims: prover_sumcheck_claims,
-		} = prove::<_, _, _, Tower, _>(&system, &witnesses, &mut proof, MemoizedData::new()).unwrap();
+		} = prove(&system, &witnesses, &mut proof, MemoizedData::new()).unwrap();
 
 		let mut proof = proof.into_verifier();
 		let ReducedClaim {
 			transparents: _,
 			sumcheck_claims: verifier_sumcheck_claims,
-		} = verify::<_, Tower, _>(&system, &mut proof).unwrap();
+		} = verify(&system, &mut proof).unwrap();
 
 		assert_eq!(prover_sumcheck_claims, verifier_sumcheck_claims);
 
@@ -274,8 +274,8 @@ fn commit_prove_verify_piop<U, Tower, MTScheme, MTProver>(
 ) where
 	U: TowerUnderlier<Tower>,
 	Tower: TowerFamily,
-	PackedType<U, FExt<Tower>>: PackedFieldIndexable,
-	FExt<Tower>: PackedTop<Tower>,
+	PackedType<U, FExt<Tower>>: PackedFieldIndexable + binius_math::PackedTop,
+	FExt<Tower>: binius_math::TowerTop + binius_math::PackedTop + PackedTop<Tower>,
 	MTScheme: MerkleTreeScheme<FExt<Tower>, Digest: SerializeBytes + DeserializeBytes>,
 	MTProver: MerkleTreeProver<FExt<Tower>, Scheme = MTScheme>,
 {
@@ -322,8 +322,7 @@ fn commit_prove_verify_piop<U, Tower, MTScheme, MTProver>(
 	let ReducedWitness {
 		transparents: transparent_multilins,
 		sumcheck_claims,
-	} = prove::<_, _, _, Tower, _>(&system, &committed_multilins, &mut proof, MemoizedData::new())
-		.unwrap();
+	} = prove(&system, &committed_multilins, &mut proof, MemoizedData::new()).unwrap();
 
 	let domain_factory = DefaultEvaluationDomainFactory::<Tower::B8>::default();
 	piop::prove(
@@ -348,7 +347,7 @@ fn commit_prove_verify_piop<U, Tower, MTScheme, MTProver>(
 	let ReducedClaim {
 		transparents,
 		sumcheck_claims,
-	} = verify::<_, Tower, _>(&system, &mut proof).unwrap();
+	} = verify(&system, &mut proof).unwrap();
 
 	piop::verify(
 		&commit_meta,

--- a/crates/core/src/ring_switch/tower_tensor_algebra.rs
+++ b/crates/core/src/ring_switch/tower_tensor_algebra.rs
@@ -23,7 +23,7 @@ impl<F: TowerTop> TowerTensorAlgebra<F> {
 	/// * `elems` must have length `FE::DEGREE`, otherwise this will pad or truncate.
 	pub fn new(kappa: usize, elems: Vec<F>) -> Result<Self, Error> {
 		match F::TOWER_LEVEL - kappa {
-			1 => Ok(Self::B1(TensorAlgebra::new(elems))),
+			0 => Ok(Self::B1(TensorAlgebra::new(elems))),
 			3 => Ok(Self::B8(TensorAlgebra::new(elems))),
 			4 => Ok(Self::B16(TensorAlgebra::new(elems))),
 			5 => Ok(Self::B32(TensorAlgebra::new(elems))),

--- a/crates/core/src/ring_switch/tower_tensor_algebra.rs
+++ b/crates/core/src/ring_switch/tower_tensor_algebra.rs
@@ -1,67 +1,66 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use binius_field::tower::{PackedTop, TowerFamily};
+use binius_math::{B1, B8, B16, B32, B64, B128, PackedTop, TowerTop};
 
 use super::error::Error;
 use crate::tensor_algebra::TensorAlgebra;
 
-type FExt<Tower> = <Tower as TowerFamily>::B128;
-
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum TowerTensorAlgebra<Tower: TowerFamily> {
-	B1(TensorAlgebra<Tower::B1, Tower::B128>),
-	B8(TensorAlgebra<Tower::B8, Tower::B128>),
-	B16(TensorAlgebra<Tower::B16, Tower::B128>),
-	B32(TensorAlgebra<Tower::B32, Tower::B128>),
-	B64(TensorAlgebra<Tower::B64, Tower::B128>),
-	B128(TensorAlgebra<Tower::B128, Tower::B128>),
+pub enum TowerTensorAlgebra<F: TowerTop> {
+	B1(TensorAlgebra<B1, F>),
+	B8(TensorAlgebra<B8, F>),
+	B16(TensorAlgebra<B16, F>),
+	B32(TensorAlgebra<B32, F>),
+	B64(TensorAlgebra<B64, F>),
+	B128(TensorAlgebra<B128, F>),
 }
 
-impl<Tower: TowerFamily> TowerTensorAlgebra<Tower> {
+impl<F: TowerTop> TowerTensorAlgebra<F> {
 	/// Constructs an element from a vector of vertical subring elements.
 	///
 	/// ## Preconditions
 	///
 	/// * `elems` must have length `FE::DEGREE`, otherwise this will pad or truncate.
-	pub fn new(kappa: usize, elems: Vec<FExt<Tower>>) -> Result<Self, Error> {
-		match kappa {
-			7 => Ok(Self::B1(TensorAlgebra::new(elems))),
-			4 => Ok(Self::B8(TensorAlgebra::new(elems))),
-			3 => Ok(Self::B16(TensorAlgebra::new(elems))),
-			2 => Ok(Self::B32(TensorAlgebra::new(elems))),
-			1 => Ok(Self::B64(TensorAlgebra::new(elems))),
-			0 => Ok(Self::B128(TensorAlgebra::new(elems))),
+	pub fn new(kappa: usize, elems: Vec<F>) -> Result<Self, Error> {
+		match F::TOWER_LEVEL - kappa {
+			1 => Ok(Self::B1(TensorAlgebra::new(elems))),
+			3 => Ok(Self::B8(TensorAlgebra::new(elems))),
+			4 => Ok(Self::B16(TensorAlgebra::new(elems))),
+			5 => Ok(Self::B32(TensorAlgebra::new(elems))),
+			6 => Ok(Self::B64(TensorAlgebra::new(elems))),
+			7 => Ok(Self::B128(TensorAlgebra::new(elems))),
 			_ => Err(Error::PackingDegreeNotSupported { kappa }),
 		}
 	}
 
 	/// Returns the additive identity element, zero.
 	pub fn zero(kappa: usize) -> Result<Self, Error> {
-		match kappa {
-			7 => Ok(Self::B1(TensorAlgebra::default())),
-			4 => Ok(Self::B8(TensorAlgebra::default())),
-			3 => Ok(Self::B16(TensorAlgebra::default())),
-			2 => Ok(Self::B32(TensorAlgebra::default())),
-			1 => Ok(Self::B64(TensorAlgebra::default())),
-			0 => Ok(Self::B128(TensorAlgebra::default())),
+		match F::TOWER_LEVEL - kappa {
+			0 => Ok(Self::B1(TensorAlgebra::default())),
+			3 => Ok(Self::B8(TensorAlgebra::default())),
+			4 => Ok(Self::B16(TensorAlgebra::default())),
+			5 => Ok(Self::B32(TensorAlgebra::default())),
+			6 => Ok(Self::B64(TensorAlgebra::default())),
+			7 => Ok(Self::B128(TensorAlgebra::default())),
 			_ => Err(Error::PackingDegreeNotSupported { kappa }),
 		}
 	}
 
 	/// Returns $\kappa$, the base-2 logarithm of the extension degree.
 	pub const fn kappa(&self) -> usize {
-		match self {
+		let tower_level = match self {
 			Self::B1(_) => 7,
 			Self::B8(_) => 4,
 			Self::B16(_) => 3,
 			Self::B32(_) => 2,
 			Self::B64(_) => 1,
 			Self::B128(_) => 0,
-		}
+		};
+		F::TOWER_LEVEL - tower_level
 	}
 
 	/// Returns a slice of the vertical subfield elements composing the tensor algebra element.
-	pub fn vertical_elems(&self) -> &[FExt<Tower>] {
+	pub fn vertical_elems(&self) -> &[F] {
 		match self {
 			Self::B1(elem) => elem.vertical_elems(),
 			Self::B8(elem) => elem.vertical_elems(),
@@ -73,7 +72,7 @@ impl<Tower: TowerFamily> TowerTensorAlgebra<Tower> {
 	}
 
 	/// Multiply by an element from the vertical subring.
-	pub fn scale_vertical(self, scalar: FExt<Tower>) -> Self {
+	pub fn scale_vertical(self, scalar: F) -> Self {
 		match self {
 			Self::B1(elem) => Self::B1(elem.scale_vertical(scalar)),
 			Self::B8(elem) => Self::B8(elem.scale_vertical(scalar)),
@@ -103,17 +102,13 @@ impl<Tower: TowerFamily> TowerTensorAlgebra<Tower> {
 	}
 }
 
-impl<Tower> TowerTensorAlgebra<Tower>
-where
-	Tower: TowerFamily,
-	FExt<Tower>: PackedTop<Tower>,
-{
+impl<F: TowerTop + PackedTop> TowerTensorAlgebra<F> {
 	/// Fold the tensor algebra element into a field element by scaling the rows and accumulating.
 	///
 	/// ## Preconditions
 	///
 	/// * `coeffs` must have length $2^\kappa$
-	pub fn fold_vertical(self, coeffs: &[FExt<Tower>]) -> FExt<Tower> {
+	pub fn fold_vertical(self, coeffs: &[F]) -> F {
 		match self {
 			Self::B1(elem) => elem.fold_vertical(coeffs),
 			Self::B8(elem) => elem.fold_vertical(coeffs),

--- a/crates/math/src/tower.rs
+++ b/crates/math/src/tower.rs
@@ -6,7 +6,10 @@ pub use binius_field::{
 	BinaryField1b as B1, BinaryField8b as B8, BinaryField16b as B16, BinaryField32b as B32,
 	BinaryField64b as B64, BinaryField128b as B128,
 };
-use binius_field::{ExtensionField, PackedExtension, PackedField, TowerField};
+use binius_field::{
+	ExtensionField, PackedExtension, PackedField, TowerField, as_packed_field::PackScalar,
+	underlier::UnderlierType,
+};
 
 trait_set::trait_set! {
 	/// The top packed field in a tower.
@@ -28,4 +31,14 @@ trait_set::trait_set! {
 		+ PackedExtension<B32>
 		+ PackedExtension<B64>
 		+ PackedExtension<B128>;
+
+		/// An underlier with associated packed types for fields in a tower.
+	pub trait TowerUnderlier =
+		UnderlierType
+		+ PackScalar<B1>
+		+ PackScalar<B8>
+		+ PackScalar<B16>
+		+ PackScalar<B32>
+		+ PackScalar<B64>
+		+ PackScalar<B128>;
 }


### PR DESCRIPTION
Replace TowerFamily with exported tower type aliases.