### PR TITLE
[m3] Add read method for lookup tables

### DIFF
--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -657,49 +657,6 @@ impl<'a, F: TowerField> TableBuilder<'a, F> {
 		});
 	}
 
-	/// Writes a group of columns from a specified lookup table.
-	///
-	/// This method enforces that the values of the provided columns are obtained from a lookup
-	/// table through the specified lookup channel. The lookup channel identifies the target
-	/// table for writing values.
-	///
-	/// # Parameters
-	///
-	/// - `lookup_chan`: The channel ID that specifies the lookup table through which the values
-	///   will be constrained.
-	/// - `cols`: An iterable of columns (`Col`) that will be constrained based on the lookup
-	///   values.
-	///
-	/// # Type Parameters
-	///
-	/// - `FSub`: The field type used for the column values.
-	/// - `V`: The number of stacked values (vertical stacking factor) per cell of each column.
-	pub fn write<FSub, const V: usize>(
-		&mut self,
-		lookup_chan: ChannelId,
-		cols: impl IntoIterator<Item = Col<FSub, V>>,
-	) where
-		FSub: TowerField,
-		F: ExtensionField<FSub>,
-	{
-		let partition = self.table.partition_mut(V);
-		let columns = cols
-			.into_iter()
-			.map(|col| {
-				assert_eq!(col.table_id, partition.table_id);
-				col.id()
-			})
-			.collect();
-
-		partition.flushes.push(Flush {
-			columns,
-			channel_id: lookup_chan,
-			direction: FlushDirection::Push,
-			multiplicity: 1,
-			selectors: vec![],
-		});
-	}
-
 	fn namespaced_name(&self, name: impl ToString) -> String {
 		let name = name.to_string();
 		match &self.namespace {

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -914,15 +914,11 @@ pub fn log_capacity(table_size: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-	use binius_core::witness;
 	use binius_field::{arch::OptimalUnderlier, as_packed_field::PackedType};
 	use bumpalo::Bump;
 
-	use super::{B1, B128, Col, Table, TableBuilder};
-	use crate::{
-		builder::{B8, ConstraintSystem, WitnessIndex, test_utils::validate_system_witness},
-		gadgets::lookup,
-	};
+	use super::{B128, Table, TableBuilder};
+	use crate::builder::{B8, ConstraintSystem, WitnessIndex, test_utils::validate_system_witness};
 
 	#[test]
 	fn namespace_nesting() {

--- a/crates/m3/src/builder/table.rs
+++ b/crates/m3/src/builder/table.rs
@@ -877,7 +877,7 @@ mod tests {
 	use super::{B128, Table, TableBuilder};
 	use crate::builder::{
 		B8, ConstraintSystem, FlushOpts, WitnessIndex,
-		test_utils::{validate_system_witness, validate_system_witness_with_prove_verify},
+		test_utils::validate_system_witness_with_prove_verify,
 	};
 
 	#[test]
@@ -921,7 +921,7 @@ mod tests {
 		let boundaries = vec![];
 
 		validate_system_witness_with_prove_verify::<OptimalUnderlier>(
-			&cs, witness, boundaries, true,
+			&cs, witness, boundaries, false,
 		);
 	}
 }

--- a/crates/m3/src/gadgets/indexed_lookup/and.rs
+++ b/crates/m3/src/gadgets/indexed_lookup/and.rs
@@ -31,17 +31,17 @@ pub struct BitAndLookup {
 	lookup_producer: LookupProducer,
 }
 
-pub struct BitAnd {
+pub struct BitAnd<const V: usize = 1> {
 	/// Input column A (8 bits)
-	in_a: Col<B8>,
+	in_a: Col<B8, V>,
 	/// Input column B (8 bits)
-	in_b: Col<B8>,
+	in_b: Col<B8, V>,
 	/// Output column (8 bits), result of in_a & in_b
-	pub output: Col<B8>,
+	pub output: Col<B8, V>,
 	/// Merged column for lookup (32 bits)
-	merged: Col<B32>,
+	merged: Col<B32, V>,
 }
-impl BitAnd {
+impl<const V: usize> BitAnd<V> {
 	/// Constructs a new bitwise-AND gadget, registering the necessary columns in the table.
 	///
 	/// # Arguments
@@ -55,12 +55,12 @@ impl BitAnd {
 	pub fn new(
 		table: &mut TableBuilder,
 		lookup_chan: ChannelId,
-		in_a: Col<B8>,
-		in_b: Col<B8>,
+		in_a: Col<B8, V>,
+		in_b: Col<B8, V>,
 	) -> Self {
-		let output = table.add_committed::<B8, 1>("output");
+		let output = table.add_committed::<B8, V>("output");
 		let merged = merge_and_columns(table, in_a, in_b, output);
-		table.pull(lookup_chan, [merged]);
+		table.read(lookup_chan, [merged]);
 		Self {
 			in_a,
 			in_b,
@@ -77,31 +77,31 @@ impl BitAnd {
 	/// # Returns
 	/// `Ok(())` if successful, or an error otherwise.
 	pub fn populate(&self, witness: &mut TableWitnessSegment) -> anyhow::Result<()> {
-		let in_a_col = witness.get_as(self.in_a)?;
-		let in_b_col = witness.get_as(self.in_b)?;
-		let mut output_col: std::cell::RefMut<'_, [u8]> = witness.get_mut_as(self.output)?;
-		let mut merged_col: std::cell::RefMut<'_, [u32]> = witness.get_mut_as(self.merged)?;
+		let in_a_col = witness.get_scalars(self.in_a)?;
+		let in_b_col = witness.get_scalars(self.in_b)?;
+		let mut output_col: std::cell::RefMut<'_, [B8]> = witness.get_scalars_mut(self.output)?;
+		let mut merged_col: std::cell::RefMut<'_, [B32]> = witness.get_scalars_mut(self.merged)?;
 
 		for i in 0..witness.size() {
-			let in_a = in_a_col[i];
-			let in_b = in_b_col[i];
+			let in_a = in_a_col[i].val();
+			let in_b = in_b_col[i].val();
 			let output = in_a & in_b;
-			output_col[i] = output;
+			output_col[i] = output.into();
 
 			// Merge the values into a single u32
-			merged_col[i] = merge_bitand_vals(in_a, in_b, output);
+			merged_col[i] = merge_bitand_vals(in_a, in_b, output).into();
 		}
 		Ok(())
 	}
 }
 
 /// Merges the input and output columns into a single B32 column for lookup.
-pub fn merge_and_columns(
+pub fn merge_and_columns<const V: usize>(
 	table: &mut TableBuilder,
-	in_a: Col<B8>,
-	in_b: Col<B8>,
-	output: Col<B8>,
-) -> Col<B32> {
+	in_a: Col<B8, V>,
+	in_b: Col<B8, V>,
+	output: Col<B8, V>,
+) -> Col<B32, V> {
 	table.add_computed(
 		"merged",
 		upcast_col(in_a)
@@ -195,12 +195,12 @@ impl BitAndLooker {
 		inputs: impl Iterator<Item = &'a (u8, u8)> + Clone,
 	) -> anyhow::Result<()> {
 		{
-			let mut in_a_col: std::cell::RefMut<'_, [u8]> = witness.get_mut_as(self.in_a)?;
-			let mut in_b_col: std::cell::RefMut<'_, [u8]> = witness.get_mut_as(self.in_b)?;
+			let mut in_a_col: std::cell::RefMut<'_, [B8]> = witness.get_scalars_mut(self.in_a)?;
+			let mut in_b_col: std::cell::RefMut<'_, [B8]> = witness.get_scalars_mut(self.in_b)?;
 
 			for (i, &(in_a, in_b)) in inputs.enumerate() {
-				in_a_col[i] = in_a;
-				in_b_col[i] = in_b;
+				in_a_col[i] = in_a.into();
+				in_b_col[i] = in_b.into();
 			}
 		}
 


### PR DESCRIPTION
# Add read and write methods to TableBuilder

This PR adds two new methods to `TableBuilder`:

1. `read<FSub, const V: usize>` - Reads a group of columns from a specified lookup table, enforcing that values are obtained through the specified lookup channel.

A test case for the `read` method is included to verify functionality with stacked columns.