### PR TITLE
[rand] Update version from 0.8.5 -> 0.9.1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,8 @@
 [build]
 rustdocflags = ["-Dwarnings", "--html-in-header", "doc/katex-header.html"]
 
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
+
 [alias]
 fast_test = "test --tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         expand:
           - runner: "r7a-2xlarge"
             name: "debug-wasm"
-            cmd: "rustup target add wasm32-unknown-unknown && cargo build --package binius_field --target wasm32-unknown-unknown"
+            cmd: "rustup target add wasm32-unknown-unknown && RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo build --package binius_field --target wasm32-unknown-unknown"
           - runner: "r7a-2xlarge"
             name: "debug-amd"
             cmd: "cargo build --tests --benches --examples"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         expand:
           - runner: "r7a-2xlarge"
             name: "debug-wasm"
-            cmd: "rustup target add wasm32-unknown-unknown && RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo build --package binius_field --target wasm32-unknown-unknown"
+            cmd: rustup target add wasm32-unknown-unknown && RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo build --package binius_field --target wasm32-unknown-unknown
           - runner: "r7a-2xlarge"
             name: "debug-amd"
             cmd: "cargo build --tests --benches --examples"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ paste = "1.0.15"
 proc-macro2 = "1.0.81"
 proptest = "1.2.0"
 quote = "1.0.36"
-rand = { version = "0.8.5", default-features = false, features = ["std_rng"] }
+rand = { version = "0.9.1", default-features = false, features = ["std", "std_rng", "thread_rng"] }
 rayon = "1.8.0"
 seq-macro = "0.3.5"
 serde = "1.0.219"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ proc-macro2 = "1.0.81"
 proptest = "1.2.0"
 quote = "1.0.36"
 rand = { version = "0.9.1", default-features = false, features = ["std", "std_rng", "thread_rng"] }
+getrandom = { version = "0.3.3" }
 rayon = "1.8.0"
 seq-macro = "0.3.5"
 serde = "1.0.219"

--- a/crates/compute/Cargo.toml
+++ b/crates/compute/Cargo.toml
@@ -20,4 +20,4 @@ thiserror.workspace = true
 assert_matches.workspace = true
 binius_compute_test_utils = { path = "../compute_test_utils", default-features = false }
 binius_core = { path = "../core", default-features = false }
-rand = { workspace = true, features = ["std"] }
+rand.workspace = true

--- a/crates/compute_test_utils/Cargo.toml
+++ b/crates/compute_test_utils/Cargo.toml
@@ -18,4 +18,4 @@ binius_math = { path = "../math", default-features = false }
 binius_ntt = { path = "../ntt", default-features = false }
 binius_utils = { path = "../utils", default-features = false }
 bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
-rand = { workspace = true, features = ["std"] }
+rand.workspace = true

--- a/crates/compute_test_utils/Cargo.toml
+++ b/crates/compute_test_utils/Cargo.toml
@@ -19,6 +19,3 @@ binius_ntt = { path = "../ntt", default-features = false }
 binius_utils = { path = "../utils", default-features = false }
 bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 rand.workspace = true
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { workspace = true, features = ["wasm_js"] }

--- a/crates/compute_test_utils/Cargo.toml
+++ b/crates/compute_test_utils/Cargo.toml
@@ -19,3 +19,6 @@ binius_ntt = { path = "../ntt", default-features = false }
 binius_utils = { path = "../utils", default-features = false }
 bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 rand.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { workspace = true, features = ["wasm_js"] }

--- a/crates/compute_test_utils/src/bivariate_sumcheck.rs
+++ b/crates/compute_test_utils/src/bivariate_sumcheck.rs
@@ -160,8 +160,8 @@ pub fn generic_test_bivariate_sumcheck_prove_verify<F, Hal, ComputeHolderType>(
 	.collect::<Vec<_>>();
 	let compositions = repeat_with(|| {
 		// Choose 2 distinct indices at random
-		let idx0 = rng.gen_range(0..n_multilins);
-		let idx1 = (idx0 + rng.gen_range(0..n_multilins - 1)) % n_multilins;
+		let idx0 = rng.random_range(0..n_multilins);
+		let idx1 = (idx0 + rng.random_range(0..n_multilins - 1)) % n_multilins;
 		IndexComposition::new(n_multilins, [idx0, idx1], BivariateProduct::default()).unwrap()
 	})
 	.take(n_compositions)
@@ -338,8 +338,8 @@ pub fn generic_test_bivariate_mlecheck_prove_verify<
 
 	let compositions = repeat_with(|| {
 		// Choose 2 distinct indices at random
-		let idx0 = rng.gen_range(0..n_multilins);
-		let idx1 = (idx0 + rng.gen_range(0..n_multilins - 1)) % n_multilins;
+		let idx0 = rng.random_range(0..n_multilins);
+		let idx1 = (idx0 + rng.random_range(0..n_multilins - 1)) % n_multilins;
 		IndexComposition::new(n_multilins, [idx0, idx1], BivariateProduct::default()).unwrap()
 	})
 	.take(n_compositions)

--- a/crates/compute_test_utils/src/layer.rs
+++ b/crates/compute_test_utils/src/layer.rs
@@ -847,7 +847,13 @@ pub fn test_map_kernels<F, Hal, ComputeHolderType>(
 
 	let input_2_host = host_alloc.alloc(1 << log_len).unwrap();
 
-	input_2_host.fill_with(|| if rng.gen_bool(0.5) { F::ONE } else { F::ZERO });
+	input_2_host.fill_with(|| {
+		if rng.random_bool(0.5) {
+			F::ONE
+		} else {
+			F::ZERO
+		}
+	});
 
 	let output_host = host_alloc.alloc(1 << log_len).unwrap();
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -36,12 +36,14 @@ thiserror.workspace = true
 tracing.workspace = true
 tracing-profile.workspace = true
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { workspace = true, features = ["wasm_js"] }
+
 [dev-dependencies]
 binius_compute_test_utils = { path = "../compute_test_utils", default-features = false }
 binius_macros = { path = "../macros", default-features = false }
 criterion.workspace = true
 proptest.workspace = true
-rand.workspace = true
 
 [lib]
 bench = false

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -41,7 +41,7 @@ binius_compute_test_utils = { path = "../compute_test_utils", default-features =
 binius_macros = { path = "../macros", default-features = false }
 criterion.workspace = true
 proptest.workspace = true
-rand = { workspace = true, features = ["std"] }
+rand.workspace = true
 
 [lib]
 bench = false

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -36,9 +36,6 @@ thiserror.workspace = true
 tracing.workspace = true
 tracing-profile.workspace = true
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { workspace = true, features = ["wasm_js"] }
-
 [dev-dependencies]
 binius_compute_test_utils = { path = "../compute_test_utils", default-features = false }
 binius_macros = { path = "../macros", default-features = false }

--- a/crates/core/benches/arith_circuit_poly.rs
+++ b/crates/core/benches/arith_circuit_poly.rs
@@ -9,7 +9,7 @@ use binius_field::{
 };
 use binius_math::{ArithExpr as Expr, CompositionPoly, RowsBatchRef};
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use rand::{RngCore, thread_rng};
+use rand::RngCore;
 
 const BATCH_SIZE: usize = 256;
 
@@ -43,7 +43,7 @@ fn evaluate_arith_circuit_poly<P: PackedField>(
 }
 
 fn benchmark_evaluate(c: &mut Criterion) {
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 
 	let query128x1b = generate_input_data(&mut rng);
 	let query128x1b = query128x1b.iter().map(|q| q.as_slice()).collect::<Vec<_>>();

--- a/crates/core/benches/binary_merkle_tree.rs
+++ b/crates/core/benches/binary_merkle_tree.rs
@@ -11,7 +11,6 @@ use binius_hash::{
 };
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use digest::{FixedOutputReset, Output, core_api::BlockSizeUser};
-use rand::thread_rng;
 
 const LOG_ELEMS: usize = 17;
 const LOG_ELEMS_IN_LEAF: usize = 4;
@@ -24,7 +23,7 @@ where
 	C: PseudoCompressionFunction<Output<H::Digest>, 2> + Sync,
 {
 	let merkle_prover = BinaryMerkleTreeProver::<_, H, C>::new(compression);
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let data: Vec<F> = repeat_with(|| Field::random(&mut rng))
 		.take(1 << (LOG_ELEMS + LOG_ELEMS_IN_LEAF))
 		.collect();

--- a/crates/core/benches/multilinear_query.rs
+++ b/crates/core/benches/multilinear_query.rs
@@ -9,7 +9,7 @@ use binius_math::MultilinearExtension;
 use criterion::{
 	BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
-use rand::{Rng, thread_rng};
+use rand::Rng;
 
 type B1Packed = <BinaryField1b as ArchOptimal>::OptimalThroughputPacked;
 type B128Packed = <BinaryField128b as ArchOptimal>::OptimalThroughputPacked;
@@ -28,7 +28,7 @@ fn generate_scalar<F: Field>(mut rng: impl Rng, log_n: usize) -> Vec<F> {
 
 fn bench_tensor_product_full_query(c: &mut Criterion) {
 	let mut group = c.benchmark_group("tensor_product_full_query");
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let backend = make_portable_backend();
 	for n in [12, 16, 20] {
 		group.throughput(Throughput::Bytes(((1 << n) * size_of::<BinaryField128b>()) as u64));
@@ -42,7 +42,7 @@ fn bench_tensor_product_full_query(c: &mut Criterion) {
 
 fn bench_evaluate(c: &mut Criterion) {
 	let mut group = c.benchmark_group("evaluate");
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let backend = make_portable_backend();
 	for n in [12, 16, 20] {
 		group.throughput(Throughput::Bytes(((1 << n) * size_of::<BinaryField128b>()) as u64));
@@ -66,7 +66,7 @@ fn run_evaluate_partial_high_bench<P, PE>(
 	P: PackedField<Scalar: BinaryField>,
 	PE: PackedField<Scalar: ExtensionField<P::Scalar> + BinaryField>,
 {
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let evals = generate_packed::<P>(&mut rng, log_evals_size);
 	let multilin = MultilinearExtension::from_values(evals).unwrap();
 	let query = generate_scalar::<PE::Scalar>(&mut rng, log_query_size);
@@ -103,7 +103,7 @@ fn bench_evaluate_partial_high(c: &mut Criterion) {
 
 fn bench_evaluate_partial_low(c: &mut Criterion) {
 	let mut group = c.benchmark_group("evaluate_partial_low");
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let backend = make_portable_backend();
 	for n in [12, 16, 20] {
 		group.throughput(Throughput::Bytes(((1 << n) * size_of::<BinaryField128b>()) as u64));

--- a/crates/core/benches/poly_commit.rs
+++ b/crates/core/benches/poly_commit.rs
@@ -18,7 +18,6 @@ use binius_math::{MLEDirectAdapter, MultilinearExtension, MultilinearPoly};
 use binius_ntt::SingleThreadedNTT;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use itertools::Itertools;
-use rand::thread_rng;
 
 fn merge_multilins<P, M>(multilins: &[M], message_buffer: &mut [P])
 where
@@ -99,7 +98,7 @@ where
 	const LOG_INV_RATE: usize = 1;
 	const SECURITY_BITS: usize = 100;
 
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let poly_data = repeat_with(|| P::random(&mut rng))
 		.take(1 << LOG_SIZE.saturating_sub(P::LOG_WIDTH))
 		.collect::<Vec<_>>();

--- a/crates/core/benches/sumcheck.rs
+++ b/crates/core/benches/sumcheck.rs
@@ -29,7 +29,6 @@ use binius_math::{
 };
 use binius_maybe_rayon::prelude::*;
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
-use rand::thread_rng;
 
 fn bench_bivariate_with_evaluation_order<
 	F: TowerField + ExtensionField<FDomain>,
@@ -41,7 +40,7 @@ fn bench_bivariate_with_evaluation_order<
 	eval_order: EvaluationOrder,
 	n_vars: usize,
 ) {
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let multilins = repeat_with(|| {
 		let values = repeat_with(|| P::random(&mut rng))
 			.take(1 << n_vars.saturating_sub(P::LOG_WIDTH))
@@ -119,7 +118,7 @@ fn bench_sumcheck_v3<T: TowerFamily, P: PackedTop<T>>(
 	field: &str,
 	n_vars: usize,
 ) {
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let multilins = repeat_with(|| {
 		let values = repeat_with(|| P::random(&mut rng))
 			.take(1 << n_vars.saturating_sub(P::LOG_WIDTH))

--- a/crates/core/src/fiat_shamir/hasher_challenger.rs
+++ b/crates/core/src/fiat_shamir/hasher_challenger.rs
@@ -202,7 +202,7 @@ where
 #[cfg(test)]
 mod tests {
 	use binius_hash::groestl::Groestl256;
-	use rand::{RngCore, thread_rng};
+	use rand::RngCore;
 
 	use super::*;
 
@@ -259,7 +259,7 @@ mod tests {
 
 		// first observing
 		let mut observable = [0u8; 1019];
-		thread_rng().fill_bytes(&mut observable);
+		rand::rng().fill_bytes(&mut observable);
 		challenger.observer().put_slice(&observable[..39]);
 		challenger.observer().put_slice(&observable[39..300]);
 		challenger.observer().put_slice(&observable[300..987]);
@@ -277,7 +277,7 @@ mod tests {
 		assert_eq!(first_hash_out[..7], out);
 
 		// second observing
-		thread_rng().fill_bytes(&mut observable);
+		rand::rng().fill_bytes(&mut observable);
 		challenger.observer().put_slice(&observable[..128]);
 		hasher.update([7, 0, 0, 0, 0, 0, 0, 0]);
 

--- a/crates/core/src/protocols/fri/tests.rs
+++ b/crates/core/src/protocols/fri/tests.rs
@@ -42,10 +42,10 @@ proptest! {
 fn test_help_fri_compatible_ntt_domains(log_dim: usize, arity: usize) {
 	let ntt = SingleThreadedNTT::<BinaryField32b>::new(32).unwrap();
 
-	let msg = repeat_with(|| BinaryField32b::random(&mut thread_rng()))
+	let msg = repeat_with(|| BinaryField32b::random(&mut rand::rng()))
 		.take(1 << (log_dim + arity))
 		.collect::<Vec<_>>();
-	let challenges = repeat_with(|| BinaryField32b::random(&mut thread_rng()))
+	let challenges = repeat_with(|| BinaryField32b::random(&mut rand::rng()))
 		.take(arity)
 		.collect::<Vec<_>>();
 

--- a/crates/core/src/protocols/gkr_exp/tests.rs
+++ b/crates/core/src/protocols/gkr_exp/tests.rs
@@ -11,7 +11,7 @@ use binius_math::{
 	DefaultEvaluationDomainFactory, EvaluationOrder, MLEEmbeddingAdapter, MultilinearExtension,
 	MultilinearPoly, MultilinearQuery, MultilinearQueryRef,
 };
-use rand::{Rng, thread_rng};
+use rand::Rng;
 
 use super::{batch_prove, common::BaseExpReductionOutput};
 use crate::{
@@ -100,13 +100,13 @@ fn generate_claim_witness<'a>(
 fn generate_mul_witnesses_claims<'a, const LOG_SIZE: usize, const COLUMN_LEN: usize>(
 	exponent_bit_width: usize,
 ) -> (Vec<ExpClaim<F>>, Vec<BaseExpWitness<'a, P>>) {
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 
 	let a: Vec<_> = (0..COLUMN_LEN)
-		.map(|_| rng.r#gen::<u64>() % (1 << exponent_bit_width))
+		.map(|_| rng.random::<u64>() % (1 << exponent_bit_width))
 		.collect();
 	let b: Vec<_> = (0..COLUMN_LEN)
-		.map(|_| rng.r#gen::<u64>() % (1 << exponent_bit_width))
+		.map(|_| rng.random::<u64>() % (1 << exponent_bit_width))
 		.collect();
 	let c: Vec<_> = a.iter().zip(&b).map(|(ai, bi)| ai * bi).collect();
 
@@ -164,13 +164,13 @@ fn witness_gen_happens_correctly() {
 	const COLUMN_LEN: usize = 1usize << LOG_SIZE;
 	const EXPONENT_BIT_WIDTH: usize = 4usize;
 
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 
 	let a: Vec<_> = (0..COLUMN_LEN)
-		.map(|_| (rng.gen_range(0..1 << EXPONENT_BIT_WIDTH)) as u64)
+		.map(|_| (rng.random_range(0..1 << EXPONENT_BIT_WIDTH)) as u64)
 		.collect();
 	let b: Vec<_> = (0..COLUMN_LEN)
-		.map(|_| (rng.gen_range(0..1 << EXPONENT_BIT_WIDTH)) as u64)
+		.map(|_| (rng.random_range(0..1 << EXPONENT_BIT_WIDTH)) as u64)
 		.collect();
 	let c: Vec<_> = a.iter().zip(&b).map(|(ai, bi)| ai * bi).collect();
 

--- a/crates/core/src/protocols/sumcheck/eq_ind.rs
+++ b/crates/core/src/protocols/sumcheck/eq_ind.rs
@@ -282,7 +282,7 @@ mod tests {
 
 		let mut rng = StdRng::seed_from_u64(0);
 		for _ in 0..n_vars + 5 {
-			nonzero_prefixes.push(rng.gen_range(1..max_nonzero_prefix));
+			nonzero_prefixes.push(rng.random_range(1..max_nonzero_prefix));
 		}
 
 		for nonzero_prefix in nonzero_prefixes {

--- a/crates/core/src/transcript/mod.rs
+++ b/crates/core/src/transcript/mod.rs
@@ -523,7 +523,7 @@ mod tests {
 		BinaryField32b, BinaryField64b, BinaryField128b, BinaryField128bPolyval,
 	};
 	use binius_hash::groestl::Groestl256;
-	use rand::{RngCore, thread_rng};
+	use rand::RngCore;
 
 	use super::*;
 	use crate::fiat_shamir::HasherChallenger;
@@ -638,7 +638,7 @@ mod tests {
 
 		const NUM_SAMPLING: usize = 32;
 		let mut random_bytes = [0u8; NUM_SAMPLING * 8];
-		thread_rng().fill_bytes(&mut random_bytes);
+		rand::rng().fill_bytes(&mut random_bytes);
 		let mut sampled_arrays = [[0u8; 8]; NUM_SAMPLING];
 
 		for i in 0..NUM_SAMPLING {

--- a/crates/fast_compute/Cargo.toml
+++ b/crates/fast_compute/Cargo.toml
@@ -23,4 +23,4 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 binius_compute_test_utils = { path = "../compute_test_utils", default-features = false }
-rand = { workspace = true, features = ["std"] }
+rand.workspace = true

--- a/crates/field/Cargo.toml
+++ b/crates/field/Cargo.toml
@@ -21,6 +21,9 @@ transpose.workspace = true
 tracing.workspace = true
 trait-set.workspace = true
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { workspace = true, features = ["wasm_js"] }
+
 [dev-dependencies]
 criterion.workspace = true
 itertools.workspace = true

--- a/crates/field/benches/binary_field.rs
+++ b/crates/field/benches/binary_field.rs
@@ -12,7 +12,6 @@ use binius_field::{
 use criterion::{
 	BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::Measurement,
 };
-use rand::thread_rng;
 
 const BATCH_SIZE: usize = 32;
 
@@ -21,7 +20,7 @@ fn bench_function<F: Field, M: Measurement, R>(
 	id: &str,
 	func: impl Fn(F, F) -> R,
 ) {
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let a: [F; BATCH_SIZE] = array::from_fn(|_| F::random(&mut rng));
 	let b: [F; BATCH_SIZE] = array::from_fn(|_| F::random(&mut rng));
 	c.bench_function(id, |bench| {

--- a/crates/field/benches/binary_field_util.rs
+++ b/crates/field/benches/binary_field_util.rs
@@ -16,7 +16,7 @@ pub fn bench_inner_product_par<FX, PX, PY>(
 	PY: PackedField,
 	FX: ExtensionField<PY::Scalar>,
 {
-	let mut rng = rand::thread_rng();
+	let mut rng = rand::rng();
 	for count in counts {
 		let xs = repeat_with(|| PX::random(&mut rng))
 			.take(count)

--- a/crates/field/benches/byte_iteration.rs
+++ b/crates/field/benches/byte_iteration.rs
@@ -17,7 +17,7 @@ pub fn bench_create_partial_sums<P>(
 ) where
 	P: PackedField + Clone,
 {
-	let mut rng = rand::thread_rng();
+	let mut rng = rand::rng();
 
 	for count in counts {
 		let count = count.next_power_of_two().max(8);

--- a/crates/field/benches/byte_sliced.rs
+++ b/crates/field/benches/byte_sliced.rs
@@ -4,11 +4,10 @@ use std::hint::black_box;
 
 use binius_field::{PackedField, arch::byte_sliced::*};
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use rand::thread_rng;
 
 macro_rules! bench_transform_to_byte_sliced {
 	($byte_sliced:ty, $group:ident) => {{
-		let mut rng = thread_rng();
+		let mut rng = rand::rng();
 		let original = std::array::from_fn(|_| PackedField::random(&mut rng));
 
 		$group.throughput(Throughput::Elements(<$byte_sliced>::WIDTH as _));
@@ -20,7 +19,7 @@ macro_rules! bench_transform_to_byte_sliced {
 
 macro_rules! bench_transform_from_byte_sliced {
 	($byte_sliced:ty, $group:ident) => {{
-		let mut rng = thread_rng();
+		let mut rng = rand::rng();
 		let original = <$byte_sliced>::random(&mut rng);
 		let mut target = std::array::from_fn(|_| PackedField::zero());
 

--- a/crates/field/benches/packed_extension_mul.rs
+++ b/crates/field/benches/packed_extension_mul.rs
@@ -8,7 +8,6 @@ use binius_field::{
 	packed::set_packed_slice_unchecked,
 };
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use rand::thread_rng;
 
 // Constants for input sizes
 const EXT_WIDTH: usize = 64 * 1024; // Fixed extension width
@@ -20,7 +19,7 @@ fn benchmark_packed_extension_mul<F>(
 	F: Field,
 	PackedBinaryField2x128b: PackedExtension<F>,
 {
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 
 	// Compute base width based on extension width and field degree
 	let base_width: usize = EXT_WIDTH / <BinaryField128b as ExtensionField<F>>::DEGREE;

--- a/crates/field/benches/packed_field_element_access.rs
+++ b/crates/field/benches/packed_field_element_access.rs
@@ -9,17 +9,14 @@ use binius_field::{
 use criterion::{
 	BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
-use rand::{
-	distributions::{Distribution, Uniform},
-	thread_rng,
-};
+use rand::distr::{Distribution, Uniform};
 
 const BATCH_SIZE: usize = 32;
 
 fn benchmark_get_impl<P: PackedField>(group: &mut BenchmarkGroup<'_, WallTime>, id: &str) {
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let value = P::random(&mut rng);
-	let distr = Uniform::<usize>::new(0, P::WIDTH);
+	let distr = Uniform::<usize>::new(0, P::WIDTH).expect("Failed to create uniform distribution");
 	let indices = array::from_fn::<_, BATCH_SIZE, _>(|_| distr.sample(&mut rng));
 
 	group.throughput(Throughput::Elements(BATCH_SIZE as _));
@@ -27,9 +24,9 @@ fn benchmark_get_impl<P: PackedField>(group: &mut BenchmarkGroup<'_, WallTime>, 
 }
 
 fn benchmark_set_impl<P: PackedField>(group: &mut BenchmarkGroup<'_, WallTime>, id: &str) {
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let mut value = P::random(&mut rng);
-	let distr = Uniform::<usize>::new(0, P::WIDTH);
+	let distr = Uniform::<usize>::new(0, P::WIDTH).expect("Failed to create uniform distribution");
 	let indices_values = array::from_fn::<_, BATCH_SIZE, _>(|_| {
 		(distr.sample(&mut rng), P::Scalar::random(&mut rng))
 	});

--- a/crates/field/benches/packed_field_init.rs
+++ b/crates/field/benches/packed_field_init.rs
@@ -9,12 +9,11 @@ use binius_field::{
 use criterion::{
 	BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
-use rand::thread_rng;
 
 const BATCH_SIZE: usize = 32;
 
 fn benchmark_get_impl<P: PackedField>(group: &mut BenchmarkGroup<'_, WallTime>, id: &str) {
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let values = array::from_fn::<_, BATCH_SIZE, _>(|_| {
 		(0..P::WIDTH)
 			.map(|_| P::Scalar::random(&mut rng))

--- a/crates/field/benches/packed_field_iter.rs
+++ b/crates/field/benches/packed_field_iter.rs
@@ -9,10 +9,9 @@ use binius_field::{
 use criterion::{
 	BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
-use rand::thread_rng;
 
 fn benchmark_iter<P: PackedField>(group: &mut BenchmarkGroup<'_, WallTime>, id: &str) {
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let value = P::random(&mut rng);
 
 	group.throughput(Throughput::Elements(P::WIDTH as _));

--- a/crates/field/benches/packed_field_linear_transform.rs
+++ b/crates/field/benches/packed_field_linear_transform.rs
@@ -15,7 +15,6 @@ use binius_field::{
 use cfg_if::cfg_if;
 use criterion::criterion_main;
 use packed_field_utils::benchmark_packed_operation;
-use rand::thread_rng;
 
 mod packed_field_utils;
 
@@ -24,7 +23,7 @@ trait TransformToSelfFactory: PackedTransformationFactory<Self> {}
 impl<T: PackedTransformationFactory<Self>> TransformToSelfFactory for T {}
 
 fn create_transformation_main<PT: TransformToSelfFactory>() -> impl Transformation<PT, PT> {
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let bases: Vec<_> = (0..PT::Scalar::DEGREE)
 		.map(|_| PT::Scalar::random(&mut rng))
 		.collect();
@@ -52,7 +51,7 @@ cfg_if! {
 
 		fn create_transformation_pairwise<PT: TaggedTransformToSelfFactory<PairwiseStrategy>>(
 		) -> impl Transformation<PT, PT> {
-			let mut rng = thread_rng();
+			let mut rng = rand::rng();
 			let bases: Vec<_> = (0..PT::Scalar::DEGREE)
 				.map(|_| PT::Scalar::random(&mut rng))
 				.collect();
@@ -63,7 +62,7 @@ cfg_if! {
 
 		fn create_transformation_packed<PT: TaggedTransformToSelfFactory<PackedStrategy>>(
 		) -> impl Transformation<PT, PT> {
-			let mut rng = thread_rng();
+			let mut rng = rand::rng();
 			let bases: Vec<_> = (0..PT::Scalar::DEGREE)
 				.map(|_| PT::Scalar::random(&mut rng))
 				.collect();
@@ -74,7 +73,7 @@ cfg_if! {
 
 		fn create_transformation_simd<PT: TaggedTransformToSelfFactory<SimdStrategy>>(
 		) -> impl Transformation<PT, PT> {
-			let mut rng = thread_rng();
+			let mut rng = rand::rng();
 			let bases: Vec<_> = (0..PT::Scalar::DEGREE)
 				.map(|_| PT::Scalar::random(&mut rng))
 				.collect();

--- a/crates/field/benches/packed_field_slice_iter.rs
+++ b/crates/field/benches/packed_field_slice_iter.rs
@@ -13,7 +13,6 @@ use binius_field::{
 use criterion::{
 	BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
-use rand::thread_rng;
 
 fn benchmark_iter_impl<P: PackedField>(
 	group: &mut BenchmarkGroup<'_, WallTime>,
@@ -21,7 +20,7 @@ fn benchmark_iter_impl<P: PackedField>(
 	len: usize,
 	skip: Option<usize>,
 ) {
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let values = repeat_with(|| P::random(&mut rng))
 		.take(len)
 		.collect::<Vec<P>>();

--- a/crates/field/benches/packed_field_spread.rs
+++ b/crates/field/benches/packed_field_spread.rs
@@ -11,7 +11,6 @@ use binius_field::{
 use criterion::{
 	BenchmarkGroup, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
-use rand::thread_rng;
 
 const BATCH_SIZE: usize = 32;
 
@@ -21,7 +20,7 @@ fn benchmark_get_impl<P: PackedField>(
 	id: &str,
 	log_block_len: usize,
 ) {
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let values = array::from_fn::<_, BATCH_SIZE, _>(|_| P::random(&mut rng));
 
 	group.throughput(Throughput::Elements(P::WIDTH as _));

--- a/crates/field/benches/packed_field_subfield_ops.rs
+++ b/crates/field/benches/packed_field_subfield_ops.rs
@@ -13,12 +13,11 @@ use binius_field::{
 use criterion::{
 	BenchmarkGroup, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
-use rand::thread_rng;
 
 const BATCH_SIZE: usize = 32;
 
 fn bench_mul_subfield<PE: PackedExtension<F>, F: Field>(group: &mut BenchmarkGroup<'_, WallTime>) {
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let packed: [PE; BATCH_SIZE] = array::from_fn(|_| PE::random(&mut rng));
 	let scalars: [F; BATCH_SIZE] = array::from_fn(|_| F::random(&mut rng));
 

--- a/crates/field/benches/packed_field_utils.rs
+++ b/crates/field/benches/packed_field_utils.rs
@@ -173,7 +173,7 @@ macro_rules! benchmark_packed_operation {
                 group.measurement_time(core::time::Duration::from_secs(3));
                 group.throughput(criterion::Throughput::Elements((<$packed_field as binius_field::PackedField>::WIDTH *  $crate::packed_field_utils::BATCH_SIZE) as _));
 
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
                 let a: $crate::packed_field_utils::Batch<$packed_field> = std::array::from_fn(|_| <$packed_field as binius_field::PackedField>::random(&mut rng));
                 let b: $crate::packed_field_utils::Batch<$packed_field> = std::array::from_fn(|_| <$packed_field as binius_field::PackedField>::random(&mut rng));
 

--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -352,7 +352,6 @@ serialize_deserialize_non_canonical!(AESTowerField128b, canonical = BinaryField1
 mod tests {
 	use binius_utils::{SerializationMode, SerializeBytes, bytes::BytesMut};
 	use proptest::{arbitrary::any, proptest};
-	use rand::thread_rng;
 
 	use super::*;
 	use crate::{
@@ -650,7 +649,7 @@ mod tests {
 	#[test]
 	fn test_canonical_serialization() {
 		let mut buffer = BytesMut::new();
-		let mut rng = thread_rng();
+		let mut rng = rand::rng();
 		let aes8 = <AESTowerField8b as Field>::random(&mut rng);
 		let aes16 = <AESTowerField16b as Field>::random(&mut rng);
 		let aes32 = <AESTowerField32b as Field>::random(&mut rng);

--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -609,7 +609,7 @@ mod tests {
 
 		let mut rng = StdRng::from_seed([0; 32]);
 
-		let original_value = M128::from(rng.r#gen::<u128>());
+		let original_value = M128::from(rng.random::<u128>());
 
 		let mut buf = BytesMut::new();
 		original_value.serialize(&mut buf, mode).unwrap();

--- a/crates/field/src/arch/portable/byte_sliced/mod.rs
+++ b/crates/field/src/arch/portable/byte_sliced/mod.rs
@@ -12,7 +12,7 @@ pub use underlier::ByteSlicedUnderlier;
 #[cfg(test)]
 pub mod tests {
 	use proptest::prelude::*;
-	use rand::{Rng, SeedableRng, distributions::Uniform, rngs::StdRng};
+	use rand::{Rng, SeedableRng, distr::Uniform, rngs::StdRng};
 
 	use super::*;
 	use crate::{
@@ -187,7 +187,7 @@ pub mod tests {
 						let mut rng = StdRng::seed_from_u64(0);
 						for log_block_len in 0..<$name>::LOG_WIDTH {
 							// iterating over all possible block lengths is too slow
-							let distribution = Uniform::from(0..(1 << (<$name>::LOG_WIDTH - log_block_len)));
+							let distribution = Uniform::new(0, (1 << (<$name>::LOG_WIDTH - log_block_len))).expect("Failed to create uniform distribution");
 							let block_index = rng.sample(distribution);
 
 							let bytesliced_result = bytesliced.spread(log_block_len, block_index);

--- a/crates/field/src/arch/portable/packed_arithmetic.rs
+++ b/crates/field/src/arch/portable/packed_arithmetic.rs
@@ -405,8 +405,6 @@ where
 mod tests {
 	use std::fmt::Debug;
 
-	use rand::thread_rng;
-
 	use super::*;
 	use crate::{
 		BinaryField1b, BinaryField2b, BinaryField4b, BinaryField8b, BinaryField16b, BinaryField32b,
@@ -486,7 +484,7 @@ mod tests {
 		P: PackedField + MulAlpha + Debug,
 		P::Scalar: MulAlpha,
 	{
-		let mut rng = thread_rng();
+		let mut rng = rand::rng();
 
 		for _ in 0..NUM_TESTS {
 			let a = P::random(&mut rng);

--- a/crates/field/src/arch/portable/packed_scaled.rs
+++ b/crates/field/src/arch/portable/packed_scaled.rs
@@ -605,8 +605,8 @@ mod tests {
 
 		let mut rng = StdRng::seed_from_u64(0);
 
-		let byte_low: u8 = rng.r#gen();
-		let byte_high: u8 = rng.r#gen();
+		let byte_low: u8 = rng.random();
+		let byte_high: u8 = rng.random();
 
 		let combined_underlier = ((byte_high as u16) << 8) | (byte_low as u16);
 

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -320,7 +320,7 @@ impl ConditionallySelectable for M128 {
 
 impl Random for M128 {
 	fn random(mut rng: impl RngCore) -> Self {
-		let val: u128 = rng.r#gen();
+		let val: u128 = rng.random();
 		val.into()
 	}
 }
@@ -1139,7 +1139,7 @@ mod tests {
 
 		let mut rng = StdRng::from_seed([0; 32]);
 
-		let original_value = M128::from(rng.r#gen::<u128>());
+		let original_value = M128::from(rng.random::<u128>());
 
 		let mut buf = BytesMut::new();
 		original_value.serialize(&mut buf, mode).unwrap();

--- a/crates/field/src/arch/x86_64/m256.rs
+++ b/crates/field/src/arch/x86_64/m256.rs
@@ -329,7 +329,7 @@ impl ConditionallySelectable for M256 {
 
 impl Random for M256 {
 	fn random(mut rng: impl RngCore) -> Self {
-		let val: [u128; 2] = rng.r#gen();
+		let val: [u128; 2] = rng.random();
 		val.into()
 	}
 }
@@ -1547,7 +1547,7 @@ mod tests {
 
 		let mut rng = StdRng::from_seed([0; 32]);
 
-		let original_value = M256::from([rng.r#gen::<u128>(), rng.r#gen::<u128>()]);
+		let original_value = M256::from([rng.random::<u128>(), rng.random::<u128>()]);
 
 		let mut buf = BytesMut::new();
 		original_value.serialize(&mut buf, mode).unwrap();

--- a/crates/field/src/arch/x86_64/m512.rs
+++ b/crates/field/src/arch/x86_64/m512.rs
@@ -380,7 +380,7 @@ impl ConditionallySelectable for M512 {
 
 impl Random for M512 {
 	fn random(mut rng: impl RngCore) -> Self {
-		let val: [u128; 4] = rng.r#gen();
+		let val: [u128; 4] = rng.random();
 		val.into()
 	}
 }
@@ -1748,7 +1748,7 @@ mod tests {
 
 		let mut rng = StdRng::from_seed([0; 32]);
 
-		let original_value = M512::from(core::array::from_fn(|_| rng.r#gen::<u128>()));
+		let original_value = M512::from(core::array::from_fn(|_| rng.random::<u128>()));
 
 		let mut buf = BytesMut::new();
 		original_value.serialize(&mut buf, mode).unwrap();

--- a/crates/field/src/packed_binary_field.rs
+++ b/crates/field/src/packed_binary_field.rs
@@ -223,7 +223,7 @@ pub mod test_utils {
 
 					// TODO: think how we can use random seed from proptests here
 					let field_transformation =
-						FieldLinearTransformation::<T::Scalar, _>::random(rand::thread_rng());
+						FieldLinearTransformation::<T::Scalar, _>::random(rand::rng());
 					let packed_transformation =
 						T::make_packed_transformation(field_transformation.clone());
 
@@ -873,7 +873,7 @@ mod tests {
 
 	use binius_utils::{DeserializeBytes, SerializationMode, SerializeBytes, bytes::BytesMut};
 	use proptest::prelude::*;
-	use rand::{Rng, SeedableRng, rngs::StdRng, thread_rng};
+	use rand::{Rng, SeedableRng, rngs::StdRng};
 	use test_utils::{check_interleave_all_heights, implements_transformation_factory};
 
 	use super::{
@@ -1088,32 +1088,32 @@ mod tests {
 
 	#[test]
 	fn test_mul_packed_256x1b() {
-		test_mul_packed_random::<PackedBinaryField256x1b>(thread_rng())
+		test_mul_packed_random::<PackedBinaryField256x1b>(rand::rng())
 	}
 
 	#[test]
 	fn test_mul_packed_32x8b() {
-		test_mul_packed_random::<PackedBinaryField32x8b>(thread_rng())
+		test_mul_packed_random::<PackedBinaryField32x8b>(rand::rng())
 	}
 
 	#[test]
 	fn test_mul_packed_16x16b() {
-		test_mul_packed_random::<PackedBinaryField16x16b>(thread_rng())
+		test_mul_packed_random::<PackedBinaryField16x16b>(rand::rng())
 	}
 
 	#[test]
 	fn test_mul_packed_8x32b() {
-		test_mul_packed_random::<PackedBinaryField8x32b>(thread_rng())
+		test_mul_packed_random::<PackedBinaryField8x32b>(rand::rng())
 	}
 
 	#[test]
 	fn test_mul_packed_4x64b() {
-		test_mul_packed_random::<PackedBinaryField4x64b>(thread_rng())
+		test_mul_packed_random::<PackedBinaryField4x64b>(rand::rng())
 	}
 
 	#[test]
 	fn test_mul_packed_2x128b() {
-		test_mul_packed_random::<PackedBinaryField2x128b>(thread_rng())
+		test_mul_packed_random::<PackedBinaryField2x128b>(rand::rng())
 	}
 
 	#[test]

--- a/crates/field/src/polyval.rs
+++ b/crates/field/src/polyval.rs
@@ -263,7 +263,7 @@ impl Field for BinaryField128bPolyval {
 	const CHARACTERISTIC: usize = 2;
 
 	fn random(mut rng: impl RngCore) -> Self {
-		Self(rng.r#gen())
+		Self(rng.random())
 	}
 
 	fn double(&self) -> Self {
@@ -1075,7 +1075,6 @@ pub fn is_polyval_tower<F: TowerField>() -> bool {
 mod tests {
 	use binius_utils::{SerializationMode, SerializeBytes, bytes::BytesMut};
 	use proptest::prelude::*;
-	use rand::thread_rng;
 
 	use super::*;
 	use crate::{
@@ -1232,7 +1231,7 @@ mod tests {
 	fn test_canonical_serialization() {
 		let mode = SerializationMode::CanonicalTower;
 		let mut buffer = BytesMut::new();
-		let mut rng = thread_rng();
+		let mut rng = rand::rng();
 
 		let b128_poly1 = <BinaryField128bPolyval as Field>::random(&mut rng);
 		let b128_poly2 = <BinaryField128bPolyval as Field>::random(&mut rng);

--- a/crates/field/src/underlier/small_uint.rs
+++ b/crates/field/src/underlier/small_uint.rs
@@ -14,10 +14,7 @@ use binius_utils::{
 };
 use bytemuck::{NoUninit, Zeroable};
 use derive_more::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign};
-use rand::{
-	RngCore,
-	distributions::{Distribution, Uniform},
-};
+use rand::Rng;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 
 use super::{Random, UnderlierType, underlier_with_bit_ops::UnderlierWithBitOps};
@@ -112,10 +109,8 @@ impl<const N: usize> ConditionallySelectable for SmallU<N> {
 }
 
 impl<const N: usize> Random for SmallU<N> {
-	fn random(mut rng: impl RngCore) -> Self {
-		let distr = Uniform::from(0u8..1u8 << N);
-
-		Self(distr.sample(&mut rng))
+	fn random(mut rng: impl Rng) -> Self {
+		Self(rng.random_range(0..1u8 << N))
 	}
 }
 

--- a/crates/field/src/underlier/underlier_type.rs
+++ b/crates/field/src/underlier/underlier_type.rs
@@ -3,10 +3,7 @@
 use std::fmt::Debug;
 
 use bytemuck::{NoUninit, Zeroable};
-use rand::{
-	Rng, RngCore,
-	distributions::{Distribution, Standard},
-};
+use rand::distr::{Distribution, StandardUniform};
 use subtle::ConstantTimeEq;
 
 /// Primitive integer underlying a binary field or packed binary field implementation.
@@ -167,15 +164,15 @@ unsafe impl<U: UnderlierType> WithUnderlier for U {
 /// A value that can be randomly generated
 pub trait Random {
 	/// Generate random value
-	fn random(rng: impl RngCore) -> Self;
+	fn random(rng: impl rand::Rng) -> Self;
 }
 
 impl<T> Random for T
 where
-	Standard: Distribution<T>,
+	StandardUniform: Distribution<T>,
 {
-	fn random(mut rng: impl RngCore) -> Self {
-		rng.r#gen()
+	fn random(mut rng: impl rand::Rng) -> Self {
+		rng.random()
 	}
 }
 

--- a/crates/hash/Cargo.toml
+++ b/crates/hash/Cargo.toml
@@ -25,7 +25,7 @@ criterion.workspace = true
 groestl_crypto.workspace = true
 hex-literal.workspace = true
 proptest.workspace = true
-rand = { workspace = true, features = ["std", "std_rng"] }
+rand.workspace = true
 
 [features]
 default = ["nightly_features"]

--- a/crates/hash/benches/hash.rs
+++ b/crates/hash/benches/hash.rs
@@ -11,12 +11,12 @@ use binius_hash::{
 use binius_maybe_rayon::{iter::IntoParallelRefIterator, prelude::ParallelIterator};
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use digest::{Digest, consts::U32, generic_array::GenericArray};
-use rand::{RngCore, thread_rng};
+use rand::RngCore;
 
 fn bench_groestl(c: &mut Criterion) {
 	let mut group = c.benchmark_group("Grøstl");
 
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 
 	const N: usize = 1 << 16;
 	let mut data = vec![0u8; N];
@@ -61,7 +61,7 @@ fn bench_groestl(c: &mut Criterion) {
 fn bench_vision32(c: &mut Criterion) {
 	let mut group = c.benchmark_group("Vision Mark-32");
 
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 
 	const N: usize = 1 << 16;
 	let mut data = [0u8; N];

--- a/crates/m3/src/builder/witness.rs
+++ b/crates/m3/src/builder/witness.rs
@@ -1569,7 +1569,7 @@ mod tests {
 		let table_index = index.init_table(test_table.id(), table_size).unwrap();
 
 		let mut rng = StdRng::seed_from_u64(0);
-		let rows = repeat_with(|| rng.r#gen())
+		let rows = repeat_with(|| rng.random())
 			.take(table_size)
 			.collect::<Vec<_>>();
 
@@ -1614,7 +1614,7 @@ mod tests {
 		let table_index = index.init_table(test_table.id(), table_size).unwrap();
 
 		let mut rng = StdRng::seed_from_u64(0);
-		let rows = repeat_with(|| rng.r#gen())
+		let rows = repeat_with(|| rng.random())
 			.take(table_size)
 			.collect::<Vec<_>>();
 

--- a/crates/m3/src/gadgets/add.rs
+++ b/crates/m3/src/gadgets/add.rs
@@ -492,8 +492,8 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let test_vector: Vec<(u32, u32, u32, u32, bool)> = (0..N_ITER)
 			.map(|_| {
-				let x: u32 = rng.r#gen();
-				let y: u32 = rng.r#gen();
+				let x: u32 = rng.random();
+				let y: u32 = rng.random();
 				let (z, carry) = x.overflowing_add(y);
 				// (x, y, carry_in, zout, final_carry)
 				(x, y, 0x00000000, z, carry)
@@ -516,9 +516,9 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let test_vector: Vec<(u32, u32, u32, u32, bool)> = (0..N_ITER)
 			.map(|_| {
-				let x: u32 = rng.r#gen();
-				let y: u32 = rng.r#gen();
-				let carry_in = rng.r#gen::<bool>() as u32;
+				let x: u32 = rng.random();
+				let y: u32 = rng.random();
+				let carry_in = rng.random::<bool>() as u32;
 				let (x_plus_y, carry1) = x.overflowing_add(y);
 				let (z, carry2) = x_plus_y.overflowing_add(carry_in);
 				let final_carry = carry1 | carry2;
@@ -648,7 +648,7 @@ mod tests {
 
 		let table_id = table.id();
 		let mut rng = StdRng::seed_from_u64(0);
-		let test_values = repeat_with(|| B32::new(rng.r#gen::<u32>()))
+		let test_values = repeat_with(|| B32::new(rng.random::<u32>()))
 			.take(TABLE_SIZE)
 			.collect::<Vec<_>>();
 
@@ -708,7 +708,7 @@ mod tests {
 
 		let mut rng = StdRng::seed_from_u64(0);
 		let test_values: Vec<(u32, u32)> = (0..TABLE_SIZE << LOG_STACKING_FACTOR)
-			.map(|_| (rng.r#gen::<u32>(), rng.r#gen::<u32>()))
+			.map(|_| (rng.random::<u32>(), rng.random::<u32>()))
 			.collect();
 
 		let mut allocator = CpuComputeAllocator::new(1 << 12);

--- a/crates/m3/src/gadgets/barrel_shifter.rs
+++ b/crates/m3/src/gadgets/barrel_shifter.rs
@@ -175,7 +175,7 @@ mod tests {
 		let mut segment = table_witness.full_segment();
 
 		let mut rng = StdRng::seed_from_u64(0x1234);
-		let test_inputs = repeat_with(|| rng.r#gen())
+		let test_inputs = repeat_with(|| rng.random())
 			.take(1 << 8)
 			.collect::<Vec<u32>>();
 

--- a/crates/m3/src/gadgets/indexed_lookup/and.rs
+++ b/crates/m3/src/gadgets/indexed_lookup/and.rs
@@ -319,8 +319,8 @@ mod tests {
 
 		let mut rng = StdRng::seed_from_u64(0);
 		let inputs_1 = repeat_with(|| {
-			let in_a = rng.r#gen::<u8>();
-			let in_b = rng.r#gen::<u8>();
+			let in_a = rng.random::<u8>();
+			let in_b = rng.random::<u8>();
 			(in_a, in_b)
 		})
 		.take(looker_1_size)
@@ -337,8 +337,8 @@ mod tests {
 
 		let boundary_reads = (0..5)
 			.map(|_| {
-				let in_a = rng.r#gen::<u8>();
-				let in_b = rng.r#gen::<u8>();
+				let in_a = rng.random::<u8>();
+				let in_b = rng.random::<u8>();
 				merge_bitand_vals(in_a, in_b, in_a & in_b)
 			})
 			.collect::<Vec<_>>();

--- a/crates/m3/src/gadgets/indexed_lookup/incr.rs
+++ b/crates/m3/src/gadgets/indexed_lookup/incr.rs
@@ -378,8 +378,8 @@ mod tests {
 
 		let mut rng = StdRng::seed_from_u64(0);
 		let inputs_1 = repeat_with(|| {
-			let input = rng.r#gen::<u8>();
-			let carry_in_bit = rng.gen_bool(0.5);
+			let input = rng.random::<u8>();
+			let carry_in_bit = rng.random_bool(0.5);
 			(input, carry_in_bit)
 		})
 		.take(looker_1_size)
@@ -395,8 +395,8 @@ mod tests {
 			.unwrap();
 
 		let inputs_2 = repeat_with(|| {
-			let input = rng.r#gen::<u8>();
-			let carry_in_bit = rng.gen_bool(0.5);
+			let input = rng.random::<u8>();
+			let carry_in_bit = rng.random_bool(0.5);
 			(input, carry_in_bit)
 		})
 		.take(looker_2_size)

--- a/crates/m3/src/gadgets/lookup.rs
+++ b/crates/m3/src/gadgets/lookup.rs
@@ -141,7 +141,7 @@ mod tests {
 			look_indices.extend(0..lookup_table_size);
 		}
 		let remaining = look_indices.capacity() - look_indices.len();
-		look_indices.extend(repeat_with(|| rng.gen_range(0..lookup_table_size)).take(remaining));
+		look_indices.extend(repeat_with(|| rng.random_range(0..lookup_table_size)).take(remaining));
 
 		let look_values = look_indices
 			.into_iter()

--- a/crates/m3/src/gadgets/merkle_tree/mod.rs
+++ b/crates/m3/src/gadgets/merkle_tree/mod.rs
@@ -797,11 +797,11 @@ mod tests {
 
 		let mut rng = StdRng::seed_from_u64(0);
 		// Create a Merkle tree with 1<<10 leaves.
-		let index = rng.gen_range(0..1 << 10);
+		let index = rng.random_range(0..1 << 10);
 		let leaves = (0..3)
 			.map(|_| {
 				(0..1 << 10)
-					.map(|_| rng.r#gen::<[u8; 32]>())
+					.map(|_| rng.random::<[u8; 32]>())
 					.collect::<Vec<_>>()
 			})
 			.collect::<Vec<_>>();

--- a/crates/m3/src/gadgets/merkle_tree/trace.rs
+++ b/crates/m3/src/gadgets/merkle_tree/trace.rs
@@ -428,9 +428,9 @@ mod tests {
 	#[test]
 	fn test_high_level_model_inclusion() {
 		let mut rng = StdRng::from_seed([0; 32]);
-		let path_index = rng.gen_range(0..1 << 10);
+		let path_index = rng.random_range(0..1 << 10);
 		let leaves = (0..1 << 10)
-			.map(|_| rng.r#gen::<[u8; 32]>())
+			.map(|_| rng.random::<[u8; 32]>())
 			.collect::<Vec<_>>();
 
 		let tree = MerkleTree::new(&leaves);
@@ -454,14 +454,14 @@ mod tests {
 		let mut rng = StdRng::from_seed([0; 32]);
 
 		let leaves = (0..1 << 4)
-			.map(|_| rng.r#gen::<[u8; 32]>())
+			.map(|_| rng.random::<[u8; 32]>())
 			.collect::<Vec<_>>();
 
 		let tree = MerkleTree::new(&leaves);
 		let root = tree.root();
 		let paths = (0..2)
 			.map(|_| {
-				let path_index = rng.gen_range(0..1 << 4);
+				let path_index = rng.random_range(0..1 << 4);
 				MerklePath {
 					root_id: 0u8,
 					index: path_index,
@@ -477,11 +477,11 @@ mod tests {
 	#[test]
 	fn test_high_level_model_inclusion_multiple_roots() {
 		let mut rng = StdRng::from_seed([0; 32]);
-		let path_index = rng.gen_range(0..1 << 10);
+		let path_index = rng.random_range(0..1 << 10);
 		let leaves = (0..3)
 			.map(|_| {
 				(0..1 << 10)
-					.map(|_| rng.r#gen::<[u8; 32]>())
+					.map(|_| rng.random::<[u8; 32]>())
 					.collect::<Vec<_>>()
 			})
 			.collect::<Vec<_>>();

--- a/crates/m3/src/gadgets/sub.rs
+++ b/crates/m3/src/gadgets/sub.rs
@@ -294,8 +294,8 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let test_vector: Vec<(u32, u32, u32, u32, bool)> = (0..N_ITER)
 			.map(|_| {
-				let x: u32 = rng.r#gen();
-				let y: u32 = rng.r#gen();
+				let x: u32 = rng.random();
+				let y: u32 = rng.random();
 				let z: u32 = x.wrapping_sub(y);
 				// (x, y, borrow_in, zout, final_borrow)
 				(x, y, 0x00000000, z, false)
@@ -318,9 +318,9 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let test_vector: Vec<(u32, u32, u32, u32, bool)> = (0..N_ITER)
 			.map(|_| {
-				let x: u32 = rng.r#gen();
-				let y: u32 = rng.r#gen();
-				let borrow_in = rng.r#gen::<bool>() as u32;
+				let x: u32 = rng.random();
+				let y: u32 = rng.random();
+				let borrow_in = rng.random::<bool>() as u32;
 				let (x_minus_y, borrow1) = x.overflowing_sub(y);
 				let (z, borrow2) = x_minus_y.overflowing_sub(borrow_in);
 				let final_borrow = borrow1 | borrow2;

--- a/crates/m3/tests/mul_div_tests.rs
+++ b/crates/m3/tests/mul_div_tests.rs
@@ -94,7 +94,7 @@ impl TableFiller for MulUU64TestTable {
 impl MulDivTestSuiteHelper for MulUU64TestTable {
 	fn generate_inputs(&self, table_size: usize) -> Vec<(B64, B64)> {
 		let mut rng = StdRng::seed_from_u64(0);
-		repeat_with(|| (B64::new(rng.r#gen::<u64>()), B64::new(rng.r#gen::<u64>())))
+		repeat_with(|| (B64::new(rng.random::<u64>()), B64::new(rng.random::<u64>())))
 			.take(table_size)
 			.collect::<Vec<_>>()
 	}
@@ -199,7 +199,7 @@ impl MulDivTestSuiteHelper for MulDiv32TestTable {
 		let mut rng = StdRng::seed_from_u64(seed);
 		match self.mul_div {
 			MulDivEnum::MulUU32(_) => {
-				repeat_with(|| (B32::new(rng.r#gen::<u32>()), B32::new(rng.r#gen::<u32>())))
+				repeat_with(|| (B32::new(rng.random::<u32>()), B32::new(rng.random::<u32>())))
 					.take(table_size)
 					.collect()
 			}
@@ -214,26 +214,26 @@ impl MulDivTestSuiteHelper for MulDiv32TestTable {
 				chain!(
 					EXPLICIT_TESTS.into_iter(),
 					repeat_with(|| (
-						B32::new(rng.r#gen::<i32>() as u32),
-						B32::new(rng.r#gen::<u32>())
+						B32::new(rng.random::<i32>() as u32),
+						B32::new(rng.random::<u32>())
 					))
 				)
 				.take(table_size)
 				.collect()
 			}
 			MulDivEnum::MulSS32(_) => repeat_with(|| {
-				(B32::new(rng.r#gen::<i32>() as u32), B32::new(rng.r#gen::<i32>() as u32))
+				(B32::new(rng.random::<i32>() as u32), B32::new(rng.random::<i32>() as u32))
 			})
 			.take(table_size)
 			.collect(),
 			MulDivEnum::DivUU32(_) => {
-				repeat_with(|| (B32::new(rng.r#gen::<u32>()), B32::new(rng.r#gen::<u32>())))
+				repeat_with(|| (B32::new(rng.random::<u32>()), B32::new(rng.random::<u32>())))
 					.filter(|(_, y)| y.val() != 0)
 					.take(table_size)
 					.collect()
 			}
 			MulDivEnum::DivSS32(_) => {
-				repeat_with(|| (B32::new(rng.r#gen::<u32>()), B32::new(rng.r#gen::<u32>())))
+				repeat_with(|| (B32::new(rng.random::<u32>()), B32::new(rng.random::<u32>())))
 					.filter(|(_, y)| y.val() != 0)
 					.take(table_size)
 					.collect()
@@ -374,8 +374,8 @@ fn test_mul_next_to_stacked_col() {
 
 	let mut rng = StdRng::seed_from_u64(0);
 	let test_inputs = repeat_with(|| {
-		let a = rng.r#gen::<u32>();
-		let b = rng.r#gen::<u32>();
+		let a = rng.random::<u32>();
+		let b = rng.random::<u32>();
 		(a, b)
 	})
 	.take(17)

--- a/crates/math/Cargo.toml
+++ b/crates/math/Cargo.toml
@@ -25,12 +25,14 @@ thiserror.workspace = true
 tracing.workspace = true
 trait-set.workspace = true
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { workspace = true, features = ["wasm_js"] }
+
 [dev-dependencies]
 assert_matches.workspace = true
 criterion.workspace = true
 itertools.workspace = true
 proptest.workspace = true
-rand.workspace = true
 
 [lib]
 bench = false

--- a/crates/math/Cargo.toml
+++ b/crates/math/Cargo.toml
@@ -30,7 +30,7 @@ assert_matches.workspace = true
 criterion.workspace = true
 itertools.workspace = true
 proptest.workspace = true
-rand = { workspace = true, features = ["std_rng"] }
+rand.workspace = true
 
 [lib]
 bench = false

--- a/crates/math/Cargo.toml
+++ b/crates/math/Cargo.toml
@@ -25,9 +25,6 @@ thiserror.workspace = true
 tracing.workspace = true
 trait-set.workspace = true
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { workspace = true, features = ["wasm_js"] }
-
 [dev-dependencies]
 assert_matches.workspace = true
 criterion.workspace = true

--- a/crates/math/benches/fold.rs
+++ b/crates/math/benches/fold.rs
@@ -13,7 +13,7 @@ const fn packed_size<P: PackedField>(log_size: usize) -> usize {
 }
 
 fn generate_random_field<P: PackedField>(log_n_values: usize) -> Vec<P> {
-	let mut rng = rand::thread_rng();
+	let mut rng = rand::rng();
 	repeat_with(|| P::random(&mut rng))
 		.take(packed_size::<P>(log_n_values))
 		.collect::<Vec<P>>()

--- a/crates/math/benches/tensor_prod_eq_ind.rs
+++ b/crates/math/benches/tensor_prod_eq_ind.rs
@@ -15,7 +15,7 @@ pub fn bench_tensor_prod_eq_ind<P: PackedField>(
 	name: &str,
 	params: impl Iterator<Item = (usize, usize)>,
 ) {
-	let mut rng = rand::thread_rng();
+	let mut rng = rand::rng();
 	for param in params {
 		let (log_n_values, extra_query_len) = param;
 

--- a/crates/ntt/Cargo.toml
+++ b/crates/ntt/Cargo.toml
@@ -17,6 +17,9 @@ rand.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { workspace = true, features = ["wasm_js"] }
+
 [dev-dependencies]
 assert_matches.workspace = true
 criterion.workspace = true

--- a/crates/ntt/Cargo.toml
+++ b/crates/ntt/Cargo.toml
@@ -17,9 +17,6 @@ rand.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { workspace = true, features = ["wasm_js"] }
-
 [dev-dependencies]
 assert_matches.workspace = true
 criterion.workspace = true

--- a/crates/ntt/benches/additive_ntt.rs
+++ b/crates/ntt/benches/additive_ntt.rs
@@ -12,7 +12,6 @@ use criterion::{
 	BenchmarkGroup, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
 	measurement::WallTime,
 };
-use rand::thread_rng;
 
 trait BenchTransformationFunc {
 	fn run_bench<F, P>(
@@ -36,7 +35,7 @@ fn bench_helper<P, BT: BenchTransformationFunc>(
 	P: PackedField<Scalar: BinaryField>,
 {
 	let data_len = 1 << (log_n + log_stride_batch - P::LOG_WIDTH);
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let mut data = repeat_with(|| P::random(&mut rng))
 		.take(data_len)
 		.collect::<Vec<_>>();

--- a/crates/ntt/benches/large_transform.rs
+++ b/crates/ntt/benches/large_transform.rs
@@ -10,14 +10,13 @@ use binius_field::{
 };
 use binius_ntt::{AdditiveNTT, NTTShape, SingleThreadedNTT};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use rand::thread_rng;
 
 fn bench_large_transform<F: TowerField, PE: PackedExtension<F>>(c: &mut Criterion, field: &str) {
 	let mut group = c.benchmark_group("NTT");
 	for log_dim in [16, 20] {
 		for log_stride_batch in [1, 4] {
 			let data_len = 1 << (log_dim + log_stride_batch - PE::LOG_WIDTH);
-			let mut rng = thread_rng();
+			let mut rng = rand::rng();
 			let mut data = repeat_with(|| PE::random(&mut rng))
 				.take(data_len)
 				.collect::<Vec<_>>();

--- a/crates/ntt/src/single_threaded.rs
+++ b/crates/ntt/src/single_threaded.rs
@@ -542,7 +542,7 @@ mod tests {
 	#[test]
 	fn one_packed_field_forward() {
 		let s = SingleThreadedNTT::<BinaryField16b>::new(10).expect("msg");
-		let mut packed = [PackedBinaryField8x16b::random(StdRng::from_entropy())];
+		let mut packed = [PackedBinaryField8x16b::random(StdRng::from_os_rng())];
 
 		let mut packed_copy = packed;
 
@@ -564,7 +564,7 @@ mod tests {
 	#[test]
 	fn one_packed_field_inverse() {
 		let s = SingleThreadedNTT::<BinaryField16b>::new(10).expect("msg");
-		let mut packed = [PackedBinaryField8x16b::random(StdRng::from_entropy())];
+		let mut packed = [PackedBinaryField8x16b::random(StdRng::from_os_rng())];
 
 		let mut packed_copy = packed;
 
@@ -586,7 +586,7 @@ mod tests {
 	#[test]
 	fn smaller_embedded_batch_forward() {
 		let s = SingleThreadedNTT::<BinaryField16b>::new(10).expect("msg");
-		let mut packed = [PackedBinaryField8x16b::random(StdRng::from_entropy())];
+		let mut packed = [PackedBinaryField8x16b::random(StdRng::from_os_rng())];
 
 		let mut packed_copy = packed;
 
@@ -608,7 +608,7 @@ mod tests {
 	#[test]
 	fn smaller_embedded_batch_inverse() {
 		let s = SingleThreadedNTT::<BinaryField16b>::new(10).expect("msg");
-		let mut packed = [PackedBinaryField8x16b::random(StdRng::from_entropy())];
+		let mut packed = [PackedBinaryField8x16b::random(StdRng::from_os_rng())];
 
 		let mut packed_copy = packed;
 

--- a/crates/utils/src/random_access_sequence.rs
+++ b/crates/utils/src/random_access_sequence.rs
@@ -191,10 +191,10 @@ mod tests {
 
 	fn check_collection_get_set<T: Eq + Copy + Debug>(
 		collection: &mut impl RandomAccessSequenceMut<T>,
-		r#gen: &mut impl FnMut() -> T,
+		random: &mut impl FnMut() -> T,
 	) {
 		for i in 0..collection.len() {
-			let value = r#gen();
+			let value = random();
 			collection.set(i, value);
 			assert_eq!(collection.get(i), value);
 			assert_eq!(unsafe { collection.get_unchecked(i) }, value);
@@ -213,16 +213,16 @@ mod tests {
 	#[test]
 	fn check_slice_mut() {
 		let mut rng = StdRng::seed_from_u64(0);
-		let mut r#gen = || -> usize { rng.r#gen() };
+		let mut random = || -> usize { rng.random::<u64>() as usize };
 
 		let mut slice: &mut [usize] = &mut [];
 
 		check_collection(&slice, slice);
-		check_collection_get_set(&mut slice, &mut r#gen);
+		check_collection_get_set(&mut slice, &mut random);
 
 		let mut slice: &mut [usize] = &mut [1, 2, 3];
 		check_collection(&slice, slice);
-		check_collection_get_set(&mut slice, &mut r#gen);
+		check_collection_get_set(&mut slice, &mut random);
 	}
 
 	#[test]
@@ -235,12 +235,12 @@ mod tests {
 	#[test]
 	fn test_subrange_mut() {
 		let mut rng = StdRng::seed_from_u64(0);
-		let mut r#gen = || -> usize { rng.r#gen() };
+		let mut random = || -> usize { rng.random::<u64>() as usize };
 
 		let mut slice: &mut [usize] = &mut [1, 2, 3, 4, 5];
 		let values = slice[1..4].to_vec();
 		let mut subrange = SequenceSubrangeMut::new(&mut slice, 1, 3);
 		check_collection(&subrange, &values);
-		check_collection_get_set(&mut subrange, &mut r#gen);
+		check_collection_get_set(&mut subrange, &mut random);
 	}
 }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -26,9 +26,6 @@ rand.workspace = true
 tracing-profile.workspace = true
 tracing.workspace = true
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { workspace = true, features = ["wasm_js"] }
-
 [[example]]
 name = "keccak"
 path = "keccak.rs"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -26,6 +26,9 @@ rand.workspace = true
 tracing-profile.workspace = true
 tracing.workspace = true
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { workspace = true, features = ["wasm_js"] }
+
 [[example]]
 name = "keccak"
 path = "keccak.rs"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -22,7 +22,7 @@ binius_utils = { path = "../crates/utils", default-features = false }
 bytesize.workspace = true
 clap = { version = "4.5.20", features = ["derive"] }
 itertools.workspace = true
-rand = { workspace = true, features = ["std", "std_rng"] }
+rand.workspace = true
 tracing-profile.workspace = true
 tracing.workspace = true
 

--- a/examples/b32_mul.rs
+++ b/examples/b32_mul.rs
@@ -41,7 +41,7 @@ fn main() -> Result<()> {
 
 	let mut rng = StdRng::seed_from_u64(0);
 	let test_vector: Vec<(u32, u32)> = (0..args.n_ops)
-		.map(|_| (rng.r#gen(), rng.r#gen()))
+		.map(|_| (rng.random(), rng.random()))
 		.collect();
 
 	let mut cs = ConstraintSystem::new();

--- a/examples/bitwise_ops.rs
+++ b/examples/bitwise_ops.rs
@@ -186,7 +186,7 @@ fn main() -> Result<()> {
 
 	let mut rng = StdRng::seed_from_u64(0);
 	let test_vector: Vec<(u32, u32)> = (0..args.n_u32_ops)
-		.map(|_| (rng.r#gen(), rng.r#gen()))
+		.map(|_| (rng.random(), rng.random()))
 		.collect();
 
 	let mut cs = binius_m3::builder::ConstraintSystem::new();

--- a/examples/groestl.rs
+++ b/examples/groestl.rs
@@ -22,7 +22,6 @@ use binius_m3::{
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
 use bytesize::ByteSize;
 use clap::{Parser, value_parser};
-use rand::thread_rng;
 use tracing_profile::init_tracing;
 
 #[derive(Debug, Parser)]
@@ -102,7 +101,7 @@ fn main() -> Result<()> {
 	let boundaries = vec![];
 	let table_sizes = vec![n_permutations];
 
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let events = repeat_with(|| array::from_fn::<_, 64, _>(|_| B8::random(&mut rng)))
 		.take(n_permutations)
 		.collect::<Vec<_>>();

--- a/examples/keccak.rs
+++ b/examples/keccak.rs
@@ -23,7 +23,7 @@ use binius_m3::{
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
 use bytesize::ByteSize;
 use clap::{Parser, value_parser};
-use rand::{RngCore, thread_rng};
+use rand::RngCore;
 use tracing_profile::init_tracing;
 
 #[derive(Debug, Parser)]
@@ -104,7 +104,7 @@ fn main() -> Result<()> {
 	let boundaries = vec![];
 	let table_sizes = vec![n_permutations];
 
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let events = repeat_with(|| StateMatrix::from_fn(|_| rng.next_u64()))
 		.take(n_permutations)
 		.collect::<Vec<_>>();

--- a/examples/merkle_tree.rs
+++ b/examples/merkle_tree.rs
@@ -53,7 +53,7 @@ fn main() -> Result<()> {
 	let mut rng = StdRng::seed_from_u64(0);
 	// Create a Merkle tree with 8 leaves
 	let leaves = (0..1 << args.log_leaves)
-		.map(|_| rng.r#gen::<[u8; 32]>())
+		.map(|_| rng.random::<[u8; 32]>())
 		.collect::<Vec<_>>();
 
 	let tree = MerkleTree::new(&leaves);
@@ -61,7 +61,7 @@ fn main() -> Result<()> {
 	let roots = tree.root();
 	let paths = (0..1 << args.log_paths)
 		.map(|_| {
-			let index = rng.gen_range(0..1 << args.log_leaves);
+			let index = rng.random_range(0..1 << args.log_leaves);
 			MerklePath {
 				root_id: 0,
 				index,

--- a/examples/u32_add.rs
+++ b/examples/u32_add.rs
@@ -43,7 +43,7 @@ fn main() -> Result<()> {
 
 	let mut rng = StdRng::seed_from_u64(0);
 	let test_vector: Vec<(u32, u32)> = (0..args.n_additions)
-		.map(|_| (rng.r#gen(), rng.r#gen()))
+		.map(|_| (rng.random(), rng.random()))
 		.collect();
 
 	let mut cs = binius_m3::builder::ConstraintSystem::new();

--- a/examples/u32_mul_gkr.rs
+++ b/examples/u32_mul_gkr.rs
@@ -21,7 +21,6 @@ use binius_m3::{
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::adjust_thread_pool};
 use bytesize::ByteSize;
 use clap::{Parser, value_parser};
-use rand::thread_rng;
 use tracing_profile::init_tracing;
 
 #[derive(Debug, Parser)]
@@ -97,7 +96,7 @@ fn main() -> Result<()> {
 	let boundaries = vec![];
 	let table_sizes = vec![1 << log_n_muls];
 
-	let mut rng = thread_rng();
+	let mut rng = rand::rng();
 	let events = repeat_with(|| (B32::random(&mut rng), B32::random(&mut rng)))
 		.take(1 << log_n_muls)
 		.collect::<Vec<_>>();


### PR DESCRIPTION
### TL;DR

Upgrade rand crate from 0.8.5 to 0.9.1 and update all method calls to match the new API.

### What changed?

- Updated rand dependency from 0.8.5 to 0.9.1 in Cargo.toml
- Added "std" and "thread_rng" features to rand in the root Cargo.toml
- Replaced `thread_rng()` calls with `rand::rng()`
- Updated method calls to match the new API:
  - `r#gen()` → `random()`
  - `gen_range()` → `random_range()`
  - `gen_bool()` → `random_bool()`
- Updated distribution usage to match the new API
- Simplified workspace dependencies by using `.workspace = true` for rand in subcrates
