### PR TITLE
[core] simplify constraint set builder

### DIFF
--- a/crates/core/src/oracle/constraint.rs
+++ b/crates/core/src/oracle/constraint.rs
@@ -7,9 +7,8 @@ use binius_field::{Field, TowerField};
 use binius_macros::{DeserializeBytes, SerializeBytes};
 use binius_math::{ArithCircuit, CompositionPoly};
 use binius_utils::bail;
-use itertools::Itertools;
 
-use super::{Error, MultilinearOracleSet, MultilinearPolyVariant, OracleId};
+use super::{Error, MultilinearOracleSet, OracleId};
 
 /// Composition trait object that can be used to create lists of compositions of differing
 /// concrete types.
@@ -105,20 +104,6 @@ impl<F: Field> ConstraintSetBuilder<F> {
 		});
 	}
 
-	pub fn add_zerocheck(
-		&mut self,
-		name: impl ToString,
-		oracle_ids: impl IntoIterator<Item = OracleId>,
-		composition: ArithCircuit<F>,
-	) {
-		self.constraints.push(UngroupedConstraint {
-			name: name.to_string(),
-			oracle_ids: oracle_ids.into_iter().collect(),
-			composition,
-			predicate: ConstraintPredicate::Zero,
-		});
-	}
-
 	/// Build a single constraint set, requiring that all included oracle n_vars are the same
 	pub fn build_one(
 		self,
@@ -177,109 +162,6 @@ impl<F: Field> ConstraintSetBuilder<F> {
 			oracle_ids,
 			constraints,
 		})
-	}
-
-	/// Create one ConstraintSet for every unique n_vars used.
-	///
-	/// Note that you can't mix oracles with different n_vars in a single constraint.
-	pub fn build(
-		self,
-		oracles: &MultilinearOracleSet<impl TowerField>,
-	) -> Result<Vec<ConstraintSet<F>>, Error> {
-		let connected_oracle_chunks = self
-			.constraints
-			.iter()
-			.map(|constraint| constraint.oracle_ids.clone())
-			.chain(oracles.polys().filter_map(|oracle| match &oracle.variant {
-				MultilinearPolyVariant::Shifted(shifted) => Some(vec![oracle.id(), shifted.id()]),
-				MultilinearPolyVariant::LinearCombination(linear_combination) => {
-					Some(linear_combination.polys().chain([oracle.id()]).collect())
-				}
-				_ => None,
-			}))
-			.collect::<Vec<_>>();
-
-		let connected_oracle_chunks = connected_oracle_chunks
-			.iter()
-			.map(|x| x.iter().map(|y| y.index()).collect::<Vec<usize>>())
-			.collect::<Vec<Vec<usize>>>();
-
-		let groups = binius_utils::graph::connected_components(&connected_oracle_chunks);
-
-		let n_vars_and_constraints = self
-			.constraints
-			.into_iter()
-			.map(|constraint| {
-				if constraint.oracle_ids.is_empty() {
-					bail!(Error::EmptyConstraintSet);
-				}
-				for id in &constraint.oracle_ids {
-					if !oracles.is_valid_oracle_id(*id) {
-						bail!(Error::InvalidOracleId(*id));
-					}
-				}
-				let n_vars = constraint
-					.oracle_ids
-					.first()
-					.map(|id| oracles.n_vars(*id))
-					.unwrap();
-
-				for id in &constraint.oracle_ids {
-					if oracles.n_vars(*id) != n_vars {
-						bail!(Error::ConstraintSetNvarsMismatch {
-							expected: n_vars,
-							got: oracles.n_vars(*id)
-						});
-					}
-				}
-				Ok::<_, Error>((n_vars, constraint))
-			})
-			.collect::<Result<Vec<_>, _>>()?;
-
-		let grouped_constraints = n_vars_and_constraints
-			.into_iter()
-			.sorted_by_key(|(_, constraint)| groups[constraint.oracle_ids[0].index()])
-			.chunk_by(|(_, constraint)| groups[constraint.oracle_ids[0].index()]);
-
-		let constraint_sets = grouped_constraints
-			.into_iter()
-			.map(|(_, grouped_constraints)| {
-				let mut constraints = vec![];
-				let mut oracle_ids = vec![];
-
-				let grouped_constraints = grouped_constraints.into_iter().collect::<Vec<_>>();
-				let (n_vars, _) = grouped_constraints[0];
-
-				for (_, constraint) in grouped_constraints {
-					oracle_ids.extend(&constraint.oracle_ids);
-					constraints.push(constraint);
-				}
-				oracle_ids.sort();
-				oracle_ids.dedup();
-
-				let constraints = constraints
-					.into_iter()
-					.map(|constraint| Constraint {
-						name: constraint.name,
-						composition: constraint
-							.composition
-							.remap_vars(&positions(&constraint.oracle_ids, &oracle_ids).expect(
-								"precondition: oracle_ids is a superset of constraint.oracle_ids",
-							))
-							.expect("Infallible by ConstraintSetBuilder invariants."),
-						predicate: constraint.predicate,
-					})
-					.collect();
-
-				ConstraintSet {
-					constraints,
-					oracle_ids,
-					n_vars,
-				}
-			})
-			.collect();
-
-		Ok(constraint_sets)
 	}
 }
 


### PR DESCRIPTION
This functionality is rudimentary and was needed for when the constraint sets
were built in binius_circuits. Now, we don't need that but it really is
annoying to maintain this. So — remove.