### PR TITLE
[core] push down po2 flush selectors

### DIFF
--- a/crates/core/src/constraint_system/channel.rs
+++ b/crates/core/src/constraint_system/channel.rs
@@ -69,6 +69,7 @@ pub enum OracleOrConst<F: Field> {
 #[derive(Debug, Clone, SerializeBytes, DeserializeBytes)]
 pub struct Flush<F: TowerField> {
 	pub table_id: TableId,
+	pub log_values_per_row: usize,
 	pub oracles: Vec<OracleOrConst<F>>,
 	pub channel_id: ChannelId,
 	pub direction: FlushDirection,
@@ -94,6 +95,7 @@ pub fn validate_witness<F, P>(
 	witness: &MultilinearExtensionIndex<P>,
 	flushes: &[Flush<F>],
 	boundaries: &[Boundary<F>],
+	table_sizes: &[usize],
 	channel_count: usize,
 ) -> Result<(), Error>
 where
@@ -127,8 +129,8 @@ where
 			ref selectors,
 			multiplicity,
 			table_id,
+			log_values_per_row,
 		} = flush;
-		let _ = table_id;
 
 		if channel_id > max_channel_id {
 			return Err(Error::ChannelIdOutOfRange {
@@ -137,7 +139,7 @@ where
 			});
 		}
 
-		let channel = &mut channels[channel_id];
+		let table_size = table_sizes[table_id];
 
 		// We check the variables only of OracleOrConst::Oracle variant oracles being the same.
 		let non_const_polys = oracles
@@ -184,7 +186,9 @@ where
 			}
 		}
 
-		for i in 0..1 << n_vars {
+		let values_per_row = 1 << log_values_per_row;
+		assert!(table_size * values_per_row <= 1 << n_vars);
+		for i in 0..table_size * values_per_row {
 			let selector_off = selector_polys.iter().any(|selector_poly| {
 				selector_poly
 					.evaluate_on_hypercube(i)
@@ -210,7 +214,7 @@ where
 						.evaluate_on_hypercube(i),
 				})
 				.collect::<Result<Vec<_>, _>>()?;
-			channel.flush(direction, multiplicity, values)?;
+			channels[channel_id].flush(direction, multiplicity, values)?;
 		}
 	}
 

--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -38,6 +38,7 @@ use crate::{
 		channel::OracleOrConst,
 		common::{FDomain, FEncode, FExt, FFastExt},
 		exp::{self, reorder_exponents},
+		verify::augument_flush_po2_step_down,
 	},
 	fiat_shamir::{CanSample, Challenger},
 	merkle_tree::BinaryMerkleTreeProver,
@@ -55,6 +56,7 @@ use crate::{
 	},
 	ring_switch,
 	transcript::ProverTranscript,
+	transparent::step_down::StepDown,
 	witness::{IndexEntry, MultilinearExtensionIndex, MultilinearWitness},
 };
 
@@ -330,6 +332,9 @@ where
 
 	flushes.retain(|flush| table_sizes[flush.table_id] > 0);
 	flushes.sort_by_key(|flush| flush.channel_id);
+	let po2_step_down_polys =
+		augument_flush_po2_step_down(&mut oracles, &mut flushes, &table_size_specs, table_sizes)?;
+	populate_flush_po2_step_down_witnesses::<U, _>(po2_step_down_polys, &mut witness)?;
 	let flush_oracle_ids =
 		make_flush_oracles(&mut oracles, &flushes, mixing_challenge, &permutation_challenges)?;
 
@@ -619,6 +624,23 @@ where
 
 		Ok(type_erased_zerocheck_prover)
 	}
+}
+
+fn populate_flush_po2_step_down_witnesses<'a, U, Tower>(
+	step_down_polys: Vec<(OracleId, StepDown)>,
+	witness: &mut MultilinearExtensionIndex<'a, PackedType<U, FExt<Tower>>>,
+) -> Result<(), Error>
+where
+	U: ProverTowerUnderlier<Tower>,
+	Tower: ProverTowerFamily,
+{
+	for (oracle_id, step_down_poly) in step_down_polys {
+		let witness_poly = step_down_poly
+			.multilinear_extension::<PackedType<U, Tower::B1>>()?
+			.specialize_arc_dyn();
+		witness.update_multilin_poly([(oracle_id, witness_poly)])?
+	}
+	Ok(())
 }
 
 #[instrument(skip_all, level = "debug")]

--- a/crates/core/src/constraint_system/tests.rs
+++ b/crates/core/src/constraint_system/tests.rs
@@ -40,6 +40,7 @@ fn test_make_masked_flush_witnesses_handles_small_n_vars() {
 
 	let flush = Flush {
 		table_id: 0,
+		log_values_per_row: 0,
 		oracles: vec![OracleOrConst::<F>::Oracle(poly_id)],
 		channel_id: 0,
 		direction: FlushDirection::Push,

--- a/crates/core/src/constraint_system/validate.rs
+++ b/crates/core/src/constraint_system/validate.rs
@@ -31,7 +31,6 @@ where
 	P: PackedField<Scalar = F> + PackedExtension<BinaryField1b>,
 	F: TowerField,
 {
-	let _ = table_sizes;
 	// Check the constraint sets
 	for constraint_set in &constraint_system.table_constraints {
 		let multilinears = constraint_set
@@ -68,6 +67,7 @@ where
 		witness,
 		&constraint_system.flushes,
 		boundaries,
+		table_sizes,
 		constraint_system.channel_count,
 	)?;
 

--- a/crates/core/src/constraint_system/verify.rs
+++ b/crates/core/src/constraint_system/verify.rs
@@ -1,5 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+use std::collections::hash_map::Entry;
+
 use binius_field::{
 	BinaryField, PackedField, TowerField,
 	tower::{PackedTop, TowerFamily, TowerUnderlier},
@@ -35,6 +37,7 @@ use crate::{
 	},
 	ring_switch,
 	transcript::VerifierTranscript,
+	transparent::step_down::StepDown,
 };
 
 /// Verifies a proof against a constraint system.
@@ -172,6 +175,8 @@ where
 
 	flushes.retain(|flush| table_sizes[flush.table_id] > 0);
 	flushes.sort_by_key(|flush| flush.channel_id);
+	let _ =
+		augument_flush_po2_step_down(&mut oracles, &mut flushes, &table_size_specs, &table_sizes)?;
 	let flush_oracle_ids =
 		make_flush_oracles(&mut oracles, &flushes, mixing_challenge, &permutation_challenges)?;
 
@@ -367,6 +372,70 @@ fn verify_channels_balance<F: TowerField>(
 	}
 
 	Ok(())
+}
+
+/// This function will create a special selectors for the flushes, that are defined on tables that
+/// are not of power-of-two size. Those artifical selectors are needed to bridge the gap between
+/// the arbitrary sized tables and the oracles (oracles are always power-of-two sized).
+///
+/// Takes the vector of `flushes` and creates the corresponding list of oracles for them. If the
+/// witness provided, then it will also fill the witness for those oracles.
+pub fn augument_flush_po2_step_down<F: TowerField>(
+	oracles: &mut MultilinearOracleSet<F>,
+	flushes: &mut [Flush<F>],
+	table_size_specs: &[TableSizeSpec],
+	table_sizes: &[usize],
+) -> Result<Vec<(OracleId, StepDown)>, Error> {
+	use std::collections::HashMap;
+
+	use crate::transparent::step_down::StepDown;
+
+	// Track created step-down oracles by (table_id, log_values_per_row)
+	let mut step_down_oracles = HashMap::<(usize, usize), OracleId>::new();
+	let mut step_down_polys = Vec::new();
+
+	// First pass: create step-down oracles for arbitrary-sized tables
+	for flush in flushes.iter() {
+		let table_id = flush.table_id;
+		let table_size = table_sizes[table_id];
+		let table_spec = &table_size_specs[table_id];
+
+		// Only process tables with arbitrary size that are not power-of-two
+		if matches!(table_spec, TableSizeSpec::Arbitrary) {
+			let log_values_per_row = flush.log_values_per_row;
+			let key = (table_id, log_values_per_row);
+
+			// Only create the step-down oracle once per (table_id, log_values_per_row) pair.
+			if let Entry::Vacant(e) = step_down_oracles.entry(key) {
+				let log_capacity = log2_ceil_usize(table_size);
+				let n_vars = log_capacity + log_values_per_row;
+				let size = table_size << log_values_per_row;
+
+				let step_down_poly = StepDown::new(n_vars, size)?;
+				let oracle_id = oracles
+					.add_named(format!("stepdown_table_{table_id}_log_values_{log_values_per_row}"))
+					.transparent(step_down_poly.clone())?;
+
+				step_down_polys.push((oracle_id, step_down_poly));
+				e.insert(oracle_id);
+			}
+		}
+	}
+
+	// Second pass: add step-down oracles as selectors to the appropriate flushes
+	for flush in flushes.iter_mut() {
+		let table_id = flush.table_id;
+		let table_spec = &table_size_specs[table_id];
+
+		if matches!(table_spec, TableSizeSpec::Arbitrary) {
+			let key = (table_id, flush.log_values_per_row);
+			if let Some(&oracle_id) = step_down_oracles.get(&key) {
+				flush.selectors.push(oracle_id);
+			}
+		}
+	}
+
+	Ok(step_down_polys)
 }
 
 /// For each flush,


### PR DESCRIPTION
Non-power-of-two tables with flushes require special selectors that would
deactivate flushing after the table size. Right now we create those selectors
and mix them to the existing flush selectors in M3. However, with
[CRY-363: Table-Aware Constraint
System](https://linear.app/irreducible/issue/CRY-363/table-aware-constraint-system)
the table sizes won't be available in M3, and thus those selectors should
be constructed in the core, during proving and verifying.