### PR TITLE
[core] verify table sizes and cs digest

### DIFF
--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -96,7 +96,6 @@ where
 		+ binius_math::PackedTop,
 	PackedType<U, Tower::FastB128>: PackedTransformationFactory<PackedType<U, Tower::B128>>,
 {
-	let _ = constraint_system_digest;
 	tracing::debug!(
 		arch = env::consts::ARCH,
 		rayon_threads = binius_maybe_rayon::current_num_threads(),
@@ -105,9 +104,6 @@ where
 
 	let domain_factory = DefaultEvaluationDomainFactory::<FDomain<Tower>>::default();
 	let fast_domain_factory = IsomorphicEvaluationDomainFactory::<FFastExt<Tower>>::default();
-
-	let mut transcript = ProverTranscript::<Challenger_>::new();
-	transcript.observe().write_slice(boundaries);
 
 	let ConstraintSystem {
 		mut oracles,
@@ -148,6 +144,14 @@ where
 			TableSizeSpec::Arbitrary => (),
 		}
 	}
+
+	let mut transcript = ProverTranscript::<Challenger_>::new();
+	transcript
+		.observe()
+		.write_slice(constraint_system_digest.as_ref());
+	transcript.observe().write_slice(boundaries);
+	let mut writer = transcript.message();
+	writer.write_slice(table_sizes);
 
 	reorder_exponents(&mut exponents, &oracles);
 


### PR DESCRIPTION
Changes transcript so that:

1. the digest of the constraint system is observed in the transcript.
2. the table sized are passed as a message to the verifier.

Then we perform the same checking if the table sizes follow the spec imposed
by the constraint system, as we done in #704.