### PR TITLE
[fast_compute] mmap-backed storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ trait-set = "0.3.0"
 tracing = "0.1.38"
 tracing-profile = "0.10.6"
 transpose = "0.2.2"
+libc = "0.2.172"
 
 [profile.release]
 lto = "fat"

--- a/crates/fast_compute/Cargo.toml
+++ b/crates/fast_compute/Cargo.toml
@@ -20,6 +20,7 @@ itertools = { workspace = true }
 stackalloc = { workspace = true }
 thread_local = { workspace = true }
 tracing = { workspace = true }
+libc = { workspace = true }
 
 [dev-dependencies]
 binius_compute_test_utils = { path = "../compute_test_utils", default-features = false }


### PR DESCRIPTION
Fixes the excessive runtime of allocation of memory in fast_compute.
More concretely, this running time is coming from explicitly zeroing the
pages.

We had this problem for some time already and to my knowledge we tried
several approaches already that did not work.

- Vec::resize leads to zeroing
- Vec::with_capacity + set_len is unsound, to my understanding
- vec![0u8; byte_sz] is not sound either, I highly suspect the alignment
  issues, but Aliaksei's investigation did not confirm this directly.
- global allocator's alloc_zeroed, perhaps surprisingly, also leads to
  explicit zeroing, but only when the alignment requested exceeds
  certain values. In our case, this does show up on the M512.

With those options exhausted, it's time to reach to the big guns,
skip the allocator and use the mmap. Justification of the safety is
quite simple. Anonymous private mappings are pretty-much guaranteed
to be zeroed. So this coupled with the documentation should give enough
certainty that this actually works.