### PR TITLE
Use transformation to byte sliced and back in `FastCpuLayer::extrapolate_lines`

### DIFF
--- a/crates/fast_compute/tests/layer.rs
+++ b/crates/fast_compute/tests/layer.rs
@@ -7,8 +7,8 @@ use binius_compute_test_utils::layer::{
 };
 use binius_fast_compute::{layer::FastCpuLayer, memory::PackedMemorySliceMut};
 use binius_field::{
-	BinaryField16b, BinaryField128b, PackedBinaryField2x128b, PackedField,
-	tower::CanonicalTowerFamily,
+	BinaryField16b, BinaryField128b, PackedBinaryField1x128b, PackedBinaryField2x128b,
+	PackedBinaryField4x128b, PackedField, tower::CanonicalTowerFamily,
 };
 
 #[test]
@@ -137,8 +137,34 @@ fn test_exec_kernel_add() {
 }
 
 #[test]
-fn test_extrapolate_line() {
+fn test_extrapolate_line_128b() {
+	type P = PackedBinaryField1x128b;
+	let log_len = 10;
+	let compute = <FastCpuLayer<CanonicalTowerFamily, P>>::default();
+	let mut device_memory = vec![P::zero(); 1 << (log_len + 3 - P::LOG_WIDTH)];
+	binius_compute_test_utils::layer::test_extrapolate_line(
+		&compute,
+		PackedMemorySliceMut::new_slice(&mut device_memory),
+		log_len,
+	);
+}
+
+#[test]
+fn test_extrapolate_line_256b() {
 	type P = PackedBinaryField2x128b;
+	let log_len = 10;
+	let compute = <FastCpuLayer<CanonicalTowerFamily, P>>::default();
+	let mut device_memory = vec![P::zero(); 1 << (log_len + 3 - P::LOG_WIDTH)];
+	binius_compute_test_utils::layer::test_extrapolate_line(
+		&compute,
+		PackedMemorySliceMut::new_slice(&mut device_memory),
+		log_len,
+	);
+}
+
+#[test]
+fn test_extrapolate_line_512b() {
+	type P = PackedBinaryField4x128b;
 	let log_len = 10;
 	let compute = <FastCpuLayer<CanonicalTowerFamily, P>>::default();
 	let mut device_memory = vec![P::zero(); 1 << (log_len + 3 - P::LOG_WIDTH)];

--- a/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
+++ b/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
@@ -58,7 +58,7 @@ macro_rules! define_byte_sliced_3d {
 			pub const BYTES: usize = <$storage_tower_level as TowerLevel>::WIDTH * <$packed_storage>::WIDTH;
 
 			const SCALAR_BYTES: usize = <$scalar_type>::N_BITS / 8;
-			pub(crate) const HEIGHT_BYTES: usize = <$storage_tower_level as TowerLevel>::WIDTH;
+			pub const HEIGHT_BYTES: usize = <$storage_tower_level as TowerLevel>::WIDTH;
 			const HEIGHT: usize = Self::HEIGHT_BYTES / Self::SCALAR_BYTES;
 			const LOG_HEIGHT: usize = checked_log_2(Self::HEIGHT);
 
@@ -633,7 +633,7 @@ macro_rules! define_byte_sliced_3d_1b {
 			pub const BYTES: usize =
 				<$storage_tower_level as TowerLevel>::WIDTH * <$packed_storage>::WIDTH;
 
-			pub(crate) const HEIGHT_BYTES: usize = <$storage_tower_level as TowerLevel>::WIDTH;
+			pub const HEIGHT_BYTES: usize = <$storage_tower_level as TowerLevel>::WIDTH;
 			const LOG_HEIGHT: usize = checked_log_2(Self::HEIGHT_BYTES);
 
 			/// Get the byte at the given index.


### PR DESCRIPTION
# Optimize extrapolate_line for binary fields using byte-sliced representation

### TL;DR

Optimize the `extrapolate_line` operation for binary fields by leveraging byte-sliced representation transformations.

### What changed?

- Added a specialized implementation of `extrapolate_line` for binary field types (`PackedBinaryField1x128b`, `PackedBinaryField2x128b`, and `PackedBinaryField4x128b`)
- Created a macro `extrapolate_line_byte_sliced` that transforms data to byte-sliced representation, performs the operation, and transforms back
- Modified the `extrapolate_line` method to use the optimized implementation for specific binary field types
- Made `HEIGHT_BYTES` constant public in byte-sliced implementations
- Added additional imports to support the new implementation

### How to test?

Added three test cases to verify the optimized implementation:
- `test_extrapolate_line_128b` for `PackedBinaryField1x128b`
- `test_extrapolate_line_256b` for `PackedBinaryField2x128b`
- `test_extrapolate_line_512b` for `PackedBinaryField4x128b`

Run these tests to ensure the optimized implementation produces correct results.

### Why make this change?

The byte-sliced representation allows for more efficient field multiplication that is the hottest part of `extrapolate_line` for big fields

This change improves the sumcheck_v3 benchmark for dense packed field by 20%