### PR TITLE
Use ComputeHolder in prove

### DIFF
--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -2,7 +2,7 @@
 
 use std::{env, iter, marker::PhantomData};
 
-use binius_compute::{ComputeLayer, ComputeMemory, FSliceMut, cpu::CpuMemory};
+use binius_compute::{ComputeData, ComputeLayer, alloc::ComputeAllocator};
 use binius_field::{
 	BinaryField, ExtensionField, Field, PackedExtension, PackedField, PackedFieldIndexable,
 	RepackedExtension, TowerField,
@@ -62,9 +62,7 @@ use crate::{
 #[allow(clippy::too_many_arguments)]
 #[instrument("constraint_system::prove", skip_all, level = "debug")]
 pub fn prove<Hal, U, Tower, Hash, Compress, Challenger_, Backend>(
-	hal: &Hal,
-	host_mem: <CpuMemory as ComputeMemory<Tower::B128>>::FSliceMut<'_>,
-	dev_mem: FSliceMut<'_, Tower::B128, Hal>,
+	compute_data: &mut ComputeData<Tower::B128, Hal>,
 	constraint_system: &ConstraintSystem<FExt<Tower>>,
 	log_inv_rate: usize,
 	security_bits: usize,
@@ -487,9 +485,9 @@ where
 	)
 	.entered();
 	piop::prove(
-		hal,
-		host_mem,
-		dev_mem,
+		compute_data.hal,
+		compute_data.host_alloc.remaining(),
+		compute_data.dev_alloc.remaining(),
 		&fri_params,
 		&ntt,
 		&merkle_prover,

--- a/examples/b32_mul.rs
+++ b/examples/b32_mul.rs
@@ -1,9 +1,9 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use anyhow::Result;
-use binius_compute::cpu::alloc::CpuComputeAllocator;
+use binius_compute::{ComputeHolder, cpu::alloc::CpuComputeAllocator};
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger};
-use binius_fast_compute::{layer::FastCpuLayer, memory::PackedMemorySliceMut};
+use binius_fast_compute::layer::FastCpuLayerHolder;
 use binius_field::{
 	arch::OptimalUnderlier, as_packed_field::PackedType, tower::CanonicalTowerFamily,
 };
@@ -13,7 +13,6 @@ use binius_m3::builder::{
 	B32, B128, ConstraintSystem, Statement, WitnessIndex, test_utils::ClosureFiller,
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
-use bytemuck::zeroed_vec;
 use bytesize::ByteSize;
 use clap::{Parser, value_parser};
 use rand::{Rng as _, SeedableRng as _, rngs::StdRng};
@@ -99,12 +98,11 @@ fn main() -> Result<()> {
 
 	let hal_span = tracing::info_span!("HAL Setup", perfetto_category = "phase.main").entered();
 
-	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
-
-	let mut host_mem = zeroed_vec(1 << 20);
-	let mut dev_mem_owned = zeroed_vec(1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH));
-
-	let dev_mem = PackedMemorySliceMut::new_slice(&mut dev_mem_owned);
+	let mut compute_holder =
+		FastCpuLayerHolder::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::new(
+			1 << 20,
+			1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH),
+		);
 
 	drop(hal_span);
 
@@ -117,9 +115,7 @@ fn main() -> Result<()> {
 		HasherChallenger<Groestl256>,
 		_,
 	>(
-		&hal,
-		&mut host_mem,
-		dev_mem,
+		&mut compute_holder.to_data(),
 		&ccs,
 		args.log_inv_rate as usize,
 		SECURITY_BITS,

--- a/examples/bitwise_ops.rs
+++ b/examples/bitwise_ops.rs
@@ -3,9 +3,9 @@
 use std::{fmt::Display, str::FromStr};
 
 use anyhow::Result;
-use binius_compute::cpu::alloc::CpuComputeAllocator;
+use binius_compute::{ComputeHolder, cpu::alloc::CpuComputeAllocator};
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger};
-use binius_fast_compute::{layer::FastCpuLayer, memory::PackedMemorySliceMut};
+use binius_fast_compute::layer::FastCpuLayerHolder;
 use binius_field::{
 	arch::OptimalUnderlier, as_packed_field::PackedType, tower::CanonicalTowerFamily,
 };
@@ -16,7 +16,6 @@ use binius_m3::builder::{
 	test_utils::ClosureFiller,
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
-use bytemuck::zeroed_vec;
 use bytesize::ByteSize;
 use clap::{Parser, value_parser};
 use rand::{Rng as _, SeedableRng as _, rngs::StdRng};
@@ -244,12 +243,11 @@ fn main() -> Result<()> {
 
 	let hal_span = tracing::info_span!("HAL Setup", perfetto_category = "phase.main").entered();
 
-	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
-
-	let mut host_mem = zeroed_vec(1 << 20);
-	let mut dev_mem_owned = zeroed_vec(1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH));
-
-	let dev_mem = PackedMemorySliceMut::new_slice(&mut dev_mem_owned);
+	let mut compute_holder =
+		FastCpuLayerHolder::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::new(
+			1 << 20,
+			1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH),
+		);
 
 	drop(hal_span);
 
@@ -262,9 +260,7 @@ fn main() -> Result<()> {
 		HasherChallenger<Groestl256>,
 		_,
 	>(
-		&hal,
-		&mut host_mem,
-		dev_mem,
+		&mut compute_holder.to_data(),
 		&ccs,
 		args.log_inv_rate as usize,
 		SECURITY_BITS,

--- a/examples/groestl.rs
+++ b/examples/groestl.rs
@@ -3,9 +3,9 @@
 use std::{array, iter::repeat_with};
 
 use anyhow::Result;
-use binius_compute::cpu::alloc::CpuComputeAllocator;
+use binius_compute::{ComputeHolder, cpu::alloc::CpuComputeAllocator};
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger};
-use binius_fast_compute::{layer::FastCpuLayer, memory::PackedMemorySliceMut};
+use binius_fast_compute::layer::FastCpuLayerHolder;
 use binius_field::{
 	Field, PackedExtension, PackedFieldIndexable, PackedSubfield, arch::OptimalUnderlier,
 	as_packed_field::PackedType, linear_transformation::PackedTransformationFactory,
@@ -21,7 +21,6 @@ use binius_m3::{
 	gadgets::hash::groestl,
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
-use bytemuck::zeroed_vec;
 use bytesize::ByteSize;
 use clap::{Parser, value_parser};
 use rand::thread_rng;
@@ -122,12 +121,11 @@ fn main() -> Result<()> {
 
 	let hal_span = tracing::info_span!("HAL Setup", perfetto_category = "phase.main").entered();
 
-	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
-
-	let mut host_mem = zeroed_vec(1 << 20);
-	let mut dev_mem_owned = zeroed_vec(1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH));
-
-	let dev_mem = PackedMemorySliceMut::new_slice(&mut dev_mem_owned);
+	let mut compute_holder =
+		FastCpuLayerHolder::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::new(
+			1 << 20,
+			1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH),
+		);
 
 	drop(hal_span);
 
@@ -140,9 +138,7 @@ fn main() -> Result<()> {
 		HasherChallenger<Groestl256>,
 		_,
 	>(
-		&hal,
-		&mut host_mem,
-		dev_mem,
+		&mut compute_holder.to_data(),
 		&ccs,
 		args.log_inv_rate as usize,
 		SECURITY_BITS,

--- a/examples/keccak.rs
+++ b/examples/keccak.rs
@@ -3,9 +3,9 @@
 use std::iter::repeat_with;
 
 use anyhow::Result;
-use binius_compute::cpu::alloc::CpuComputeAllocator;
+use binius_compute::{ComputeHolder, cpu::alloc::CpuComputeAllocator};
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger};
-use binius_fast_compute::{layer::FastCpuLayer, memory::PackedMemorySliceMut};
+use binius_fast_compute::layer::FastCpuLayerHolder;
 use binius_field::{
 	PackedExtension, PackedFieldIndexable, PackedSubfield, arch::OptimalUnderlier,
 	as_packed_field::PackedType, linear_transformation::PackedTransformationFactory,
@@ -21,7 +21,6 @@ use binius_m3::{
 	gadgets::hash::keccak::{StateMatrix, stacked::Keccakf},
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
-use bytemuck::zeroed_vec;
 use bytesize::ByteSize;
 use clap::{Parser, value_parser};
 use rand::{RngCore, thread_rng};
@@ -123,12 +122,11 @@ fn main() -> Result<()> {
 
 	let hal_span = tracing::info_span!("HAL Setup", perfetto_category = "phase.main").entered();
 
-	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
-
-	let mut host_mem = zeroed_vec(1 << 20);
-	let mut dev_mem_owned = zeroed_vec(1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH));
-
-	let dev_mem = PackedMemorySliceMut::new_slice(&mut dev_mem_owned);
+	let mut compute_holder =
+		FastCpuLayerHolder::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::new(
+			1 << 20,
+			1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH),
+		);
 
 	drop(hal_span);
 
@@ -141,9 +139,7 @@ fn main() -> Result<()> {
 		HasherChallenger<Groestl256>,
 		_,
 	>(
-		&hal,
-		&mut host_mem,
-		dev_mem,
+		&mut compute_holder.to_data(),
 		&ccs,
 		args.log_inv_rate as usize,
 		SECURITY_BITS,

--- a/examples/keccak_lookups.rs
+++ b/examples/keccak_lookups.rs
@@ -3,12 +3,12 @@
 use std::{cmp::Reverse, iter::repeat_with};
 
 use anyhow::Result;
-use binius_compute::cpu::alloc::CpuComputeAllocator;
+use binius_compute::{ComputeHolder, cpu::alloc::CpuComputeAllocator};
 use binius_core::{
 	constraint_system::{self, channel::ChannelId},
 	fiat_shamir::HasherChallenger,
 };
-use binius_fast_compute::{layer::FastCpuLayer, memory::PackedMemorySliceMut};
+use binius_fast_compute::layer::FastCpuLayerHolder;
 use binius_field::{
 	PackedExtension, PackedFieldIndexable, PackedSubfield, arch::OptimalUnderlier,
 	as_packed_field::PackedType, linear_transformation::PackedTransformationFactory,
@@ -27,7 +27,6 @@ use binius_m3::{
 	},
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
-use bytemuck::zeroed_vec;
 use bytesize::ByteSize;
 use clap::{Parser, value_parser};
 use itertools::Itertools;
@@ -149,12 +148,11 @@ fn main() -> Result<()> {
 
 	let hal_span = tracing::info_span!("HAL Setup", perfetto_category = "phase.main").entered();
 
-	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
-
-	let mut host_mem = zeroed_vec(1 << 20);
-	let mut dev_mem_owned = zeroed_vec(1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH));
-
-	let dev_mem = PackedMemorySliceMut::new_slice(&mut dev_mem_owned);
+	let mut compute_holder =
+		FastCpuLayerHolder::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::new(
+			1 << 20,
+			1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH),
+		);
 
 	drop(hal_span);
 
@@ -167,9 +165,7 @@ fn main() -> Result<()> {
 		HasherChallenger<Groestl256>,
 		_,
 	>(
-		&hal,
-		&mut host_mem,
-		dev_mem,
+		&mut compute_holder.to_data(),
 		&ccs,
 		args.log_inv_rate as usize,
 		SECURITY_BITS,

--- a/examples/merkle_tree.rs
+++ b/examples/merkle_tree.rs
@@ -1,9 +1,9 @@
 // Copyright 2025 Irreducible Inc.
 
 use anyhow::Result;
-use binius_compute::cpu::alloc::CpuComputeAllocator;
+use binius_compute::{ComputeHolder, cpu::alloc::CpuComputeAllocator};
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger};
-use binius_fast_compute::{layer::FastCpuLayer, memory::PackedMemorySliceMut};
+use binius_fast_compute::layer::FastCpuLayerHolder;
 use binius_field::{
 	arch::OptimalUnderlier, as_packed_field::PackedType, tower::CanonicalTowerFamily,
 };
@@ -17,7 +17,6 @@ use binius_m3::{
 	},
 };
 use binius_utils::rayon::adjust_thread_pool;
-use bytemuck::zeroed_vec;
 use bytesize::ByteSize;
 use clap::{Parser, value_parser};
 use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -106,12 +105,11 @@ fn main() -> Result<()> {
 
 	let hal_span = tracing::info_span!("HAL Setup", perfetto_category = "phase.main").entered();
 
-	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
-
-	let mut host_mem = zeroed_vec(1 << 20);
-	let mut dev_mem_owned = zeroed_vec(1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH));
-
-	let dev_mem = PackedMemorySliceMut::new_slice(&mut dev_mem_owned);
+	let mut compute_holder =
+		FastCpuLayerHolder::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::new(
+			1 << 20,
+			1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH),
+		);
 
 	drop(hal_span);
 
@@ -124,9 +122,7 @@ fn main() -> Result<()> {
 		HasherChallenger<Groestl256>,
 		_,
 	>(
-		&hal,
-		&mut host_mem,
-		dev_mem,
+		&mut compute_holder.to_data(),
 		&ccs,
 		args.log_inv_rate as usize,
 		SECURITY_BITS,

--- a/examples/u32_add.rs
+++ b/examples/u32_add.rs
@@ -1,8 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
 use anyhow::Result;
-use binius_compute::cpu::alloc::CpuComputeAllocator;
+use binius_compute::{ComputeHolder, cpu::alloc::CpuComputeAllocator};
 use binius_core::{constraint_system, fiat_shamir::HasherChallenger};
-use binius_fast_compute::{layer::FastCpuLayer, memory::PackedMemorySliceMut};
+use binius_fast_compute::layer::FastCpuLayerHolder;
 use binius_field::{
 	arch::OptimalUnderlier, as_packed_field::PackedType, tower::CanonicalTowerFamily,
 };
@@ -13,7 +13,6 @@ use binius_m3::{
 	gadgets::add::{U32Add, U32AddFlags},
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
-use bytemuck::zeroed_vec;
 use bytesize::ByteSize;
 use clap::{Parser, value_parser};
 use rand::{Rng as _, SeedableRng as _, rngs::StdRng};
@@ -97,12 +96,11 @@ fn main() -> Result<()> {
 
 	let hal_span = tracing::info_span!("HAL Setup", perfetto_category = "phase.main").entered();
 
-	let hal = FastCpuLayer::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::default();
-
-	let mut host_mem = zeroed_vec(1 << 20);
-	let mut dev_mem_owned = zeroed_vec(1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH));
-
-	let dev_mem = PackedMemorySliceMut::new_slice(&mut dev_mem_owned);
+	let mut compute_holder =
+		FastCpuLayerHolder::<CanonicalTowerFamily, PackedType<OptimalUnderlier, B128>>::new(
+			1 << 20,
+			1 << (28 - PackedType::<OptimalUnderlier, B128>::LOG_WIDTH),
+		);
 
 	drop(hal_span);
 
@@ -115,9 +113,7 @@ fn main() -> Result<()> {
 		HasherChallenger<Groestl256>,
 		_,
 	>(
-		&hal,
-		&mut host_mem,
-		dev_mem,
+		&mut compute_holder.to_data(),
 		&ccs,
 		args.log_inv_rate as usize,
 		SECURITY_BITS,


### PR DESCRIPTION
### TL;DR

Refactored compute memory management to use `ComputeData` and `ComputeHolder` abstractions.

### What changed?

- Modified the `prove` function in `constraint_system/prove.rs` to accept a single `ComputeData` parameter instead of separate HAL, host memory, and device memory parameters
- Replaced direct memory allocation with `ComputeHolder` and `FastCpuLayerHolder` in test utilities and examples
- Updated all example files to use the new memory management approach
- Removed manual memory allocation with `zeroed_vec` in favor of the new abstractions

### How to test?

Run the examples to verify they still work with the new memory management approach:
```bash
cargo run --example b32_mul
cargo run --example bitwise_ops
cargo run --example groestl
cargo run --example keccak
cargo run --example keccak_lookups
cargo run --example merkle_tree
cargo run --example u32_add
cargo run --example u32_mul_gkr
```

Also run the test suite to ensure the changes don't break existing functionality:
```bash
cargo test
```

### Why make this change?

This change improves memory management by:
1. Encapsulating memory allocation and management in dedicated abstractions
2. Reducing boilerplate code in examples and tests
3. Making the API more ergonomic by requiring fewer parameters
4. Providing a more consistent interface for compute resources across the codebase