### PR TITLE
Use ComputeData in `piop::prove`

### DIFF
--- a/crates/compute/src/alloc.rs
+++ b/crates/compute/src/alloc.rs
@@ -52,6 +52,11 @@ where
 			buffer: Mutex::new(Some(buffer)),
 		}
 	}
+
+	/// Returns the remaining unallocated capacity as a new allocator with a limited scope.
+	pub fn subscope_allocator<'b>(&'b mut self) -> BumpAllocator<'b, F, Mem> {
+		BumpAllocator::new(self.remaining())
+	}
 }
 
 impl<'a, F, Mem: ComputeMemory<F>> ComputeAllocator<F, Mem> for BumpAllocator<'a, F, Mem> {

--- a/crates/core/src/constraint_system/prove.rs
+++ b/crates/core/src/constraint_system/prove.rs
@@ -2,7 +2,7 @@
 
 use std::{env, iter, marker::PhantomData};
 
-use binius_compute::{ComputeData, ComputeLayer, alloc::ComputeAllocator};
+use binius_compute::{ComputeData, ComputeLayer};
 use binius_field::{
 	BinaryField, ExtensionField, Field, PackedExtension, PackedField, PackedFieldIndexable,
 	RepackedExtension, TowerField,
@@ -519,9 +519,7 @@ where
 	)
 	.entered();
 	piop::prove(
-		compute_data.hal,
-		compute_data.host_alloc.remaining(),
-		compute_data.dev_alloc.remaining(),
+		compute_data,
 		&fri_params,
 		&ntt,
 		&merkle_prover,

--- a/crates/core/src/piop/tests.rs
+++ b/crates/core/src/piop/tests.rs
@@ -2,7 +2,7 @@
 
 use std::iter::repeat_with;
 
-use binius_compute::cpu::CpuLayer;
+use binius_compute::{ComputeHolder, cpu::layer::CpuLayerHolder};
 use binius_field::{
 	BinaryField, Field, PackedBinaryField2x128b, PackedExtension, PackedField, PackedFieldIndexable,
 };
@@ -152,15 +152,11 @@ fn commit_prove_verify<FDomain, FEncode, F, P, MTScheme>(
 	let mut proof = ProverTranscript::<HasherChallenger<Groestl256>>::new();
 	proof.message().write(&commitment);
 
-	let hal = CpuLayer::<F>::default();
-	let mut host_mem = vec![F::ZERO; 1 << 14];
-	let mut dev_mem = vec![F::ZERO; 1 << 22];
+	let mut compute_holder = CpuLayerHolder::<F>::new(1 << 14, 1 << 22);
 	// If this unwraps on an out-of-memory error, allocate more above (tests are assumed to not
 	// require so much memory)
 	prove(
-		&hal,
-		&mut host_mem,
-		&mut dev_mem,
+		&mut compute_holder.to_data(),
 		&fri_params,
 		&ntt,
 		merkle_prover,


### PR DESCRIPTION
### TL;DR

Added a `subscope_allocator` method to `BumpAllocator` and simplified the `prove` function interface by using `ComputeData`.

### What changed?

- Added a new `subscope_allocator` method to `BumpAllocator` that returns a new allocator with the remaining unallocated capacity
- Simplified the `prove` function interface in `piop/prove.rs` to take a `ComputeData` reference instead of separate HAL and memory parameters
- Updated all call sites to use the new interface, including:
  - `constraint_system/prove.rs`
  - `piop/tests.rs`
  - `ring_switch/tests.rs`
- Tests now use `CpuLayerHolder` and `to_data()` instead of manually creating HAL and memory buffers

### How to test?

Run the existing test suite to ensure that all tests pass with the new interface:

```bash
cargo test
```

### Why make this change?

This change improves the API ergonomics by:
1. Encapsulating memory allocation logic within the `BumpAllocator` class
2. Simplifying the function signature of `prove` by using a single `ComputeData` parameter instead of separate HAL and memory parameters
3. Making the code more maintainable by reducing parameter passing and centralizing allocation logic