### PR TITLE
Extract generic ring_switch_tests (temporary solution)

### DIFF
--- a/crates/compute/src/cpu/layer.rs
+++ b/crates/compute/src/cpu/layer.rs
@@ -597,8 +597,8 @@ pub struct CpuLayerHolder<F> {
 	dev_mem: Vec<F>,
 }
 
-impl<F: Field> CpuLayerHolder<F> {
-	pub fn new(host_mem_size: usize, dev_mem_size: usize) -> Self {
+impl<F: TowerTop> ComputeHolder<F, CpuLayer<F>> for CpuLayerHolder<F> {
+	fn new(host_mem_size: usize, dev_mem_size: usize) -> Self {
 		let cpu_mem = zeroed_vec(host_mem_size);
 		let dev_mem = zeroed_vec(dev_mem_size);
 		Self {
@@ -607,9 +607,7 @@ impl<F: Field> CpuLayerHolder<F> {
 			dev_mem,
 		}
 	}
-}
 
-impl<F: TowerTop> ComputeHolder<F, CpuLayer<F>> for CpuLayerHolder<F> {
 	fn to_data(&mut self) -> ComputeData<'_, F, CpuLayer<F>> {
 		ComputeData {
 			hal: &self.layer,

--- a/crates/compute/src/layer.rs
+++ b/crates/compute/src/layer.rs
@@ -613,6 +613,8 @@ pub type KernelSliceMut<'a, 'b, F, HAL> =
 /// * a host memory allocator,
 /// * a device memory allocator.
 pub trait ComputeHolder<F: Field, HAL: ComputeLayer<F>> {
+	fn new(host_size: usize, dev_size: usize) -> Self;
+
 	fn to_data(&mut self) -> ComputeData<'_, F, HAL>;
 }
 

--- a/crates/compute_test_utils/src/lib.rs
+++ b/crates/compute_test_utils/src/lib.rs
@@ -3,3 +3,4 @@
 pub mod bivariate_sumcheck;
 pub mod layer;
 pub mod piop;
+pub mod ring_switch;

--- a/crates/core/src/ring_switch/mod.rs
+++ b/crates/core/src/ring_switch/mod.rs
@@ -29,8 +29,6 @@ mod eq_ind;
 mod error;
 mod logging;
 mod prove;
-#[cfg(test)]
-mod tests;
 mod tower_tensor_algebra;
 mod verify;
 

--- a/crates/core/tests/ring_switch.rs
+++ b/crates/core/tests/ring_switch.rs
@@ -1,0 +1,103 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use binius_compute::cpu::{CpuLayer, layer::CpuLayerHolder};
+use binius_compute_test_utils::ring_switch::{
+	check_eval_point_consistency, commit_prove_verify_piop, generate_multilinears,
+	make_test_oracle_set, setup_test_eval_claims,
+};
+use binius_core::{
+	fiat_shamir::HasherChallenger,
+	merkle_tree::BinaryMerkleTreeProver,
+	oracle::MultilinearOracleSet,
+	piop,
+	protocols::evalcheck::subclaims::MemoizedData,
+	ring_switch::{EvalClaimSystem, ReducedClaim, ReducedWitness, prove, verify},
+	transcript::ProverTranscript,
+	witness::MultilinearWitness,
+};
+use binius_field::{
+	arch::OptimalUnderlier128b,
+	as_packed_field::{PackScalar, PackedType},
+};
+use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
+use binius_math::{B128, TowerTop, TowerUnderlier};
+use rand::prelude::*;
+
+fn with_test_instance_from_oracles<U, F, R>(
+	mut rng: R,
+	oracles: &MultilinearOracleSet<F>,
+	func: impl FnOnce(R, EvalClaimSystem<F>, Vec<MultilinearWitness<PackedType<U, F>>>),
+) where
+	U: TowerUnderlier + PackScalar<F>,
+	F: TowerTop,
+	R: Rng,
+{
+	let (commit_meta, oracle_to_commit_index) = piop::make_oracle_commit_meta(oracles).unwrap();
+
+	let witness_index = generate_multilinears::<U, F>(&mut rng, oracles);
+	let witnesses = piop::collect_committed_witnesses::<U, _>(
+		&commit_meta,
+		&oracle_to_commit_index,
+		oracles,
+		&witness_index,
+	)
+	.unwrap();
+
+	let eval_claims = setup_test_eval_claims::<U, _>(&mut rng, oracles, &witness_index);
+
+	// Finish setting up the test case
+	let system =
+		EvalClaimSystem::new(oracles, &commit_meta, &oracle_to_commit_index, &eval_claims).unwrap();
+	check_eval_point_consistency(&system);
+
+	func(rng, system, witnesses)
+}
+
+#[test]
+fn test_prove_verify_claim_reduction_with_naive_validation() {
+	type U = OptimalUnderlier128b;
+	type F = B128;
+
+	let rng = StdRng::seed_from_u64(0);
+	let oracles = make_test_oracle_set();
+
+	with_test_instance_from_oracles::<U, F, _>(rng, &oracles, |_rng, system, witnesses| {
+		let mut proof = ProverTranscript::<HasherChallenger<Groestl256>>::new();
+
+		let ReducedWitness {
+			transparents: transparent_witnesses,
+			sumcheck_claims: prover_sumcheck_claims,
+		} = prove(&system, &witnesses, &mut proof, MemoizedData::new()).unwrap();
+
+		let mut proof = proof.into_verifier();
+		let ReducedClaim {
+			transparents: _,
+			sumcheck_claims: verifier_sumcheck_claims,
+		} = verify(&system, &mut proof).unwrap();
+
+		assert_eq!(prover_sumcheck_claims, verifier_sumcheck_claims);
+
+		piop::validate_sumcheck_witness(
+			&witnesses,
+			&transparent_witnesses,
+			&prover_sumcheck_claims,
+		)
+		.unwrap();
+	});
+}
+
+#[test]
+fn test_prove_verify_piop_integration() {
+	type U = OptimalUnderlier128b;
+	type F = B128;
+
+	let oracles = make_test_oracle_set();
+	let log_inv_rate = 2;
+	let merkle_prover = BinaryMerkleTreeProver::<_, Groestl256, _>::new(Groestl256ByteCompression);
+
+	commit_prove_verify_piop::<U, F, _, _, CpuLayer<F>, CpuLayerHolder<F>>(
+		&merkle_prover,
+		&oracles,
+		log_inv_rate,
+	);
+}

--- a/crates/fast_compute/src/layer.rs
+++ b/crates/fast_compute/src/layer.rs
@@ -833,8 +833,10 @@ pub struct FastCpuLayerHolder<T: TowerFamily, P: PackedTop<T>> {
 	dev_mem: Vec<P>,
 }
 
-impl<T: TowerFamily, P: PackedTop<T>> FastCpuLayerHolder<T, P> {
-	pub fn new(host_mem_size: usize, dev_mem_size: usize) -> Self {
+impl<T: TowerFamily, P: PackedTop<T>> ComputeHolder<T::B128, FastCpuLayer<T, P>>
+	for FastCpuLayerHolder<T, P>
+{
+	fn new(host_mem_size: usize, dev_mem_size: usize) -> Self {
 		let layer = FastCpuLayer::default();
 		let host_mem = vec![T::B128::zero(); host_mem_size];
 		let dev_mem = vec![P::zero(); (dev_mem_size >> P::LOG_WIDTH).max(1)];
@@ -845,11 +847,7 @@ impl<T: TowerFamily, P: PackedTop<T>> FastCpuLayerHolder<T, P> {
 			dev_mem,
 		}
 	}
-}
 
-impl<T: TowerFamily, P: PackedTop<T>> ComputeHolder<T::B128, FastCpuLayer<T, P>>
-	for FastCpuLayerHolder<T, P>
-{
 	fn to_data(&mut self) -> ComputeData<'_, T::B128, FastCpuLayer<T, P>> {
 		ComputeData {
 			hal: &self.layer,


### PR DESCRIPTION
### TL;DR

Extract generic ring switch tests.
This is a temporary solution

### What changed?

- Added `new()` method to the `ComputeHolder` trait in `crates/compute/src/layer.rs`
- Moved implementation of `new()` from struct implementations to trait implementations for `CpuLayerHolder` and `FastCpuLayerHolder`
- Moved ring switch test utilities from `crates/core/src/ring_switch/tests.rs` to a new module `crates/compute_test_utils/src/ring_switch.rs`
- Created a new integration test file `crates/core/tests/ring_switch.rs` that uses the extracted test utilities

### How to test?

Run the existing tests to ensure they still pass:

```bash
cargo test --package binius-core --test ring_switch
```

### Why make this change?

This refactoring improves the code organization by:

1. Making the `ComputeHolder` trait more complete by including the `new()` method that was previously implemented separately for each holder type
2. Moving test utilities to a dedicated test utilities crate, making them reusable across different test scenarios
3. Converting module tests to integration tests, which provides better separation between implementation and testing code