### PR TITLE
[m3] Indexed lookup structs made public

### DIFF
--- a/crates/m3/src/gadgets/indexed_lookup/and.rs
+++ b/crates/m3/src/gadgets/indexed_lookup/and.rs
@@ -210,7 +210,7 @@ impl BitAndLooker {
 }
 
 /// Internal struct for indexed lookup logic for AND operations.
-struct BitAndIndexedLookup;
+pub struct BitAndIndexedLookup;
 
 impl IndexedLookup<B128> for BitAndIndexedLookup {
 	/// Returns the log2 size of the table (16 for 8 bits + 8 bits).

--- a/crates/m3/src/gadgets/indexed_lookup/incr.rs
+++ b/crates/m3/src/gadgets/indexed_lookup/incr.rs
@@ -242,7 +242,7 @@ impl TableFiller for IncrLookup {
 }
 
 /// Internal struct for indexed lookup logic for increment operations.
-struct IncrIndexedLookup;
+pub struct IncrIndexedLookup;
 
 impl IndexedLookup<B128> for IncrIndexedLookup {
 	/// Returns the log2 size of the table (9 for 8 bits + 1 carry).


### PR DESCRIPTION
Made `BitAndIndexedLookup` and `IncrIndexedLookup` structs public.
