### PR TITLE
[chore] add profile.json to .gitignore as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,7 @@ benchmark_results/
 **/rustc-ice-*.txt
 /*.bin
 .last_perfetto_trace_path
+
+# Samply profile files
 profile.json.gz
+profile.json


### PR DESCRIPTION
On macOS I am getting profile.json, i.e. without compression, for some reason.