### PR TITLE
[fix] flush oracles with n_vars less P::LOG_WIDTH

### DIFF
--- a/crates/core/src/constraint_system/mod.rs
+++ b/crates/core/src/constraint_system/mod.rs
@@ -8,6 +8,9 @@ mod prove;
 pub mod validate;
 mod verify;
 
+#[cfg(test)]
+mod tests;
+
 use binius_field::{BinaryField128b, TowerField};
 use binius_macros::{DeserializeBytes, SerializeBytes};
 use channel::Flush;

--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -654,6 +654,11 @@ where
 					<PackedType<U, FExt<Tower>>>::from_fn(|j| {
 						let index = i << log_width | j;
 
+						// If n_vars < P::LOG_WIDTH, fill the remaining scalars with zeroes.
+						if index >= 1 << n_vars {
+							return <FExt<Tower>>::ZERO;
+						}
+
 						// Compute the product of all selectors at this point
 						let selector_off = selectors.iter().any(|selector| {
 							let sel_val = selector

--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -554,7 +554,7 @@ where
 }
 
 #[instrument(skip_all, level = "debug")]
-fn make_masked_flush_witnesses<'a, U, Tower>(
+pub fn make_masked_flush_witnesses<'a, U, Tower>(
 	oracles: &MultilinearOracleSet<FExt<Tower>>,
 	witness_index: &mut MultilinearExtensionIndex<'a, PackedType<U, FExt<Tower>>>,
 	flush_oracle_ids: &[OracleId],

--- a/crates/core/src/constraint_system/tests.rs
+++ b/crates/core/src/constraint_system/tests.rs
@@ -1,0 +1,58 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_field::{
+	Field, PackedBinaryField2x128b, PackedBinaryField256x1b, PackedField, TowerField,
+	arch::OptimalUnderlier256b, tower::CanonicalTowerFamily,
+};
+use binius_math::{B1, B128, MLEDirectAdapter, MLEEmbeddingAdapter, MultilinearExtension};
+
+use crate::{
+	constraint_system::{
+		channel::{Flush, FlushDirection, OracleOrConst},
+		prove::make_masked_flush_witnesses,
+	},
+	oracle::MultilinearOracleSet,
+	witness::MultilinearExtensionIndex,
+};
+
+#[test]
+// Test that [make_masked_flush_witnesses] does not fail when n_vars < P::LOG_WIDTH
+fn test_make_masked_flush_witnesses_handles_small_n_vars() {
+	type P = PackedBinaryField2x128b;
+	type F = B128;
+
+	let mut oracles = MultilinearOracleSet::<F>::new();
+	let mut witness = MultilinearExtensionIndex::<P>::new();
+
+	let poly_id = oracles.add_committed(0, F::TOWER_LEVEL);
+	let eval = P::from_scalars(vec![F::ONE]);
+	let mle = MultilinearExtension::new(0, vec![eval]).unwrap();
+	let poly = MLEDirectAdapter::from(mle).upcast_arc_dyn();
+
+	let selector_id = oracles.add_committed(0, B1::TOWER_LEVEL);
+	let eval = PackedBinaryField256x1b::from_scalars(vec![B1::ONE]);
+	let mle = MultilinearExtension::new(0, vec![eval]).unwrap();
+	let selector = MLEEmbeddingAdapter::<_, P>::from(mle).upcast_arc_dyn();
+
+	witness
+		.update_multilin_poly(vec![(selector_id, selector.clone()), (poly_id, poly.clone())])
+		.unwrap();
+
+	let flush = Flush {
+		oracles: vec![OracleOrConst::<F>::Oracle(poly_id)],
+		channel_id: 0,
+		direction: FlushDirection::Push,
+		selectors: vec![selector_id],
+		multiplicity: 1,
+	};
+
+	make_masked_flush_witnesses::<OptimalUnderlier256b, CanonicalTowerFamily>(
+		&oracles,
+		&mut witness,
+		&[poly_id],
+		&[flush],
+		F::ONE,
+		&[F::ONE],
+	)
+	.unwrap();
+}


### PR DESCRIPTION
Added a bounds check in the constraint system proving code to ensure that when the number of variables of flash oracles is less than `P::LOG_WIDTH`, we fill the remaining scalars with zeroes instead of attempting to access out-of-bounds indices