### PR TITLE
[core] instead of max_channel_id use channel count directly

### DIFF
--- a/crates/circuits/src/builder/constraint_system.rs
+++ b/crates/circuits/src/builder/constraint_system.rs
@@ -58,13 +58,10 @@ impl<'arena> ConstraintSystemBuilder<'arena> {
 	#[allow(clippy::type_complexity)]
 	pub fn build(self) -> Result<ConstraintSystem<F>, anyhow::Error> {
 		let table_constraints = self.constraints.build(&self.oracles.borrow())?;
+		let max_channel_id = self.flushes.iter().map(|flush| flush.channel_id).max();
+		let channel_count = max_channel_id.map_or(0, |id| id + 1);
 		Ok(ConstraintSystem {
-			max_channel_id: self
-				.flushes
-				.iter()
-				.map(|flush| flush.channel_id)
-				.max()
-				.unwrap_or(0),
+			channel_count,
 			table_constraints,
 			non_zero_oracle_ids: self.non_zero_oracle_ids,
 			oracles: Rc::into_inner(self.oracles)

--- a/crates/core/src/constraint_system/channel.rs
+++ b/crates/core/src/constraint_system/channel.rs
@@ -93,13 +93,14 @@ pub fn validate_witness<F, P>(
 	witness: &MultilinearExtensionIndex<P>,
 	flushes: &[Flush<F>],
 	boundaries: &[Boundary<F>],
-	max_channel_id: ChannelId,
+	channel_count: usize,
 ) -> Result<(), Error>
 where
 	P: PackedField<Scalar = F>,
 	F: TowerField,
 {
-	let mut channels = vec![Channel::<F>::new(); max_channel_id + 1];
+	let mut channels = vec![Channel::<F>::new(); channel_count];
+	let max_channel_id = channel_count.saturating_sub(1);
 
 	for boundary in boundaries.iter().cloned() {
 		let Boundary {

--- a/crates/core/src/constraint_system/mod.rs
+++ b/crates/core/src/constraint_system/mod.rs
@@ -10,7 +10,7 @@ mod verify;
 
 use binius_field::{BinaryField128b, TowerField};
 use binius_macros::{DeserializeBytes, SerializeBytes};
-use channel::{ChannelId, Flush};
+use channel::Flush;
 use exp::Exp;
 pub use prove::prove;
 pub use verify::verify;
@@ -32,7 +32,7 @@ pub struct ConstraintSystem<F: TowerField> {
 	pub non_zero_oracle_ids: Vec<OracleId>,
 	pub flushes: Vec<Flush<F>>,
 	pub exponents: Vec<Exp<F>>,
-	pub max_channel_id: ChannelId,
+	pub channel_count: usize,
 }
 
 impl<F: TowerField> ConstraintSystem<F> {}

--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -104,7 +104,7 @@ where
 		mut flushes,
 		mut exponents,
 		non_zero_oracle_ids,
-		max_channel_id,
+		channel_count,
 	} = constraint_system.clone();
 
 	reorder_exponents(&mut exponents, &oracles);
@@ -272,7 +272,7 @@ where
 
 	// Grand products for flushing
 	let mixing_challenge = transcript.sample();
-	let permutation_challenges = transcript.sample_vec(max_channel_id + 1);
+	let permutation_challenges = transcript.sample_vec(channel_count);
 
 	flushes.sort_by_key(|flush| flush.channel_id);
 	let flush_oracle_ids =

--- a/crates/core/src/constraint_system/validate.rs
+++ b/crates/core/src/constraint_system/validate.rs
@@ -66,7 +66,7 @@ where
 		witness,
 		&constraint_system.flushes,
 		boundaries,
-		constraint_system.max_channel_id,
+		constraint_system.channel_count,
 	)?;
 
 	// Check consistency of virtual oracle witnesses (eg. that shift polynomials are actually

--- a/crates/core/src/constraint_system/verify.rs
+++ b/crates/core/src/constraint_system/verify.rs
@@ -58,7 +58,7 @@ where
 		table_constraints,
 		mut flushes,
 		non_zero_oracle_ids,
-		max_channel_id,
+		channel_count,
 		mut exponents,
 		..
 	} = constraint_system.clone();
@@ -134,7 +134,7 @@ where
 	// Grand products for flushing
 	let mixing_challenge = transcript.sample();
 	// TODO(cryptographers): Find a way to sample less randomness
-	let permutation_challenges = transcript.sample_vec(max_channel_id + 1);
+	let permutation_challenges = transcript.sample_vec(channel_count);
 
 	flushes.sort_by_key(|flush| flush.channel_id);
 	let flush_oracle_ids =

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -355,7 +355,7 @@ impl<F: TowerField> ConstraintSystem<F> {
 			table_constraints,
 			flushes: compiled_flushes,
 			non_zero_oracle_ids,
-			max_channel_id: self.channels.len().saturating_sub(1),
+			channel_count: self.channels.len(),
 			exponents,
 		})
 	}


### PR DESCRIPTION
This seems to be a more logical approach, but it will also for the consistency
with the to-be-added table_count

This is part of [CRY-363: Table-Aware Constraint System](https://linear.app/irreducible/issue/CRY-363/table-aware-constraint-system)