### PR TITLE
[core] push TableId down to core

### DIFF
--- a/crates/core/src/constraint_system/mod.rs
+++ b/crates/core/src/constraint_system/mod.rs
@@ -48,3 +48,5 @@ impl Proof {
 		self.transcript.len()
 	}
 }
+
+pub type TableId = usize;

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -2,6 +2,7 @@
 
 use std::{ops::Index, sync::Arc};
 
+pub use binius_core::constraint_system::TableId;
 use binius_core::{
 	constraint_system::channel::{ChannelId, FlushDirection},
 	oracle::ShiftVariant,
@@ -29,8 +30,6 @@ use super::{
 	types::B128,
 	upcast_col,
 };
-
-pub type TableId = usize;
 
 #[derive(Debug)]
 pub struct TableBuilder<'a, F: TowerField = B128> {


### PR DESCRIPTION
As part of [CRY-363: Table-Aware Constraint
System](https://linear.app/irreducible/issue/CRY-363/table-aware-constraint-system),
we would need to introduce the concept of tables into core and we would need
a way to address them via those IDs.

Proper structurification and rustdoc should come in a follow-up (specifically it's tracked [here](https://linear.app/irreducible/issue/CRY-350/newtype-tableid)).