### PR TITLE
[compute] Create KernelBuilder trait

### DIFF
--- a/crates/compute/src/cpu/layer.rs
+++ b/crates/compute/src/cpu/layer.rs
@@ -14,7 +14,7 @@ use itertools::izip;
 
 use super::{memory::CpuMemory, tower_macro::each_tower_subfield};
 use crate::{
-	KernelBuilder,
+	KernelExecutor,
 	alloc::{BumpAllocator, ComputeAllocator},
 	layer::{ComputeLayer, Error, FSlice, FSliceMut, KernelBuffer, KernelMemMap},
 	memory::{ComputeMemory, SizedSlice, SlicesBatch, SubfieldSlice},
@@ -377,7 +377,7 @@ impl<T: TowerFamily> ComputeLayer<T::B128> for CpuLayer<T> {
 #[derive(Debug)]
 pub struct CpuKernelBuilder;
 
-impl<F: TowerField> KernelBuilder<F> for CpuKernelBuilder {
+impl<F: TowerField> KernelExecutor<F> for CpuKernelBuilder {
 	type Mem = CpuMemory;
 	type Value = F;
 	type ExprEval = ArithCircuit<F>;

--- a/crates/compute/src/layer.rs
+++ b/crates/compute/src/layer.rs
@@ -24,7 +24,7 @@ pub trait ComputeLayer<F: Field>: 'static + Sync {
 
 	/// The executor that can execute operations on a kernel-level granularity (i.e., a single
 	/// core).
-	type KernelExec: KernelBuilder<F, Mem = Self::DevMem, Value = Self::KernelValue, ExprEval = Self::ExprEval>;
+	type KernelExec: KernelExecutor<F, Mem = Self::DevMem, Value = Self::KernelValue, ExprEval = Self::ExprEval>;
 
 	/// The operation (scalar) value type.
 	type OpValue;
@@ -454,13 +454,13 @@ pub trait ComputeLayer<F: Field>: 'static + Sync {
 	) -> Result<(), Error>;
 }
 
-/// An interface for constructing execution kernels.
+/// An interface for defining execution kernels.
 ///
 /// A _kernel_ is a program that executes synchronously in one thread, with access to
 /// local memory buffers.
 ///
 /// See [`ComputeLayer::accumulate_kernels`] for more information.
-pub trait KernelBuilder<F> {
+pub trait KernelExecutor<F> {
 	/// The type for kernel-local memory buffers.
 	type Mem: ComputeMemory<F>;
 

--- a/crates/fast_compute/src/layer.rs
+++ b/crates/fast_compute/src/layer.rs
@@ -3,7 +3,7 @@
 use std::{cell::RefCell, iter::repeat_with, marker::PhantomData, mem::MaybeUninit, slice};
 
 use binius_compute::{
-	KernelBuilder,
+	KernelExecutor,
 	alloc::{BumpAllocator, ComputeAllocator},
 	cpu::layer::count_total_local_buffer_sizes,
 	each_tower_subfield,
@@ -485,7 +485,7 @@ impl<T, P> Default for FastKernelBuilder<T, P> {
 	}
 }
 
-impl<T: TowerFamily, P: PackedTop<T>> KernelBuilder<T::B128> for FastKernelBuilder<T, P> {
+impl<T: TowerFamily, P: PackedTop<T>> KernelExecutor<T::B128> for FastKernelBuilder<T, P> {
 	type Mem = PackedMemory<P>;
 	type Value = T::B128;
 	type ExprEval = ArithCircuitPoly<T::B128>;


### PR DESCRIPTION
Move kernel construction methods from ComputeLayer onto a new trait, which is an associated type. This helps move towards an API where ComputeLayer can be sync while allowing for multithreaded backends.