### PR TITLE
SYS-334: remove 'static lifetime bound from `ComputeLayer`

### DIFF
--- a/crates/compute/src/layer.rs
+++ b/crates/compute/src/layer.rs
@@ -19,12 +19,14 @@ use crate::{
 };
 
 /// A hardware abstraction layer (HAL) for compute operations.
-pub trait ComputeLayer<F: Field>: 'static {
+pub trait ComputeLayer<F: Field> {
 	/// The device memory.
 	type DevMem: ComputeMemory<F>;
 
 	/// The executor that can execute operations on the device.
-	type Exec<'a>: ComputeLayerExecutor<F, DevMem = Self::DevMem>;
+	type Exec<'a>: ComputeLayerExecutor<F, DevMem = Self::DevMem>
+	where
+		Self: 'a;
 
 	/// Copy data from the host to the device.
 	///


### PR DESCRIPTION
This bound is not required by Binius. The requirement that all references contained in the HAL must survive for the duration of the program is too strict for ic1.