### PR TITLE
[core] new prove/verify API

### DIFF
--- a/crates/core/src/constraint_system/mod.rs
+++ b/crates/core/src/constraint_system/mod.rs
@@ -13,7 +13,9 @@ mod tests;
 
 use binius_field::{BinaryField128b, TowerField};
 use binius_macros::{DeserializeBytes, SerializeBytes};
+use binius_utils::{SerializationMode, SerializeBytes};
 use channel::Flush;
+use digest::{Digest, Output};
 use exp::Exp;
 pub use prove::prove;
 pub use verify::verify;
@@ -38,7 +40,17 @@ pub struct ConstraintSystem<F: TowerField> {
 	pub channel_count: usize,
 }
 
-impl<F: TowerField> ConstraintSystem<F> {}
+impl<F: TowerField> ConstraintSystem<F> {
+	/// Returns the hash digest of this constraint system.
+	///
+	/// This assumes that the constraint system should be serializable.
+	pub fn digest<Hash: Digest>(&self) -> Output<Hash> {
+		let mut buf = Vec::new();
+		self.serialize(&mut buf, SerializationMode::CanonicalTower)
+			.expect("the constraint system should be serializable");
+		Hash::digest(&buf)
+	}
+}
 
 /// Constraint system proof that has been serialized into bytes
 #[derive(Debug, Clone)]

--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -68,7 +68,9 @@ pub fn prove<Hal, U, Tower, Hash, Compress, Challenger_, Backend>(
 	constraint_system: &ConstraintSystem<FExt<Tower>>,
 	log_inv_rate: usize,
 	security_bits: usize,
+	constraint_system_digest: &Output<Hash::Digest>,
 	boundaries: &[Boundary<FExt<Tower>>],
+	table_sizes: &[usize],
 	mut witness: MultilinearExtensionIndex<PackedType<U, FExt<Tower>>>,
 	backend: &Backend,
 ) -> Result<Proof, Error>
@@ -94,6 +96,7 @@ where
 		+ binius_math::PackedTop,
 	PackedType<U, Tower::FastB128>: PackedTransformationFactory<PackedType<U, Tower::B128>>,
 {
+	let _ = (constraint_system_digest, table_sizes);
 	tracing::debug!(
 		arch = env::consts::ARCH,
 		rayon_threads = binius_maybe_rayon::current_num_threads(),

--- a/crates/core/src/constraint_system/validate.rs
+++ b/crates/core/src/constraint_system/validate.rs
@@ -24,12 +24,14 @@ use crate::{
 pub fn validate_witness<F, P>(
 	constraint_system: &ConstraintSystem<F>,
 	boundaries: &[Boundary<F>],
+	table_sizes: &[usize],
 	witness: &MultilinearExtensionIndex<'_, P>,
 ) -> Result<(), Error>
 where
 	P: PackedField<Scalar = F> + PackedExtension<BinaryField1b>,
 	F: TowerField,
 {
+	let _ = table_sizes;
 	// Check the constraint sets
 	for constraint_set in &constraint_system.table_constraints {
 		let multilinears = constraint_set

--- a/crates/core/src/constraint_system/verify.rs
+++ b/crates/core/src/constraint_system/verify.rs
@@ -7,7 +7,7 @@ use binius_field::{
 use binius_hash::PseudoCompressionFunction;
 use binius_math::{ArithExpr, CompositionPoly, EvaluationOrder};
 use binius_utils::{bail, checked_arithmetics::log2_ceil_usize};
-use digest::{Digest, Output, core_api::BlockSizeUser};
+use digest::{Digest, Output, OutputSizeUser, core_api::BlockSizeUser};
 use itertools::{Itertools, chain};
 use tracing::instrument;
 
@@ -38,10 +38,12 @@ use crate::{
 
 /// Verifies a proof against a constraint system.
 #[instrument("constraint_system::verify", skip_all, level = "debug")]
+#[allow(clippy::too_many_arguments)]
 pub fn verify<U, Tower, Hash, Compress, Challenger_>(
 	constraint_system: &ConstraintSystem<FExt<Tower>>,
 	log_inv_rate: usize,
 	security_bits: usize,
+	constraint_system_digest: &Output<Hash>,
 	boundaries: &[Boundary<FExt<Tower>>],
 	proof: Proof,
 ) -> Result<(), Error>
@@ -49,10 +51,11 @@ where
 	U: TowerUnderlier<Tower>,
 	Tower: TowerFamily,
 	Tower::B128: binius_math::TowerTop + binius_math::PackedTop + PackedTop<Tower>,
-	Hash: Digest + BlockSizeUser,
+	Hash: Digest + BlockSizeUser + OutputSizeUser,
 	Compress: PseudoCompressionFunction<Output<Hash>, 2> + Default + Sync,
 	Challenger_: Challenger + Default,
 {
+	let _ = constraint_system_digest;
 	let ConstraintSystem {
 		mut oracles,
 		table_constraints,

--- a/crates/core/src/polynomial/multivariate.rs
+++ b/crates/core/src/polynomial/multivariate.rs
@@ -7,7 +7,7 @@ use binius_field::{Field, PackedField, TowerField};
 use binius_math::{
 	ArithCircuit, CompositionPoly, MLEDirectAdapter, MultilinearPoly, MultilinearQueryRef,
 };
-use binius_utils::{SerializationError, SerializationMode, bail};
+use binius_utils::{SerializationError, SerializationMode, SerializeBytes as _, bail};
 use bytes::BufMut;
 use itertools::Itertools;
 use rand::{SeedableRng, rngs::StdRng};
@@ -92,6 +92,14 @@ impl<F: TowerField> MultivariatePoly<F> for ArithCircuit<F> {
 
 	fn binary_tower_level(&self) -> usize {
 		self.binary_tower_level()
+	}
+
+	fn erased_serialize(
+		&self,
+		write_buf: &mut dyn BufMut,
+		mode: SerializationMode,
+	) -> Result<(), SerializationError> {
+		self.serialize(write_buf, mode)
 	}
 }
 

--- a/crates/m3/src/builder/test_utils.rs
+++ b/crates/m3/src/builder/test_utils.rs
@@ -124,6 +124,7 @@ pub fn validate_system_witness_with_prove_verify<U>(
 	binius_core::constraint_system::validate::validate_witness(
 		&ccs,
 		&statement.boundaries,
+		&statement.table_sizes,
 		&witness,
 	)
 	.unwrap();
@@ -139,6 +140,7 @@ pub fn validate_system_witness_with_prove_verify<U>(
 
 		let dev_mem = PackedMemorySliceMut::new_slice(&mut dev_mem_owned);
 
+		let ccs_digest = ccs.digest::<Groestl256>();
 		let proof = binius_core::constraint_system::prove::<
 			_,
 			U,
@@ -154,7 +156,9 @@ pub fn validate_system_witness_with_prove_verify<U>(
 			&ccs,
 			LOG_INV_RATE,
 			SECURITY_BITS,
+			&ccs_digest,
 			&statement.boundaries,
+			&statement.table_sizes,
 			witness,
 			&binius_hal::make_portable_backend(),
 		)
@@ -166,7 +170,7 @@ pub fn validate_system_witness_with_prove_verify<U>(
 			Groestl256,
 			Groestl256ByteCompression,
 			HasherChallenger<Groestl256>,
-		>(&ccs, LOG_INV_RATE, SECURITY_BITS, &statement.boundaries, proof)
+		>(&ccs, LOG_INV_RATE, SECURITY_BITS, &ccs_digest, &statement.boundaries, proof)
 		.unwrap();
 	}
 }

--- a/crates/m3/src/gadgets/add.rs
+++ b/crates/m3/src/gadgets/add.rs
@@ -521,10 +521,16 @@ mod tests {
 
 			// Validate constraint system
 			let ccs = cs.compile(&statement).unwrap();
+			let table_sizes = witness.table_sizes();
 			let witness = witness.into_multilinear_extension_index();
 
-			binius_core::constraint_system::validate::validate_witness(&ccs, &[], &witness)
-				.unwrap();
+			binius_core::constraint_system::validate::validate_witness(
+				&ccs,
+				&[],
+				&table_sizes,
+				&witness,
+			)
+			.unwrap();
 		}
 	}
 

--- a/crates/m3/src/gadgets/barrel_shifter.rs
+++ b/crates/m3/src/gadgets/barrel_shifter.rs
@@ -208,9 +208,16 @@ mod tests {
 		}
 
 		let ccs = cs.compile(&statement).unwrap();
+		let table_sizes = witness.table_sizes();
 		let witness = witness.into_multilinear_extension_index();
 
-		binius_core::constraint_system::validate::validate_witness(&ccs, &[], &witness).unwrap();
+		binius_core::constraint_system::validate::validate_witness(
+			&ccs,
+			&[],
+			&table_sizes,
+			&witness,
+		)
+		.unwrap();
 	}
 
 	#[test]

--- a/crates/m3/src/gadgets/hash/groestl.rs
+++ b/crates/m3/src/gadgets/hash/groestl.rs
@@ -439,9 +439,16 @@ mod tests {
 		sbox.populate(&mut segment).unwrap();
 
 		let ccs = cs.compile(&statement).unwrap();
+		let table_sizes = witness.table_sizes();
 		let witness = witness.into_multilinear_extension_index();
 
-		binius_core::constraint_system::validate::validate_witness(&ccs, &[], &witness).unwrap();
+		binius_core::constraint_system::validate::validate_witness(
+			&ccs,
+			&[],
+			&table_sizes,
+			&witness,
+		)
+		.unwrap();
 	}
 
 	#[test]
@@ -492,9 +499,16 @@ mod tests {
 		}
 
 		let ccs = cs.compile(&statement).unwrap();
+		let table_sizes = witness.table_sizes();
 		let witness = witness.into_multilinear_extension_index();
 
-		binius_core::constraint_system::validate::validate_witness(&ccs, &[], &witness).unwrap();
+		binius_core::constraint_system::validate::validate_witness(
+			&ccs,
+			&[],
+			&table_sizes,
+			&witness,
+		)
+		.unwrap();
 	}
 
 	#[test]
@@ -545,9 +559,16 @@ mod tests {
 		}
 
 		let ccs = cs.compile(&statement).unwrap();
+		let table_sizes = witness.table_sizes();
 		let witness = witness.into_multilinear_extension_index();
 
-		binius_core::constraint_system::validate::validate_witness(&ccs, &[], &witness).unwrap();
+		binius_core::constraint_system::validate::validate_witness(
+			&ccs,
+			&[],
+			&table_sizes,
+			&witness,
+		)
+		.unwrap();
 	}
 
 	#[test]

--- a/crates/m3/src/gadgets/hash/keccak/stacked.rs
+++ b/crates/m3/src/gadgets/hash/keccak/stacked.rs
@@ -616,7 +616,13 @@ mod tests {
 		let ccs = cs.compile(&statement).unwrap();
 		let witness = witness.into_multilinear_extension_index();
 
-		binius_core::constraint_system::validate::validate_witness(&ccs, &[], &witness).unwrap();
+		binius_core::constraint_system::validate::validate_witness(
+			&ccs,
+			&statement.boundaries,
+			&statement.table_sizes,
+			&witness,
+		)
+		.unwrap();
 	}
 
 	#[test]
@@ -661,6 +667,12 @@ mod tests {
 		let ccs = cs.compile(&statement).unwrap();
 		let witness = witness.into_multilinear_extension_index();
 
-		binius_core::constraint_system::validate::validate_witness(&ccs, &[], &witness).unwrap();
+		binius_core::constraint_system::validate::validate_witness(
+			&ccs,
+			&statement.boundaries,
+			&statement.table_sizes,
+			&witness,
+		)
+		.unwrap();
 	}
 }

--- a/crates/m3/src/gadgets/sub.rs
+++ b/crates/m3/src/gadgets/sub.rs
@@ -432,10 +432,16 @@ mod tests {
 
 			// Validate constraint system
 			let ccs = cs.compile(&statement).unwrap();
+			let table_sizes = witness.table_sizes();
 			let witness = witness.into_multilinear_extension_index();
 
-			binius_core::constraint_system::validate::validate_witness(&ccs, &[], &witness)
-				.unwrap();
+			binius_core::constraint_system::validate::validate_witness(
+				&ccs,
+				&[],
+				&table_sizes,
+				&witness,
+			)
+			.unwrap();
 		}
 	}
 }

--- a/examples/b32_mul.rs
+++ b/examples/b32_mul.rs
@@ -91,6 +91,7 @@ fn main() -> Result<()> {
 	drop(trace_gen_scope);
 
 	let ccs = cs.compile(&statement).unwrap();
+	let cs_digest = ccs.digest::<Groestl256>();
 	let witness = witness.into_multilinear_extension_index();
 
 	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
@@ -115,7 +116,9 @@ fn main() -> Result<()> {
 		&ccs,
 		args.log_inv_rate as usize,
 		SECURITY_BITS,
-		&[],
+		&cs_digest,
+		&statement.boundaries,
+		&statement.table_sizes,
 		witness,
 		&make_portable_backend(),
 	)
@@ -129,7 +132,14 @@ fn main() -> Result<()> {
 		Groestl256,
 		Groestl256ByteCompression,
 		HasherChallenger<Groestl256>,
-	>(&ccs, args.log_inv_rate as usize, SECURITY_BITS, &[], proof)?;
+	>(
+		&ccs,
+		args.log_inv_rate as usize,
+		SECURITY_BITS,
+		&cs_digest,
+		&statement.boundaries,
+		proof,
+	)?;
 
 	Ok(())
 }

--- a/examples/bitwise_ops.rs
+++ b/examples/bitwise_ops.rs
@@ -233,6 +233,7 @@ fn main() -> Result<()> {
 	drop(trace_gen_scope);
 
 	let ccs = cs.compile(&statement).unwrap();
+	let cs_digest = ccs.digest::<Groestl256>();
 	let witness = witness.into_multilinear_extension_index();
 
 	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
@@ -257,7 +258,9 @@ fn main() -> Result<()> {
 		&ccs,
 		args.log_inv_rate as usize,
 		SECURITY_BITS,
-		&[],
+		&cs_digest,
+		&statement.boundaries,
+		&statement.table_sizes,
 		witness,
 		&make_portable_backend(),
 	)?;
@@ -270,7 +273,14 @@ fn main() -> Result<()> {
 		Groestl256,
 		Groestl256ByteCompression,
 		HasherChallenger<Groestl256>,
-	>(&ccs, args.log_inv_rate as usize, SECURITY_BITS, &[], proof)?;
+	>(
+		&ccs,
+		args.log_inv_rate as usize,
+		SECURITY_BITS,
+		&cs_digest,
+		&statement.boundaries,
+		proof,
+	)?;
 
 	Ok(())
 }

--- a/examples/groestl.rs
+++ b/examples/groestl.rs
@@ -112,6 +112,7 @@ fn main() -> Result<()> {
 	drop(trace_gen_scope);
 
 	let ccs = cs.compile(&statement).unwrap();
+	let cs_digest = ccs.digest::<Groestl256>();
 	let witness = witness.into_multilinear_extension_index();
 
 	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
@@ -136,7 +137,9 @@ fn main() -> Result<()> {
 		&ccs,
 		args.log_inv_rate as usize,
 		SECURITY_BITS,
+		&cs_digest,
 		&statement.boundaries,
+		&statement.table_sizes,
 		witness,
 		&make_portable_backend(),
 	)
@@ -150,7 +153,14 @@ fn main() -> Result<()> {
 		Groestl256,
 		Groestl256ByteCompression,
 		HasherChallenger<Groestl256>,
-	>(&ccs, args.log_inv_rate as usize, SECURITY_BITS, &statement.boundaries, proof)
+	>(
+		&ccs,
+		args.log_inv_rate as usize,
+		SECURITY_BITS,
+		&cs_digest,
+		&statement.boundaries,
+		proof,
+	)
 	.unwrap();
 
 	Ok(())

--- a/examples/keccak.rs
+++ b/examples/keccak.rs
@@ -113,6 +113,7 @@ fn main() -> Result<()> {
 	drop(trace_gen_scope);
 
 	let ccs = cs.compile(&statement).unwrap();
+	let cs_digest = ccs.digest::<Groestl256>();
 	let witness = witness.into_multilinear_extension_index();
 
 	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
@@ -137,7 +138,9 @@ fn main() -> Result<()> {
 		&ccs,
 		args.log_inv_rate as usize,
 		SECURITY_BITS,
+		&cs_digest,
 		&statement.boundaries,
+		&statement.table_sizes,
 		witness,
 		&make_portable_backend(),
 	)
@@ -151,7 +154,14 @@ fn main() -> Result<()> {
 		Groestl256,
 		Groestl256ByteCompression,
 		HasherChallenger<Groestl256>,
-	>(&ccs, args.log_inv_rate as usize, SECURITY_BITS, &statement.boundaries, proof)
+	>(
+		&ccs,
+		args.log_inv_rate as usize,
+		SECURITY_BITS,
+		&cs_digest,
+		&statement.boundaries,
+		proof,
+	)
 	.unwrap();
 
 	Ok(())

--- a/examples/merkle_tree.rs
+++ b/examples/merkle_tree.rs
@@ -94,6 +94,7 @@ fn main() -> Result<()> {
 	};
 
 	let ccs = cs.compile(&statement).unwrap();
+	let cs_digest = ccs.digest::<Groestl256>();
 	let witness = witness.into_multilinear_extension_index();
 
 	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
@@ -118,7 +119,9 @@ fn main() -> Result<()> {
 		&ccs,
 		args.log_inv_rate as usize,
 		SECURITY_BITS,
+		&cs_digest,
 		&statement.boundaries,
+		&statement.table_sizes,
 		witness,
 		&make_portable_backend(),
 	)
@@ -132,7 +135,14 @@ fn main() -> Result<()> {
 		Groestl256,
 		Groestl256ByteCompression,
 		HasherChallenger<Groestl256>,
-	>(&ccs, args.log_inv_rate as usize, SECURITY_BITS, &statement.boundaries, proof)?;
+	>(
+		&ccs,
+		args.log_inv_rate as usize,
+		SECURITY_BITS,
+		&cs_digest,
+		&statement.boundaries,
+		proof,
+	)?;
 
 	Ok(())
 }

--- a/examples/u32_add.rs
+++ b/examples/u32_add.rs
@@ -87,6 +87,7 @@ fn main() -> Result<()> {
 	drop(trace_gen_scope);
 
 	let ccs = cs.compile(&statement).unwrap();
+	let cs_digest = ccs.digest::<Groestl256>();
 	let witness = witness.into_multilinear_extension_index();
 
 	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
@@ -111,7 +112,9 @@ fn main() -> Result<()> {
 		&ccs,
 		args.log_inv_rate as usize,
 		SECURITY_BITS,
-		&[],
+		&cs_digest,
+		&statement.boundaries,
+		&statement.table_sizes,
 		witness,
 		&make_portable_backend(),
 	)
@@ -125,7 +128,14 @@ fn main() -> Result<()> {
 		Groestl256,
 		Groestl256ByteCompression,
 		HasherChallenger<Groestl256>,
-	>(&ccs, args.log_inv_rate as usize, SECURITY_BITS, &[], proof)?;
+	>(
+		&ccs,
+		args.log_inv_rate as usize,
+		SECURITY_BITS,
+		&cs_digest,
+		&statement.boundaries,
+		proof,
+	)?;
 
 	Ok(())
 }

--- a/examples/u32_mul_gkr.rs
+++ b/examples/u32_mul_gkr.rs
@@ -109,6 +109,7 @@ fn main() -> Result<()> {
 	drop(trace_gen_scope);
 
 	let ccs = cs.compile(&statement)?;
+	let cs_digest = ccs.digest::<Groestl256>();
 	let witness = witness.into_multilinear_extension_index();
 
 	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
@@ -133,7 +134,9 @@ fn main() -> Result<()> {
 		&ccs,
 		args.log_inv_rate as usize,
 		SECURITY_BITS,
-		&[],
+		&cs_digest,
+		&statement.boundaries,
+		&statement.table_sizes,
 		witness,
 		&make_portable_backend(),
 	)
@@ -147,7 +150,14 @@ fn main() -> Result<()> {
 		Groestl256,
 		Groestl256ByteCompression,
 		HasherChallenger<Groestl256>,
-	>(&ccs, args.log_inv_rate as usize, SECURITY_BITS, &[], proof)?;
+	>(
+		&ccs,
+		args.log_inv_rate as usize,
+		SECURITY_BITS,
+		&cs_digest,
+		&statement.boundaries,
+		proof,
+	)?;
 
 	Ok(())
 }


### PR DESCRIPTION
This is a glimpse of the new API. Changes:

- table sizes are now passed into the prove method
- prove and verify now accepts the digest of the cs
- cs gains a `digest` method
- add erased_serialize on `MultivariatePoly for ArithCircuit`