### PR TITLE
Optimize kernel memory allocations in FastCPULayer

### DIFF
--- a/crates/core/benches/sumcheck.rs
+++ b/crates/core/benches/sumcheck.rs
@@ -158,13 +158,13 @@ fn bench_sumcheck_v3<T: TowerFamily, P: PackedTop<T>>(
 	let mut group = c.benchmark_group(format!("SumcheckV3/{field}"));
 	let mut cpu_memory = vec![T::B128::ZERO; 1 << n_vars];
 	let mut device_memory = vec![P::zero(); 1 << (n_vars + 1 - P::LOG_WIDTH)];
+	let hal = FastCpuLayer::default();
 
 	group.bench_function(format!("n_vars={n_vars}"), |b| {
 		b.iter(|| {
 			let cpu_allocator = HostBumpAllocator::new(&mut cpu_memory);
 			let device_memory = PackedMemorySliceMut::new_slice(&mut device_memory);
 			let device_allocator = BumpAllocator::new(device_memory);
-			let hal = FastCpuLayer::default();
 
 			let prover = BivariateSumcheckProver::new(
 				&hal,

--- a/crates/fast_compute/Cargo.toml
+++ b/crates/fast_compute/Cargo.toml
@@ -18,6 +18,7 @@ bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 bytes = { workspace = true }
 itertools = { workspace = true }
 stackalloc = { workspace = true }
+thread_local = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
It appeared that allocating memory (even a rayon-thread local) can be hot. Introducing thread-local memory buffers in the `FastCPUCore` show signifficant improvement in sumcheck_v3 benchmarks:

```
SumcheckV3/BinaryField128b/n_vars=20
                        time:   [56.705 ms 57.130 ms 57.606 ms]
                        change: [−2.5240% −1.6333% −0.6557%] (p = 0.00 < 0.05)
                        Change within noise threshold.

SumcheckV3/ByteSlicedAES32x128b/n_vars=20
                        time:   [14.317 ms 14.397 ms 14.482 ms]
                        change: [−90.718% −90.649% −90.584%] (p = 0.00 < 0.05)
                        Performance has improved.

```    