### PR TITLE
[core] plumb table id thru constraint set

### DIFF
--- a/crates/core/src/oracle/constraint.rs
+++ b/crates/core/src/oracle/constraint.rs
@@ -9,6 +9,7 @@ use binius_math::{ArithCircuit, CompositionPoly};
 use binius_utils::bail;
 
 use super::{Error, MultilinearOracleSet, OracleId};
+use crate::constraint_system::TableId;
 
 /// Composition trait object that can be used to create lists of compositions of differing
 /// concrete types.
@@ -57,9 +58,11 @@ impl<F: Field> SizedConstraintSet<F> {
 }
 
 /// Constraint set is a group of constraints that operate over the same set of oracle-identified
-/// multilinears
+/// multilinears. The multilinears are expected to be of the same size.
 #[derive(Debug, Clone, SerializeBytes, DeserializeBytes)]
 pub struct ConstraintSet<F: Field> {
+	pub table_id: TableId,
+	pub log_values_per_row: usize,
 	pub n_vars: usize,
 	pub oracle_ids: Vec<OracleId>,
 	pub constraints: Vec<Constraint<F>>,

--- a/crates/m3/src/builder/constraint_system.rs
+++ b/crates/m3/src/builder/constraint_system.rs
@@ -345,8 +345,13 @@ impl<F: TowerField> ConstraintSystem<F> {
 				}
 
 				if !zero_constraints.is_empty() {
-					let constraint_set =
-						translate_constraint_set(n_vars, zero_constraints, partition_oracle_ids);
+					let constraint_set = translate_constraint_set(
+						table.id(),
+						log2_strict_usize(*values_per_row),
+						n_vars,
+						zero_constraints,
+						partition_oracle_ids,
+					);
 					table_constraints.push(constraint_set);
 				}
 			}
@@ -674,6 +679,8 @@ fn add_oracle_for_column<F: TowerField>(
 /// The resulting constraint set will only contain oracles that were actually referenced from any
 /// of the constraint expressions.
 fn translate_constraint_set<F: TowerField>(
+	table_id: TableId,
+	log_values_per_row: usize,
 	n_vars: usize,
 	zero_constraints: &[ZeroConstraint<F>],
 	partition_oracle_ids: Vec<OracleId>,
@@ -728,6 +735,8 @@ fn translate_constraint_set<F: TowerField>(
 		.collect::<Vec<_>>();
 
 	ConstraintSet {
+		table_id,
+		log_values_per_row,
 		n_vars,
 		oracle_ids: dense_oracle_ids,
 		constraints: compiled_constraints,


### PR DESCRIPTION
This would be needed to prune constraint sets that are not effectful and would
otherwise access oracles that are not added due to belonging to zero sized
tables.

Also clean up the calculation of the size for the SizedConstraintSet.