### PR TITLE
Execute `FastCpuLayerExecutor::join` in parallel

### DIFF
--- a/crates/compute/src/layer.rs
+++ b/crates/compute/src/layer.rs
@@ -95,17 +95,17 @@ pub trait ComputeLayerExecutor<F: Field> {
 	type DevMem: ComputeMemory<F>;
 
 	/// The operation (scalar) value type.
-	type OpValue;
+	type OpValue: Send;
 
 	/// The executor that can execute operations on a kernel-level granularity (i.e., a single
 	/// core).
 	type KernelExec: KernelExecutor<F, ExprEval = Self::ExprEval>;
 
 	/// Creates an operation that depends on the concurrent execution of two inner operations.
-	fn join<Out1, Out2>(
+	fn join<Out1: Send, Out2: Send>(
 		&mut self,
-		op1: impl FnOnce(&mut Self) -> Result<Out1, Error>,
-		op2: impl FnOnce(&mut Self) -> Result<Out2, Error>,
+		op1: impl Send + FnOnce(&mut Self) -> Result<Out1, Error>,
+		op2: impl Send + FnOnce(&mut Self) -> Result<Out2, Error>,
 	) -> Result<(Out1, Out2), Error> {
 		let out1 = op1(self)?;
 		let out2 = op2(self)?;


### PR DESCRIPTION
# Parallel Execution Support for FastCpuExecutor

### TL;DR

Implement parallel execution for `FastCpuExecutor` by overriding the `join` method and adding necessary trait bounds.

### What changed?

- Added `Send` trait bound to `OpValue` in `ComputeLayerExecutor` trait
- Added `Send` trait bounds to `join` method parameters in `ComputeLayerExecutor` trait
- Implemented `Clone` for `FastCpuExecutor` to support parallel execution
- Overrode the `join` method in `FastCpuExecutor` to use `binius_maybe_rayon::join` for parallel execution

### Why make this change?

This change enables parallel execution of operations in `FastCpuExecutor`, which can significantly improve performance for compute-intensive tasks. By leveraging the `binius_maybe_rayon` crate's parallel execution capabilities, operations that were previously executed sequentially can now run concurrently, making better use of available CPU cores.