### PR TITLE
Use ComputeData in sumcheck_v3 benchmarks

### DIFF
--- a/crates/compute_test_utils/src/bivariate_sumcheck.rs
+++ b/crates/compute_test_utils/src/bivariate_sumcheck.rs
@@ -192,6 +192,7 @@ pub fn generic_test_bivariate_sumcheck_prove_verify<F, Hal>(
 		host_alloc,
 	} = compute_data;
 	let host_alloc = host_alloc.subscope_allocator();
+	let dev_alloc = dev_alloc.subscope_allocator();
 
 	let claim_req_mem = <BivariateSumcheckProver<F, Hal>>::required_host_memory(&claim);
 	let max_eval_len = evals.iter().map(|elem| elem.len()).max().unwrap();
@@ -220,7 +221,7 @@ pub fn generic_test_bivariate_sumcheck_prove_verify<F, Hal>(
 	);
 
 	let prover =
-		BivariateSumcheckProver::new(*hal, dev_alloc, &host_alloc, &claim, dev_multilins).unwrap();
+		BivariateSumcheckProver::new(*hal, &dev_alloc, &host_alloc, &claim, dev_multilins).unwrap();
 
 	let mut transcript = ProverTranscript::<HasherChallenger<Groestl256>>::new();
 

--- a/crates/core/src/protocols/sumcheck/v3/bivariate_product.rs
+++ b/crates/core/src/protocols/sumcheck/v3/bivariate_product.rs
@@ -28,7 +28,7 @@ use crate::{
 pub struct BivariateSumcheckProver<'a, 'alloc, F: Field, Hal: ComputeLayer<F>> {
 	hal: &'a Hal,
 	dev_alloc: &'a BumpAllocator<'alloc, F, Hal::DevMem>,
-	host_alloc: &'a HostBumpAllocator<'a, F>,
+	host_alloc: &'a HostBumpAllocator<'alloc, F>,
 	n_vars_initial: usize,
 	n_vars_remaining: usize,
 	multilins: Vec<SumcheckMultilinear<'a, F, Hal::DevMem>>,
@@ -44,7 +44,7 @@ where
 	pub fn new(
 		hal: &'a Hal,
 		dev_alloc: &'a BumpAllocator<'alloc, F, Hal::DevMem>,
-		host_alloc: &'a HostBumpAllocator<'a, F>,
+		host_alloc: &'a HostBumpAllocator<'alloc, F>,
 		claim: &SumcheckClaim<F, IndexComposition<BivariateProduct, 2>>,
 		multilins: Vec<FSlice<'a, F, Hal>>,
 	) -> Result<Self, Error> {


### PR DESCRIPTION
### TL;DR

Refactored the sumcheck benchmark to use `ComputeData` and `ComputeHolder` abstractions.

### What changed?

- Replaced direct usage of `BumpAllocator` and `HostBumpAllocator` with the higher-level `ComputeData` and `ComputeHolder` abstractions
- Updated imports to reflect these changes
- Replaced manual memory allocation with `FastCpuLayerHolder::new()` which manages both CPU and device memory
- Modified the benchmark function to use `to_data()` to extract the necessary components (hal, dev_alloc, host_alloc) from the compute holder

### How to test?

Run the sumcheck benchmarks to ensure they still function correctly and produce comparable results to the previous implementation:

```bash
cargo bench --bench sumcheck
```

### Why make this change?

This change simplifies the benchmark code by using higher-level abstractions for memory management and computation. The `ComputeHolder` pattern provides a cleaner way to manage resources and reduces boilerplate code. This approach is more maintainable and aligns with the project's architecture for handling compute resources.