### PR TITLE
[m3] Fix tally for packed flushes.

### DIFF
--- a/crates/m3/src/builder/indexed_lookup.rs
+++ b/crates/m3/src/builder/indexed_lookup.rs
@@ -89,7 +89,7 @@ where
 						}
 
 						let mut elems = vec![B128::ZERO; cols.len()];
-						// It's important that this is only the table size, not the full segment
+						// It's important that this is only the unpacked table size(rows * values per row in the partition), not the full segment
 						// size. The entries after the table size are not flushed.
 						for i in 0..table_size * partition.values_per_row {
 							for (elem, col) in iter::zip(&mut elems, &cols) {

--- a/crates/m3/src/builder/indexed_lookup.rs
+++ b/crates/m3/src/builder/indexed_lookup.rs
@@ -91,7 +91,7 @@ where
 						let mut elems = vec![B128::ZERO; cols.len()];
 						// It's important that this is only the table size, not the full segment
 						// size. The entries after the table size are not flushed.
-						for i in 0..table_size {
+						for i in 0..table_size * partition.values_per_row {
 							for (elem, col) in iter::zip(&mut elems, &cols) {
 								*elem = col.get(i);
 							}

--- a/crates/m3/src/builder/indexed_lookup.rs
+++ b/crates/m3/src/builder/indexed_lookup.rs
@@ -89,8 +89,9 @@ where
 						}
 
 						let mut elems = vec![B128::ZERO; cols.len()];
-						// It's important that this is only the unpacked table size(rows * values per row in the partition), not the full segment
-						// size. The entries after the table size are not flushed.
+						// It's important that this is only the unpacked table size(rows * values
+						// per row in the partition), not the full segment size. The entries
+						// after the table size are not flushed.
 						for i in 0..table_size * partition.values_per_row {
 							for (elem, col) in iter::zip(&mut elems, &cols) {
 								*elem = col.get(i);


### PR DESCRIPTION
The tally function needed to account for table sizes as well as the values per row in the partitions to work properly, previous tests did not catch this bug.