### PR TITLE
SYS-287: move HAL operations to exec

### DIFF
--- a/crates/compute_test_utils/src/bivariate_sumcheck.rs
+++ b/crates/compute_test_utils/src/bivariate_sumcheck.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use binius_compute::{
-	ComputeLayer, ComputeMemory, FSliceMut,
+	ComputeLayer, ComputeLayerExecutor, ComputeMemory, FSliceMut,
 	alloc::{BumpAllocator, ComputeAllocator, HostBumpAllocator},
 };
 use binius_core::{
@@ -458,7 +458,7 @@ where
 	}
 
 	hal.execute(|exec| {
-		hal.tensor_expand(exec, 0, eq_ind_challenges, &mut eq_ind_partial_evals_buffer)?;
+		exec.tensor_expand(0, eq_ind_challenges, &mut eq_ind_partial_evals_buffer)?;
 		Ok(vec![])
 	})
 	.unwrap();

--- a/crates/core/src/protocols/sumcheck/v3/bivariate_product.rs
+++ b/crates/core/src/protocols/sumcheck/v3/bivariate_product.rs
@@ -3,8 +3,8 @@
 use std::{iter, slice};
 
 use binius_compute::{
-	ComputeLayer, ComputeMemory, FSlice, KernelBuffer, KernelExecutor, KernelMemMap, SizedSlice,
-	SlicesBatch,
+	ComputeLayer, ComputeLayerExecutor, ComputeMemory, FSlice, KernelBuffer, KernelExecutor,
+	KernelMemMap, SizedSlice, SlicesBatch,
 	alloc::{BumpAllocator, ComputeAllocator, HostBumpAllocator},
 };
 use binius_field::{Field, TowerField, util::powers};
@@ -157,43 +157,35 @@ where
 
 		// Fold the multilinears
 		let _ = self.hal.execute(|exec| {
-			self.multilins = self
-				.hal
-				.map(exec, self.multilins.drain(..), |exec, multilin| {
-					let folded_evals = match multilin {
-						SumcheckMultilinear::PreFold(evals) => {
-							debug_assert_eq!(evals.len(), 1 << self.n_vars_remaining);
-							let (evals_0, evals_1) =
-								Hal::DevMem::split_at(evals, 1 << (self.n_vars_remaining - 1));
+			self.multilins = exec.map(self.multilins.drain(..), |exec, multilin| {
+				let folded_evals = match multilin {
+					SumcheckMultilinear::PreFold(evals) => {
+						debug_assert_eq!(evals.len(), 1 << self.n_vars_remaining);
+						let (evals_0, evals_1) =
+							Hal::DevMem::split_at(evals, 1 << (self.n_vars_remaining - 1));
 
-							// Allocate new buffer for the folded evaluations and copy in evals_0.
-							let mut folded_evals =
-								self.dev_alloc.alloc(1 << (self.n_vars_remaining - 1))?;
-							// This is kind of sketchy to do a copy without an execution context.
-							self.hal.copy_d2d(evals_0, &mut folded_evals)?;
+						// Allocate new buffer for the folded evaluations and copy in evals_0.
+						let mut folded_evals =
+							self.dev_alloc.alloc(1 << (self.n_vars_remaining - 1))?;
+						// This is kind of sketchy to do a copy without an execution context.
+						self.hal.copy_d2d(evals_0, &mut folded_evals)?;
 
-							self.hal.extrapolate_line(
-								exec,
-								&mut folded_evals,
-								evals_1,
-								challenge,
-							)?;
-							folded_evals
-						}
-						SumcheckMultilinear::PostFold(evals) => {
-							debug_assert_eq!(evals.len(), 1 << self.n_vars_remaining);
-							let (mut evals_0, evals_1) = Hal::DevMem::split_half_mut(evals);
-							self.hal.extrapolate_line(
-								exec,
-								&mut evals_0,
-								Hal::DevMem::as_const(&evals_1),
-								challenge,
-							)?;
-							evals_0
-						}
-					};
-					Ok(SumcheckMultilinear::<F, Hal::DevMem>::PostFold(folded_evals))
-				})?;
+						exec.extrapolate_line(&mut folded_evals, evals_1, challenge)?;
+						folded_evals
+					}
+					SumcheckMultilinear::PostFold(evals) => {
+						debug_assert_eq!(evals.len(), 1 << self.n_vars_remaining);
+						let (mut evals_0, evals_1) = Hal::DevMem::split_half_mut(evals);
+						exec.extrapolate_line(
+							&mut evals_0,
+							Hal::DevMem::as_const(&evals_1),
+							challenge,
+						)?;
+						evals_0
+					}
+				};
+				Ok(SumcheckMultilinear::<F, Hal::DevMem>::PostFold(folded_evals))
+			})?;
 
 			Ok(Vec::new())
 		})?;
@@ -312,8 +304,7 @@ pub fn calculate_round_evals<'a, F: TowerField, HAL: ComputeLayer<F>>(
 		.collect::<Vec<_>>();
 
 	let evals = hal.execute(|exec| {
-		hal.accumulate_kernels(
-			exec,
+		exec.accumulate_kernels(
 			|local_exec, log_chunks, mut buffers| {
 				let log_chunk_size = split_n_vars - log_chunks;
 


### PR DESCRIPTION
Remove the `Sync` requirement from the HAL. This property was only required by the optimized CPU implementation.