### PR TITLE
Fix PackedMemorySliceMut splitting logic

### DIFF
--- a/crates/fast_compute/src/memory.rs
+++ b/crates/fast_compute/src/memory.rs
@@ -2,7 +2,9 @@
 
 use std::{
 	marker::PhantomData,
+	mem::ManuallyDrop,
 	ops::{Bound, RangeBounds},
+	sync::{Arc, Mutex},
 };
 
 use binius_compute::memory::{ComputeMemory, SizedSlice};
@@ -21,15 +23,15 @@ impl<P: PackedField> ComputeMemory<P::Scalar> for PackedMemory<P> {
 	fn as_const<'a>(data: &'a Self::FSliceMut<'_>) -> Self::FSlice<'a> {
 		match data {
 			PackedMemorySliceMut::Slice(slice) => PackedMemorySlice::Slice(slice),
-			PackedMemorySliceMut::Owned(chunk) => PackedMemorySlice::Owned(*chunk),
+			PackedMemorySliceMut::SingleElement { owned, .. } => PackedMemorySlice::Owned(*owned),
 		}
 	}
 
 	fn to_const(data: Self::FSliceMut<'_>) -> Self::FSlice<'_> {
-		match data {
-			PackedMemorySliceMut::Slice(slice) => PackedMemorySlice::Slice(slice),
-			PackedMemorySliceMut::Owned(chunk) => PackedMemorySlice::Owned(chunk),
-		}
+		data.apply_changes_and_deconstruct(
+			|slice| PackedMemorySlice::Slice(slice),
+			|owned, _| PackedMemorySlice::Owned(owned),
+		)
 	}
 
 	fn slice(data: Self::FSlice<'_>, range: impl std::ops::RangeBounds<usize>) -> Self::FSlice<'_> {
@@ -65,11 +67,16 @@ impl<P: PackedField> ComputeMemory<P::Scalar> for PackedMemory<P> {
 	) -> (Self::FSliceMut<'_>, Self::FSliceMut<'_>) {
 		assert_eq!(mid % P::WIDTH, 0, "mid must be a multiple of {}", P::WIDTH);
 		let mid = mid >> P::LOG_WIDTH;
-		let PackedMemorySliceMut::Slice(slice) = data else {
-			panic!("splitting slices of length less than `Self::ALIGNMENT` is not supported");
-		};
-		let (left, right) = slice.split_at_mut(mid);
-		(PackedMemorySliceMut::Slice(left), PackedMemorySliceMut::Slice(right))
+
+		data.apply_changes_and_deconstruct(
+			|slice| {
+				let (left, right) = slice.split_at_mut(mid);
+				(PackedMemorySliceMut::Slice(left), PackedMemorySliceMut::Slice(right))
+			},
+			|_, _| {
+				panic!("splitting slices of length less than `Self::ALIGNMENT` is not supported");
+			},
+		)
 	}
 
 	fn narrow<'a>(data: &'a Self::FSlice<'_>) -> Self::FSlice<'a> {
@@ -86,7 +93,12 @@ impl<P: PackedField> ComputeMemory<P::Scalar> for PackedMemory<P> {
 	fn to_owned_mut<'a>(data: &'a mut Self::FSliceMut<'_>) -> Self::FSliceMut<'a> {
 		match data {
 			PackedMemorySliceMut::Slice(slice) => PackedMemorySliceMut::Slice(slice),
-			PackedMemorySliceMut::Owned(chunk) => PackedMemorySliceMut::Owned(*chunk),
+			PackedMemorySliceMut::SingleElement { owned, original } => {
+				PackedMemorySliceMut::SingleElement {
+					owned: *owned,
+					original: OriginalRef::new(&mut owned.data, original.offset),
+				}
+			}
 		}
 	}
 
@@ -99,13 +111,16 @@ impl<P: PackedField> ComputeMemory<P::Scalar> for PackedMemory<P> {
 
 		let chunk_len = chunk_len >> P::LOG_WIDTH;
 
-		let PackedMemorySliceMut::Slice(slice) = data else {
-			panic!("splitting slices of length less than `Self::ALIGNMENT` is not supported");
-		};
-
-		slice
-			.chunks_mut(chunk_len)
-			.map(|chunk| Self::FSliceMut::new_slice(chunk))
+		data.apply_changes_and_deconstruct(
+			|slice| {
+				slice
+					.chunks_mut(chunk_len)
+					.map(|chunk| Self::FSliceMut::new_slice(chunk))
+			},
+			|_, _| {
+				panic!("splitting slices of length less than `Self::ALIGNMENT` is not supported");
+			},
+		)
 	}
 
 	fn split_half<'a>(data: Self::FSlice<'a>) -> (Self::FSlice<'a>, Self::FSlice<'a>) {
@@ -145,28 +160,61 @@ impl<P: PackedField> ComputeMemory<P::Scalar> for PackedMemory<P> {
 			"data.len() must be a power of two greater than 1"
 		);
 
-		match data {
-			PackedMemorySliceMut::Slice(slice) => match slice.len() {
+		data.apply_changes_and_deconstruct(
+			|slice| match slice.len() {
 				len if len > 1 => {
 					let mid = slice.len() / 2;
+					let slice = unsafe {
+						// SAFETY:
+						// - `slice` is guaranteed to be valid for the lifetime of `data`.
+						// - `slice` is not accessed after this line.
+						std::slice::from_raw_parts_mut(slice.as_mut_ptr(), slice.len())
+					};
+
 					let (left, right) = slice.split_at_mut(mid);
 					(PackedMemorySliceMut::Slice(left), PackedMemorySliceMut::Slice(right))
 				}
-				1 => (
-					PackedMemorySliceMut::new_owned(slice, 0, P::WIDTH / 2),
-					PackedMemorySliceMut::new_owned(slice, P::WIDTH / 2, P::WIDTH / 2),
-				),
+				1 => {
+					let value_ptr = Arc::new(Mutex::new(&raw mut slice[0] as _));
+
+					let left = PackedMemorySliceMut::SingleElement {
+						owned: SmallOwnedChunk::new_from_slice(slice, 0, P::WIDTH / 2),
+						original: OriginalRef::new_with_ptr(value_ptr.clone(), 0),
+					};
+
+					let right = PackedMemorySliceMut::SingleElement {
+						owned: SmallOwnedChunk::new_from_slice(slice, P::WIDTH / 2, P::WIDTH / 2),
+						original: OriginalRef::new_with_ptr(value_ptr, P::WIDTH / 2),
+					};
+
+					(left, right)
+				}
 				_ => {
 					unreachable!()
 				}
 			},
-			PackedMemorySliceMut::Owned(chunk) => {
-				let mid = chunk.len / 2;
-				let left = chunk.subrange(0, mid);
-				let right = chunk.subrange(mid, chunk.len);
-				(PackedMemorySliceMut::Owned(left), PackedMemorySliceMut::Owned(right))
-			}
-		}
+			|owned, original| {
+				let mid = owned.len / 2;
+				let left_chunk = owned.subrange(0, mid);
+				let right_chunk = owned.subrange(mid, owned.len);
+
+				let (original_left, original_right) = (
+					OriginalRef::new_with_ptr(original.data.clone(), original.offset),
+					OriginalRef::new_with_ptr(original.data.clone(), original.offset + mid),
+				);
+
+				(
+					PackedMemorySliceMut::SingleElement {
+						owned: left_chunk,
+						original: original_left,
+					},
+					PackedMemorySliceMut::SingleElement {
+						owned: right_chunk,
+						original: original_right,
+					},
+				)
+			},
+		)
 	}
 }
 
@@ -291,10 +339,46 @@ impl<'a, P: PackedField> SizedSlice for PackedMemorySlice<'a, P> {
 	}
 }
 
+/// A reference to the original data that is used to update the original packed field.
+#[derive(Clone, Debug)]
+pub struct OriginalRef<'a, P: PackedField> {
+	// Since we want `PackedMemorySliceMut` to be `Send` and `Sync`, we need to use an
+	// `Arc<Mutex<_>>` to ensure that the original data is not accessed concurrently.
+	// We can't use Arc<Mutex<&'a mut P>> because `Mutex` is invariant over its type parameter,
+	// so implementing [`PackedMemory::narrow_mut`] would not be possible.
+	data: Arc<Mutex<*mut P>>,
+	offset: usize,
+	_pd: PhantomData<&'a mut P>,
+}
+
+impl<'a, P: PackedField> OriginalRef<'a, P> {
+	#[inline]
+	pub fn new(data: &'a mut P, offset: usize) -> Self {
+		Self::new_with_ptr(Arc::new(Mutex::new(data as *mut P)), offset)
+	}
+
+	#[inline]
+	pub fn new_with_ptr(data: Arc<Mutex<*mut P>>, offset: usize) -> Self {
+		Self {
+			data,
+			offset,
+			_pd: PhantomData,
+		}
+	}
+}
+
+// Safety: We are accessing the original data by pointer through a mutex, which ensures that
+// the data is not modified concurrently.
+unsafe impl<P> Send for OriginalRef<'_, P> where P: PackedField {}
+unsafe impl<P> Sync for OriginalRef<'_, P> where P: PackedField {}
+
 #[derive(Debug)]
 pub enum PackedMemorySliceMut<'a, P: PackedField> {
 	Slice(&'a mut [P]),
-	Owned(SmallOwnedChunk<P>),
+	SingleElement {
+		owned: SmallOwnedChunk<P>,
+		original: OriginalRef<'a, P>,
+	},
 }
 
 impl<'a, P: PackedField> PackedMemorySliceMut<'a, P> {
@@ -304,16 +388,10 @@ impl<'a, P: PackedField> PackedMemorySliceMut<'a, P> {
 	}
 
 	#[inline(always)]
-	pub fn new_owned(data: &mut [P], offset: usize, len: usize) -> Self {
-		let chunk = SmallOwnedChunk::new_from_slice(data, offset, len);
-		Self::Owned(chunk)
-	}
-
-	#[inline(always)]
 	pub fn as_const(&self) -> PackedMemorySlice<'_, P> {
 		match self {
 			Self::Slice(data) => PackedMemorySlice::Slice(data),
-			Self::Owned(chunk) => PackedMemorySlice::Owned(*chunk),
+			Self::SingleElement { owned, .. } => PackedMemorySlice::Owned(*owned),
 		}
 	}
 
@@ -321,7 +399,7 @@ impl<'a, P: PackedField> PackedMemorySliceMut<'a, P> {
 	pub fn as_slice(&'a self) -> &'a [P] {
 		match self {
 			Self::Slice(data) => data,
-			Self::Owned(chunk) => std::slice::from_ref(&chunk.data),
+			Self::SingleElement { owned, .. } => std::slice::from_ref(&owned.data),
 		}
 	}
 
@@ -329,7 +407,58 @@ impl<'a, P: PackedField> PackedMemorySliceMut<'a, P> {
 	pub fn as_slice_mut(&mut self) -> &mut [P] {
 		match self {
 			Self::Slice(data) => data,
-			Self::Owned(chunk) => std::slice::from_mut(&mut chunk.data),
+			Self::SingleElement { owned, .. } => std::slice::from_mut(&mut owned.data),
+		}
+	}
+
+	/// Copy the values to the original packed field.
+	#[inline]
+	fn apply_changes_to_original(&mut self) {
+		if let Self::SingleElement { owned, original } = self {
+			let packed_value_lock = original.data.lock().expect("mutex poisoned");
+
+			// Safety: the pointer is guaranteed to be valid because in `new` we are capturing a
+			// mutable reference to `P` with a lifetime `'a` that outlives self.
+			let mut packed_value = unsafe { packed_value_lock.read() };
+			for i in 0..owned.len {
+				packed_value.set(i + original.offset, owned.data.get(i));
+			}
+
+			unsafe { packed_value_lock.write(packed_value) };
+		}
+	}
+
+	/// Applies the changes to the original packed field and deconstructs the memory slice.
+	/// Since `PackedMemorySliceMut` we can't just consume the value in a match statement which is a
+	/// common case in our code.
+	fn apply_changes_and_deconstruct<R>(
+		self,
+		on_slice: impl FnOnce(&'a mut [P]) -> R,
+		on_single: impl FnOnce(SmallOwnedChunk<P>, OriginalRef<'a, P>) -> R,
+	) -> R {
+		let mut value = ManuallyDrop::new(self);
+		value.apply_changes_to_original();
+		match &mut *value {
+			Self::Slice(slice) => {
+				// SAFETY:
+				// - `slice` is guaranteed to be valid for the lifetime of `value`.
+				// - `slice` is not accessed after this line.
+				let slice =
+					unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr(), slice.len()) };
+
+				on_slice(slice)
+			}
+			Self::SingleElement { owned, original } => on_single(*owned, original.clone()),
+		}
+	}
+
+	#[cfg(test)]
+	fn iter_scalars(&self) -> impl Iterator<Item = P::Scalar> {
+		use itertools::Either;
+
+		match self {
+			Self::Slice(data) => Either::Left(data.iter().flat_map(|p| p.iter())),
+			Self::SingleElement { owned, .. } => Either::Right(owned.iter_scalars()),
 		}
 	}
 }
@@ -339,7 +468,7 @@ impl<'a, P: PackedField> SizedSlice for PackedMemorySliceMut<'a, P> {
 	fn is_empty(&self) -> bool {
 		match self {
 			Self::Slice(data) => data.is_empty(),
-			Self::Owned(chunk) => chunk.len == 0,
+			Self::SingleElement { owned, .. } => owned.len == 0,
 		}
 	}
 
@@ -347,14 +476,21 @@ impl<'a, P: PackedField> SizedSlice for PackedMemorySliceMut<'a, P> {
 	fn len(&self) -> usize {
 		match self {
 			Self::Slice(data) => data.len() << P::LOG_WIDTH,
-			Self::Owned(chunk) => chunk.len,
+			Self::SingleElement { owned, .. } => owned.len,
 		}
+	}
+}
+
+impl<'a, P: PackedField> Drop for PackedMemorySliceMut<'a, P> {
+	fn drop(&mut self) {
+		self.apply_changes_to_original();
 	}
 }
 
 #[cfg(test)]
 mod tests {
-	use binius_field::PackedBinaryField4x32b;
+
+	use binius_field::{Field, PackedBinaryField4x32b};
 	use itertools::Itertools;
 	use rand::{SeedableRng, rngs::StdRng};
 
@@ -411,16 +547,21 @@ mod tests {
 	fn test_convert_mut_mem_slice_to_const() {
 		let mut data = make_random_vec(3);
 		let data_clone = data.clone();
-		let memory = PackedMemorySliceMut::new_slice(&mut data);
 
-		assert_eq!(PackedMemory::as_const(&memory).as_slice(), &data_clone[..]);
+		{
+			let memory = PackedMemorySliceMut::new_slice(&mut data);
+			assert_eq!(PackedMemory::as_const(&memory).as_slice(), &data_clone[..]);
+		}
 
-		let owned_memory = PackedMemorySliceMut::new_owned(&mut data, 0, Packed::WIDTH - 1);
+		let owned_memory = PackedMemorySliceMut::SingleElement {
+			owned: SmallOwnedChunk::new_from_slice(&data, 0, Packed::WIDTH - 1),
+			original: OriginalRef::new(&mut data[0], 0),
+		};
 		assert_eq!(
 			PackedMemory::as_const(&owned_memory)
 				.iter_scalars()
 				.collect_vec(),
-			PackedMemorySlice::new_owned(&data, 0, Packed::WIDTH - 1)
+			PackedMemorySlice::new_owned(&data_clone, 0, Packed::WIDTH - 1)
 				.iter_scalars()
 				.collect_vec()
 		);
@@ -489,7 +630,10 @@ mod tests {
 	#[should_panic]
 	fn test_slice_mut_on_mem_slice_panic_5() {
 		let mut data = make_random_vec(3);
-		let mut memory = PackedMemorySliceMut::new_owned(&mut data, 0, Packed::WIDTH - 1);
+		let mut memory = PackedMemorySliceMut::SingleElement {
+			owned: SmallOwnedChunk::new_from_slice(&data, 0, Packed::WIDTH - 1),
+			original: OriginalRef::new(&mut data[0], 0),
+		};
 
 		PackedMemory::slice_mut(&mut memory, 1..);
 	}
@@ -520,7 +664,10 @@ mod tests {
 	#[should_panic]
 	fn test_split_at_mut_panic_2() {
 		let mut data = make_random_vec(3);
-		let memory = PackedMemorySliceMut::new_owned(&mut data, 0, Packed::WIDTH - 1);
+		let memory = PackedMemorySliceMut::SingleElement {
+			owned: SmallOwnedChunk::new_from_slice(&data, 0, Packed::WIDTH - 1),
+			original: OriginalRef::new(&mut data[0], 0),
+		};
 
 		// `&mut T` can't cross the catch unwind boundary, so we have to use several tests
 		// to test the panic cases.
@@ -566,5 +713,98 @@ mod tests {
 				.iter_scalars()
 				.collect_vec()
 		);
+	}
+
+	#[test]
+	fn test_split_half_mut() {
+		let mut data = make_random_vec(2);
+		let data_clone = data.clone();
+		let memory = PackedMemorySliceMut::new_slice(&mut data);
+
+		{
+			let (left, right) = PackedMemory::split_half_mut(memory);
+			assert_eq!(left.as_slice(), &data_clone[0..1]);
+			assert_eq!(right.as_slice(), &data_clone[1..]);
+		}
+
+		let mut rng = StdRng::seed_from_u64(0);
+		let new_left = Field::random(&mut rng);
+		let new_right = Field::random(&mut rng);
+		{
+			let memory = PackedMemorySliceMut::new_slice(&mut data[0..1]);
+			let (mut left, mut right) = PackedMemory::split_half_mut(memory);
+
+			assert_eq!(
+				left.iter_scalars().collect_vec(),
+				PackedMemorySlice::new_owned(&data_clone, 0, Packed::WIDTH / 2)
+					.iter_scalars()
+					.collect_vec()
+			);
+			assert_eq!(
+				right.iter_scalars().collect_vec(),
+				PackedMemorySlice::new_owned(&data_clone, Packed::WIDTH / 2, Packed::WIDTH / 2)
+					.iter_scalars()
+					.collect_vec()
+			);
+
+			left.as_slice_mut()[0].set(0, new_left);
+			right.as_slice_mut()[0].set(0, new_right);
+		}
+		// Check that the changes are applied to the original data
+		assert_eq!(data[0].get(0), new_left);
+		assert_eq!(data[0].get(Packed::WIDTH / 2), new_right);
+
+		let memory = PackedMemorySliceMut::SingleElement {
+			owned: SmallOwnedChunk::new_from_slice(&data, 0, Packed::WIDTH / 2),
+			original: OriginalRef::new(&mut data[0], 0),
+		};
+		let new_left = Field::random(&mut rng);
+		let new_right = Field::random(&mut rng);
+		{
+			let (mut left, mut right) = PackedMemory::split_half_mut(memory);
+			assert_eq!(
+				left.iter_scalars().collect_vec(),
+				PackedMemorySlice::new_owned(&data_clone, 0, Packed::WIDTH / 4)
+					.iter_scalars()
+					.collect_vec()
+			);
+			assert_eq!(
+				right.iter_scalars().collect_vec(),
+				PackedMemorySlice::new_owned(&data_clone, Packed::WIDTH / 4, Packed::WIDTH / 4)
+					.iter_scalars()
+					.collect_vec()
+			);
+
+			left.as_slice_mut()[0].set(0, new_left);
+			right.as_slice_mut()[0].set(0, new_right);
+		}
+		// Check that the changes are applied to the original data
+		assert_eq!(data[0].get(0), new_left);
+		assert_eq!(data[0].get(Packed::WIDTH / 4), new_right);
+	}
+
+	#[test]
+	fn test_into_owned_mut() {
+		let mut data = make_random_vec(3);
+		let data_clone = data.clone();
+
+		{
+			let mut memory = PackedMemorySliceMut::new_slice(&mut data);
+
+			let owned_memory = PackedMemory::to_owned_mut(&mut memory);
+			assert_eq!(owned_memory.as_slice(), &data_clone[..]);
+		}
+
+		let new_value = Field::ONE;
+		let mut memory = PackedMemorySliceMut::SingleElement {
+			owned: SmallOwnedChunk::new_from_slice(&data, 1, Packed::WIDTH - 1),
+			original: OriginalRef::new(&mut data[0], 1),
+		};
+		{
+			let mut owned_memory = PackedMemory::to_owned_mut(&mut memory);
+			owned_memory.as_slice_mut()[0].set(0, new_value);
+		}
+		// Check that the changes are applied to the original data
+		assert_eq!(memory.as_slice()[0].get(1), new_value);
 	}
 }


### PR DESCRIPTION
### TL;DR

Improved memory management in `PackedMemorySliceMut` to properly handle changes to the local stored elements (the case of a small slice) ensure they are written back to the original data.

This change complicates `PackedMemorySliceMut` a lot, but I didn't find any solution that is simpler and sound.

### What changed?

- Replaced `PackedMemorySliceMut::Owned` variant with `PackedMemorySliceMut::SingleElement` that tracks both the owned chunk and a reference to the original data
- Added `OriginalRef` struct to safely track and update the original data
- Implemented `Drop` for `PackedMemorySliceMut` to ensure changes are applied when the slice is dropped
- Added `apply_changes_to_original()` and `apply_changes_and_deconstruct()` methods to handle writing changes back to the original data
- Updated all methods that manipulate `PackedMemorySliceMut` to properly handle the new structure
- Added comprehensive tests to verify that changes to single elements are correctly propagated back to the original data

### How to test?

Run the new tests that verify the correct behavior:
- `test_split_half_mut` - Tests that changes to split halves are applied to the original data
- `test_into_owned_mut` - Tests that changes to owned memory slices are applied to the original data

All existing tests should continue to pass.

### Why make this change?

The previous implementation didn't properly track changes to single elements in `PackedMemorySliceMut::Owned`, which could lead to lost updates. This change ensures that any modifications to memory slices are correctly propagated back to the original data, maintaining data consistency and preventing subtle bugs.