### PR TITLE
Remove white intervals from traces after adding HAL.

### DIFF
--- a/crates/core/src/piop/prove.rs
+++ b/crates/core/src/piop/prove.rs
@@ -221,6 +221,12 @@ where
 		})
 		.collect::<Result<Vec<_>, _>>()?;
 
+	let copy_span = tracing::debug_span!(
+		"[task] Copy polynomials to device memory",
+		phase = "piop_compiler",
+		perfetto_category = "phase.sub",
+	)
+	.entered();
 	let packed_committed_fslices_mut = packed_committed_multilins
 		.iter()
 		.map(|packed_committed_multilin| {
@@ -262,6 +268,8 @@ where
 		.iter()
 		.map(|fslice_mut| Hal::DevMem::as_const(fslice_mut))
 		.collect::<Vec<_>>();
+
+	drop(copy_span);
 
 	let non_empty_sumcheck_descs = sumcheck_claim_descs
 		.iter()

--- a/examples/b32_mul.rs
+++ b/examples/b32_mul.rs
@@ -94,12 +94,16 @@ fn main() -> Result<()> {
 	let cs_digest = ccs.digest::<Groestl256>();
 	let witness = witness.into_multilinear_extension_index();
 
+	let hal_span = tracing::info_span!("HAL Setup", perfetto_category = "phase.main").entered();
+
 	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
 
 	let mut host_mem = zeroed_vec(1 << 20);
 	let mut dev_mem_owned = zeroed_vec(1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH));
 
 	let dev_mem = PackedMemorySliceMut::new_slice(&mut dev_mem_owned);
+
+	drop(hal_span);
 
 	let proof = constraint_system::prove::<
 		_,

--- a/examples/bitwise_ops.rs
+++ b/examples/bitwise_ops.rs
@@ -236,12 +236,16 @@ fn main() -> Result<()> {
 	let cs_digest = ccs.digest::<Groestl256>();
 	let witness = witness.into_multilinear_extension_index();
 
+	let hal_span = tracing::info_span!("HAL Setup", perfetto_category = "phase.main").entered();
+
 	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
 
 	let mut host_mem = zeroed_vec(1 << 20);
 	let mut dev_mem_owned = zeroed_vec(1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH));
 
 	let dev_mem = PackedMemorySliceMut::new_slice(&mut dev_mem_owned);
+
+	drop(hal_span);
 
 	let proof = constraint_system::prove::<
 		_,

--- a/examples/groestl.rs
+++ b/examples/groestl.rs
@@ -115,12 +115,16 @@ fn main() -> Result<()> {
 	let cs_digest = ccs.digest::<Groestl256>();
 	let witness = witness.into_multilinear_extension_index();
 
+	let hal_span = tracing::info_span!("HAL Setup", perfetto_category = "phase.main").entered();
+
 	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
 
 	let mut host_mem = zeroed_vec(1 << 20);
 	let mut dev_mem_owned = zeroed_vec(1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH));
 
 	let dev_mem = PackedMemorySliceMut::new_slice(&mut dev_mem_owned);
+
+	drop(hal_span);
 
 	let proof = constraint_system::prove::<
 		_,

--- a/examples/keccak.rs
+++ b/examples/keccak.rs
@@ -116,12 +116,16 @@ fn main() -> Result<()> {
 	let cs_digest = ccs.digest::<Groestl256>();
 	let witness = witness.into_multilinear_extension_index();
 
+	let hal_span = tracing::info_span!("HAL Setup", perfetto_category = "phase.main").entered();
+
 	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
 
 	let mut host_mem = zeroed_vec(1 << 20);
 	let mut dev_mem_owned = zeroed_vec(1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH));
 
 	let dev_mem = PackedMemorySliceMut::new_slice(&mut dev_mem_owned);
+
+	drop(hal_span);
 
 	let proof = constraint_system::prove::<
 		_,

--- a/examples/keccak_lookups.rs
+++ b/examples/keccak_lookups.rs
@@ -142,12 +142,16 @@ fn main() -> Result<()> {
 	let cs_digest = ccs.digest::<Groestl256>();
 	let witness = witness.into_multilinear_extension_index();
 
+	let hal_span = tracing::info_span!("HAL Setup", perfetto_category = "phase.main").entered();
+
 	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
 
 	let mut host_mem = zeroed_vec(1 << 20);
 	let mut dev_mem_owned = zeroed_vec(1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH));
 
 	let dev_mem = PackedMemorySliceMut::new_slice(&mut dev_mem_owned);
+
+	drop(hal_span);
 
 	let proof = constraint_system::prove::<
 		_,

--- a/examples/merkle_tree.rs
+++ b/examples/merkle_tree.rs
@@ -97,12 +97,16 @@ fn main() -> Result<()> {
 	let cs_digest = ccs.digest::<Groestl256>();
 	let witness = witness.into_multilinear_extension_index();
 
+	let hal_span = tracing::info_span!("HAL Setup", perfetto_category = "phase.main").entered();
+
 	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
 
 	let mut host_mem = zeroed_vec(1 << 20);
 	let mut dev_mem_owned = zeroed_vec(1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH));
 
 	let dev_mem = PackedMemorySliceMut::new_slice(&mut dev_mem_owned);
+
+	drop(hal_span);
 
 	let proof = constraint_system::prove::<
 		_,

--- a/examples/u32_add.rs
+++ b/examples/u32_add.rs
@@ -90,12 +90,16 @@ fn main() -> Result<()> {
 	let cs_digest = ccs.digest::<Groestl256>();
 	let witness = witness.into_multilinear_extension_index();
 
+	let hal_span = tracing::info_span!("HAL Setup", perfetto_category = "phase.main").entered();
+
 	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
 
 	let mut host_mem = zeroed_vec(1 << 20);
 	let mut dev_mem_owned = zeroed_vec(1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH));
 
 	let dev_mem = PackedMemorySliceMut::new_slice(&mut dev_mem_owned);
+
+	drop(hal_span);
 
 	let proof = constraint_system::prove::<
 		_,

--- a/examples/u32_mul_gkr.rs
+++ b/examples/u32_mul_gkr.rs
@@ -112,12 +112,16 @@ fn main() -> Result<()> {
 	let cs_digest = ccs.digest::<Groestl256>();
 	let witness = witness.into_multilinear_extension_index();
 
+	let hal_span = tracing::info_span!("HAL Setup", perfetto_category = "phase.main").entered();
+
 	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
 
 	let mut host_mem = zeroed_vec(1 << 20);
 	let mut dev_mem_owned = zeroed_vec(1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH));
 
 	let dev_mem = PackedMemorySliceMut::new_slice(&mut dev_mem_owned);
+
+	drop(hal_span);
 
 	let proof = constraint_system::prove::<
 		_,


### PR DESCRIPTION
# Add tracing spans for better performance monitoring

### TL;DR

Added tracing spans to track HAL setup and polynomial copying operations for better performance profiling.

### What changed?

- Added a tracing span in `piop/prove.rs` to track the time spent copying polynomials to device memory
- Added consistent HAL setup tracing spans across all example files (b32_mul, bitwise_ops, groestl, keccak, keccak_lookups, merkle_tree, u32_add, u32_mul_gkr)
- All spans include appropriate perfetto categories for integration with performance monitoring tools

### How to test?

Run any of the example files with tracing enabled to verify the new spans appear in the logs:

```bash
RUST_LOG=info cargo run --example b32_mul
```

For more detailed tracing, enable debug logs and check for the polynomial copying span:

```bash
RUST_LOG=debug cargo run --example b32_mul
```

### Why make this change?

These tracing spans provide better visibility into performance bottlenecks during proving operations. The HAL setup and polynomial copying are potentially expensive operations, and having dedicated spans allows for more precise performance analysis and optimization efforts.