### PR TITLE
Set release LTO to thin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ tracing-profile = "0.10.6"
 transpose = "0.2.2"
 
 [profile.release]
-lto = "fat"
+lto = "thin"
 
 [profile.profiling]
 inherits = "release"


### PR DESCRIPTION
FatLTO takes a lot of time and it's annoyingly slow when I am trying multiple variants of some code. I tasked codex to check different options, and it gave me this:

<img width="994" alt="Screenshot 2025-06-14 at 16 24 21" src="https://github.com/user-attachments/assets/5002c702-091e-4425-8335-a893e6b3e80c" />

I double checked the results and it seems to confirm this[^1]:

[^1]: tested on the Keccak example by changing something in binius_field and rebuilding.

1. ThinLTO reduces time ≈2x. From 1m 12s with FatLTO to 35s with ThinLTO.
2. The data suggests consistent perf improvement in FatLTO case. The improvement is very modest. [^2].
 
That makes me think that it's better to assign thin LTO for the release profile by default. In case somebody needs to squeeze extra juice, they can add extra rustc flags.

[^2]: IPC is better by 0.5%, 0.7% less instruction executed. 0.8% faster wallclock time.