### PR TITLE
[field] Add Rng import to test modules

### DIFF
--- a/crates/field/src/arch/portable/byte_sliced/mod.rs
+++ b/crates/field/src/arch/portable/byte_sliced/mod.rs
@@ -12,7 +12,7 @@ pub use underlier::ByteSlicedUnderlier;
 #[cfg(test)]
 pub mod tests {
 	use proptest::prelude::*;
-	use rand::{SeedableRng, distributions::Uniform, rngs::StdRng};
+	use rand::{Rng, SeedableRng, distributions::Uniform, rngs::StdRng};
 
 	use super::*;
 	use crate::{

--- a/crates/field/src/packed_binary_field.rs
+++ b/crates/field/src/packed_binary_field.rs
@@ -873,7 +873,7 @@ mod tests {
 
 	use binius_utils::{DeserializeBytes, SerializationMode, SerializeBytes, bytes::BytesMut};
 	use proptest::prelude::*;
-	use rand::{SeedableRng, rngs::StdRng, thread_rng};
+	use rand::{Rng, SeedableRng, rngs::StdRng, thread_rng};
 	use test_utils::{check_interleave_all_heights, implements_transformation_factory};
 
 	use super::{


### PR DESCRIPTION
### TL;DR

Added missing `Rng` import in two test modules. This was breaking CI after updated dependencies.

### What changed?

Added the `Rng` trait to the import statements in two test modules:
- `crates/field/src/arch/portable/byte_sliced/mod.rs`
- `crates/field/src/packed_binary_field.rs`
