### PR TITLE
Use ComputeData in sumcheck_v3 tests

### DIFF
--- a/crates/core/src/protocols/sumcheck/v3/bivariate_mlecheck.rs
+++ b/crates/core/src/protocols/sumcheck/v3/bivariate_mlecheck.rs
@@ -510,23 +510,18 @@ fn calculate_round_evals<'a, F: TowerField, Hal: ComputeLayer<F>>(
 
 #[cfg(test)]
 mod tests {
-	use binius_compute::cpu::{CpuLayer, alloc::CpuComputeAllocator};
+	use binius_compute::{ComputeHolder, cpu::layer::CpuLayerHolder};
 	use binius_compute_test_utils::bivariate_sumcheck::generic_test_bivariate_mlecheck_prove_verify;
 	use binius_math::B128;
-	use bytemuck::zeroed_vec;
 
 	#[test]
 	fn test_bivariate_mlecheck_prove_verify() {
-		let hal = <CpuLayer<B128>>::default();
-		let mut dev_mem = zeroed_vec(1 << 12);
-		let mut host_allocator = CpuComputeAllocator::new(dev_mem.len() * 2);
+		let mut compute_holder = CpuLayerHolder::<B128>::new(1 << 13, 1 << 12);
 		let n_vars = 8;
 		let n_multilins = 8;
 		let n_compositions = 8;
 		generic_test_bivariate_mlecheck_prove_verify(
-			&hal,
-			&mut dev_mem,
-			&host_allocator.into_bump_allocator(),
+			&mut compute_holder.to_data(),
 			n_vars,
 			n_multilins,
 			n_compositions,


### PR DESCRIPTION
### TL;DR

Refactored compute layer management by introducing `ComputeData` and `ComputeHolder` abstractions to simplify memory allocation and resource management.

### What changed?

- Introduced `ComputeData` struct to encapsulate HAL, device allocator, and host allocator
- Replaced explicit memory allocation with `ComputeHolder` implementations (`CpuLayerHolder` and `FastCpuLayerHolder`)
- Modified test utility functions to accept `ComputeData` instead of separate HAL, memory, and allocator parameters
- Simplified test code by removing manual memory allocation and management
- Updated function signatures to use the new abstractions throughout the codebase

### How to test?

Run the existing tests which now use the new abstractions:
- `test_calculate_round_evals`
- `test_calculate_round_evals_fast_cpu`
- `test_bivariate_sumcheck_prove_verify`
- `test_bivariate_sumcheck_prove_verify_fast`
- `test_bivariate_mlecheck_prove_verify`

### Why make this change?

This refactoring improves code maintainability and reduces boilerplate by:
1. Centralizing memory allocation and management logic
2. Providing a cleaner API for compute operations
3. Reducing the risk of memory-related bugs
4. Making test code more concise and focused on the actual test logic rather than setup

The new abstractions make it easier to work with different compute layers while maintaining a consistent interface.