### PR TITLE
Extract macro to instantiate ring switch tests

### DIFF
--- a/crates/core/test_utils/src/piop.rs
+++ b/crates/core/test_utils/src/piop.rs
@@ -224,3 +224,146 @@ pub fn commit_prove_verify<FDomain, FEncode, F, P, MTScheme, HAL, ComputeHolderT
 	)
 	.unwrap();
 }
+
+#[macro_export]
+macro_rules! instantiate_piop_tests {
+	($compute_holder:ty) => {
+		#[test]
+		fn test_with_one_poly() {
+			use binius_core::piop::CommitMeta;
+			use binius_field::PackedBinaryField2x128b;
+			use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
+			use binius_math::{B8, B16, B128};
+
+			let commit_meta = CommitMeta::with_vars([4]);
+			let merkle_prover =
+				BinaryMerkleTreeProver::<_, Groestl256, _>::new(Groestl256ByteCompression);
+			let n_transparents = 1;
+			let log_inv_rate = 1;
+			let compute_holder = <$compute_holder>::new(1 << 14, 1 << 22);
+
+			$crate::piop::commit_prove_verify::<B8, B16, B128, PackedBinaryField2x128b, _, _, _>(
+				compute_holder,
+				&commit_meta,
+				n_transparents,
+				&merkle_prover,
+				log_inv_rate,
+			);
+		}
+
+		#[test]
+		fn test_without_opening_claims() {
+			use binius_core::piop::CommitMeta;
+			use binius_field::PackedBinaryField2x128b;
+			use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
+			use binius_math::{B8, B16, B128};
+
+			let commit_meta = CommitMeta::with_vars([4, 4, 6, 7]);
+			let merkle_prover =
+				BinaryMerkleTreeProver::<_, Groestl256, _>::new(Groestl256ByteCompression);
+			let n_transparents = 0;
+			let log_inv_rate = 1;
+			let compute_holder = <$compute_holder>::new(1 << 14, 1 << 22);
+
+			$crate::piop::commit_prove_verify::<B8, B16, B128, PackedBinaryField2x128b, _, _, _>(
+				compute_holder,
+				&commit_meta,
+				n_transparents,
+				&merkle_prover,
+				log_inv_rate,
+			);
+		}
+
+		#[test]
+		fn test_with_one_n_vars() {
+			use binius_core::piop::CommitMeta;
+			use binius_field::PackedBinaryField2x128b;
+			use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
+			use binius_math::{B8, B16, B128};
+
+			let commit_meta = CommitMeta::with_vars([4, 4]);
+			let merkle_prover =
+				BinaryMerkleTreeProver::<_, Groestl256, _>::new(Groestl256ByteCompression);
+			let n_transparents = 1;
+			let log_inv_rate = 1;
+			let compute_holder = <$compute_holder>::new(1 << 14, 1 << 22);
+
+			$crate::piop::commit_prove_verify::<B8, B16, B128, PackedBinaryField2x128b, _, _, _>(
+				compute_holder,
+				&commit_meta,
+				n_transparents,
+				&merkle_prover,
+				log_inv_rate,
+			);
+		}
+
+		#[test]
+		fn test_commit_prove_verify_extreme_rate() {
+			use binius_core::piop::CommitMeta;
+			use binius_field::PackedBinaryField2x128b;
+			use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
+			use binius_math::{B8, B16, B128};
+
+			let commit_meta = CommitMeta::with_vars([3, 3, 5, 6]);
+			let merkle_prover =
+				BinaryMerkleTreeProver::<_, Groestl256, _>::new(Groestl256ByteCompression);
+			let n_transparents = 2;
+			let log_inv_rate = 8;
+			let compute_holder = <$compute_holder>::new(1 << 14, 1 << 22);
+
+			$crate::piop::commit_prove_verify::<B8, B16, B128, PackedBinaryField2x128b, _, _, _>(
+				compute_holder,
+				&commit_meta,
+				n_transparents,
+				&merkle_prover,
+				log_inv_rate,
+			);
+		}
+
+		#[test]
+		fn test_commit_prove_verify_small() {
+			use binius_core::piop::CommitMeta;
+			use binius_field::PackedBinaryField2x128b;
+			use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
+			use binius_math::{B8, B16, B128};
+
+			let commit_meta = CommitMeta::with_vars([4, 4, 6, 7]);
+			let merkle_prover =
+				BinaryMerkleTreeProver::<_, Groestl256, _>::new(Groestl256ByteCompression);
+			let n_transparents = 2;
+			let log_inv_rate = 1;
+			let compute_holder = <$compute_holder>::new(1 << 14, 1 << 22);
+
+			$crate::piop::commit_prove_verify::<B8, B16, B128, PackedBinaryField2x128b, _, _, _>(
+				compute_holder,
+				&commit_meta,
+				n_transparents,
+				&merkle_prover,
+				log_inv_rate,
+			);
+		}
+
+		#[test]
+		fn test_commit_prove_verify() {
+			use binius_core::piop::CommitMeta;
+			use binius_field::PackedBinaryField2x128b;
+			use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
+			use binius_math::{B8, B16, B128};
+
+			let commit_meta = CommitMeta::with_vars([6, 6, 8, 9]);
+			let merkle_prover =
+				BinaryMerkleTreeProver::<_, Groestl256, _>::new(Groestl256ByteCompression);
+			let n_transparents = 2;
+			let log_inv_rate = 1;
+			let compute_holder = <$compute_holder>::new(1 << 14, 1 << 22);
+
+			$crate::piop::commit_prove_verify::<B8, B16, B128, PackedBinaryField2x128b, _, _, _>(
+				compute_holder,
+				&commit_meta,
+				n_transparents,
+				&merkle_prover,
+				log_inv_rate,
+			);
+		}
+	};
+}

--- a/crates/core/test_utils/src/ring_switch.rs
+++ b/crates/core/test_utils/src/ring_switch.rs
@@ -2,7 +2,7 @@
 
 use std::{cmp::Ordering, iter::repeat_with};
 
-use binius_compute::{ComputeHolder, ComputeLayer};
+use binius_compute::{ComputeData, ComputeHolder, ComputeLayer};
 use binius_core::{
 	fiat_shamir::HasherChallenger,
 	merkle_tree::{MerkleTreeProver, MerkleTreeScheme},
@@ -300,4 +300,118 @@ pub fn commit_prove_verify_piop<U, F, MTScheme, MTProver, Hal, HalHolder>(
 		&mut proof,
 	)
 	.unwrap();
+}
+
+fn with_test_instance_from_oracles<U, F, R>(
+	mut rng: R,
+	oracles: &MultilinearOracleSet<F>,
+	func: impl FnOnce(R, EvalClaimSystem<F>, Vec<MultilinearWitness<PackedType<U, F>>>),
+) where
+	U: TowerUnderlier + PackScalar<F>,
+	F: TowerTop,
+	R: Rng,
+{
+	let (commit_meta, oracle_to_commit_index) = piop::make_oracle_commit_meta(oracles).unwrap();
+
+	let witness_index = generate_multilinears::<U, F>(&mut rng, oracles);
+	let witnesses = piop::collect_committed_witnesses::<U, _>(
+		&commit_meta,
+		&oracle_to_commit_index,
+		oracles,
+		&witness_index,
+	)
+	.unwrap();
+
+	let eval_claims = setup_test_eval_claims::<U, _>(&mut rng, oracles, &witness_index);
+
+	// Finish setting up the test case
+	let system =
+		EvalClaimSystem::new(oracles, &commit_meta, &oracle_to_commit_index, &eval_claims).unwrap();
+	check_eval_point_consistency(&system);
+
+	func(rng, system, witnesses)
+}
+
+pub fn test_prove_verify_claim_reduction_with_naive_validation<U, F, Hal, HalHolder>(
+	create_hal_holder: impl FnOnce(usize, usize) -> HalHolder,
+) where
+	U: TowerUnderlier + PackScalar<F>,
+	PackedType<U, F>: PackedFieldIndexable + PackedTop,
+	F: TowerTop + PackedTop<Scalar = F>,
+	Hal: ComputeLayer<F>,
+	HalHolder: ComputeHolder<F, Hal>,
+{
+	let mut compute_holder = create_hal_holder(1 << 7, 1 << 12);
+
+	let ComputeData {
+		hal,
+		host_alloc,
+		dev_alloc,
+		..
+	} = compute_holder.to_data();
+
+	let rng = StdRng::seed_from_u64(0);
+	let oracles = make_test_oracle_set();
+
+	with_test_instance_from_oracles::<U, F, _>(rng, &oracles, |_rng, system, witnesses| {
+		let mut proof = ProverTranscript::<HasherChallenger<Groestl256>>::new();
+
+		let ReducedWitness {
+			transparents: transparent_witnesses,
+			sumcheck_claims: prover_sumcheck_claims,
+		} = prove(&system, &witnesses, &mut proof, MemoizedData::new(), hal, &dev_alloc, &host_alloc)
+			.unwrap();
+
+		let mut proof = proof.into_verifier();
+		let ReducedClaim {
+			transparents: _,
+			sumcheck_claims: verifier_sumcheck_claims,
+		} = verify(&system, &mut proof).unwrap();
+
+		assert_eq!(prover_sumcheck_claims, verifier_sumcheck_claims);
+
+		piop::validate_sumcheck_witness(
+			&witnesses,
+			&transparent_witnesses,
+			&prover_sumcheck_claims,
+			hal,
+		)
+		.unwrap();
+	});
+}
+
+#[macro_export]
+macro_rules! instantiate_ring_switch_tests {
+	($compute_holder:ty) => {
+		#[test]
+		fn test_prove_verify_piop_integration() {
+			type U = OptimalUnderlier128b;
+			type F = B128;
+
+			let oracles = make_test_oracle_set();
+			let log_inv_rate = 2;
+			let merkle_prover =
+				BinaryMerkleTreeProver::<_, Groestl256, _>::new(Groestl256ByteCompression);
+
+			$crate::ring_switch::commit_prove_verify_piop::<U, F, _, _, _, $compute_holder>(
+				&merkle_prover,
+				&oracles,
+				log_inv_rate,
+				<$compute_holder>::new,
+			);
+		}
+
+		#[test]
+		fn test_prove_verify_claim_reduction_with_naive_validation() {
+			type U = OptimalUnderlier128b;
+			type F = B128;
+
+			$crate::ring_switch::test_prove_verify_claim_reduction_with_naive_validation::<
+				U,
+				F,
+				_,
+				$compute_holder,
+			>(<$compute_holder>::new);
+		}
+	};
 }

--- a/crates/core/tests/ring_switch.rs
+++ b/crates/core/tests/ring_switch.rs
@@ -1,118 +1,26 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use binius_compute::{
-	ComputeData, ComputeHolder,
-	cpu::{CpuLayer, layer::CpuLayerHolder},
-};
-use binius_core::{
-	fiat_shamir::HasherChallenger,
-	merkle_tree::BinaryMerkleTreeProver,
-	oracle::MultilinearOracleSet,
-	piop,
-	protocols::evalcheck::subclaims::MemoizedData,
-	ring_switch::{EvalClaimSystem, ReducedClaim, ReducedWitness, prove, verify},
-	transcript::ProverTranscript,
-	witness::MultilinearWitness,
-};
-use binius_core_test_utils::ring_switch::{
-	check_eval_point_consistency, commit_prove_verify_piop, generate_multilinears,
-	make_test_oracle_set, setup_test_eval_claims,
-};
-use binius_field::{
-	arch::OptimalUnderlier128b,
-	as_packed_field::{PackScalar, PackedType},
-};
+use binius_core::merkle_tree::BinaryMerkleTreeProver;
+use binius_core_test_utils::{instantiate_ring_switch_tests, ring_switch::make_test_oracle_set};
+use binius_field::{arch::OptimalUnderlier128b, as_packed_field::PackedType};
 use binius_hash::groestl::{Groestl256, Groestl256ByteCompression};
-use binius_math::{B128, TowerTop, TowerUnderlier};
-use rand::prelude::*;
+use binius_math::B128;
 
-fn with_test_instance_from_oracles<U, F, R>(
-	mut rng: R,
-	oracles: &MultilinearOracleSet<F>,
-	func: impl FnOnce(R, EvalClaimSystem<F>, Vec<MultilinearWitness<PackedType<U, F>>>),
-) where
-	U: TowerUnderlier + PackScalar<F>,
-	F: TowerTop,
-	R: Rng,
-{
-	let (commit_meta, oracle_to_commit_index) = piop::make_oracle_commit_meta(oracles).unwrap();
+mod cpu_tests {
+	use binius_compute::cpu::layer::CpuLayerHolder;
 
-	let witness_index = generate_multilinears::<U, F>(&mut rng, oracles);
-	let witnesses = piop::collect_committed_witnesses::<U, _>(
-		&commit_meta,
-		&oracle_to_commit_index,
-		oracles,
-		&witness_index,
-	)
-	.unwrap();
+	use super::*;
 
-	let eval_claims = setup_test_eval_claims::<U, _>(&mut rng, oracles, &witness_index);
-
-	// Finish setting up the test case
-	let system =
-		EvalClaimSystem::new(oracles, &commit_meta, &oracle_to_commit_index, &eval_claims).unwrap();
-	check_eval_point_consistency(&system);
-
-	func(rng, system, witnesses)
+	instantiate_ring_switch_tests!(CpuLayerHolder<B128>);
 }
 
-#[test]
-fn test_prove_verify_claim_reduction_with_naive_validation() {
-	type U = OptimalUnderlier128b;
-	type F = B128;
+mod fast_cpu_tests {
+	use binius_fast_compute::layer::FastCpuLayerHolder;
+	use binius_field::tower::CanonicalTowerFamily;
 
-	let mut compute_holder = CpuLayerHolder::<B128>::new(1 << 7, 1 << 12);
+	use super::*;
 
-	let ComputeData {
-		hal,
-		host_alloc,
-		dev_alloc,
-		..
-	} = compute_holder.to_data();
-
-	let rng = StdRng::seed_from_u64(0);
-	let oracles = make_test_oracle_set();
-
-	with_test_instance_from_oracles::<U, F, _>(rng, &oracles, |_rng, system, witnesses| {
-		let mut proof = ProverTranscript::<HasherChallenger<Groestl256>>::new();
-
-		let ReducedWitness {
-			transparents: transparent_witnesses,
-			sumcheck_claims: prover_sumcheck_claims,
-		} = prove(&system, &witnesses, &mut proof, MemoizedData::new(), hal, &dev_alloc, &host_alloc)
-			.unwrap();
-
-		let mut proof = proof.into_verifier();
-		let ReducedClaim {
-			transparents: _,
-			sumcheck_claims: verifier_sumcheck_claims,
-		} = verify(&system, &mut proof).unwrap();
-
-		assert_eq!(prover_sumcheck_claims, verifier_sumcheck_claims);
-
-		piop::validate_sumcheck_witness(
-			&witnesses,
-			&transparent_witnesses,
-			&prover_sumcheck_claims,
-			hal,
-		)
-		.unwrap();
-	});
-}
-
-#[test]
-fn test_prove_verify_piop_integration() {
-	type U = OptimalUnderlier128b;
-	type F = B128;
-
-	let oracles = make_test_oracle_set();
-	let log_inv_rate = 2;
-	let merkle_prover = BinaryMerkleTreeProver::<_, Groestl256, _>::new(Groestl256ByteCompression);
-
-	commit_prove_verify_piop::<U, F, _, _, CpuLayer<F>, CpuLayerHolder<F>>(
-		&merkle_prover,
-		&oracles,
-		log_inv_rate,
-		CpuLayerHolder::new,
+	instantiate_ring_switch_tests!(
+		FastCpuLayerHolder::<CanonicalTowerFamily, PackedType<OptimalUnderlier128b, B128>>
 	);
 }


### PR DESCRIPTION
### TL;DR

Added a macro to instantiate PIOP and ring switch tests for different compute layers.

### What changed?

- Added `instantiate_piop_tests!` macro in `piop.rs` that generates six test cases for different PIOP scenarios
- Added `instantiate_ring_switch_tests!` macro in `ring_switch.rs` that generates two test cases for ring switch functionality
- Refactored existing ring switch tests to use the new macro
- Added helper functions to support the test macros
- Implemented both CPU and FastCPU test modules in `ring_switch.rs`

### How to test?

Run the tests with:
```bash
cargo test --package binius-core
```

The tests will now run for both CPU and FastCPU compute layers, verifying that the PIOP and ring switch functionality works correctly across different implementations.

### Why make this change?

This change improves test coverage by ensuring that PIOP and ring switch functionality works consistently across different compute layer implementations. By using macros to generate the tests, we avoid code duplication while still testing the same functionality with different backends. This makes it easier to add support for new compute layers in the future, as they can simply instantiate these test macros to verify compatibility.