### PR TITLE
[piop] Fix failing PIOP case when there are no evaluation claims (#221)

### DIFF
--- a/crates/compute/tests/layer.rs
+++ b/crates/compute/tests/layer.rs
@@ -145,3 +145,21 @@ fn test_map_kernels() {
 		log_len,
 	);
 }
+
+#[test]
+fn test_pairwise_product_reduce_single_round() {
+	let log_len = 1;
+	binius_compute_test_utils::layer::test_generic_pairwise_product_reduce(
+		CpuLayerHolder::<B128>::new(1 << (log_len + 4), 1 << (log_len + 3)),
+		log_len,
+	);
+}
+
+#[test]
+fn test_pairwise_product_reduce() {
+	let log_len = 8;
+	binius_compute_test_utils::layer::test_generic_pairwise_product_reduce(
+		CpuLayerHolder::<B128>::new(1 << (log_len + 4), 1 << (log_len + 3)),
+		log_len,
+	);
+}

--- a/crates/compute_test_utils/Cargo.toml
+++ b/crates/compute_test_utils/Cargo.toml
@@ -18,4 +18,6 @@ binius_math = { path = "../math", default-features = false }
 binius_ntt = { path = "../ntt", default-features = false }
 binius_utils = { path = "../utils", default-features = false }
 bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
+itertools.workspace = true
 rand = { workspace = true, features = ["std"] }
+

--- a/crates/compute_test_utils/src/layer.rs
+++ b/crates/compute_test_utils/src/layer.rs
@@ -16,6 +16,7 @@ use binius_math::{
 };
 use binius_ntt::fri::fold_interleaved;
 use binius_utils::checked_arithmetics::checked_log_2;
+use itertools::Itertools;
 use rand::{Rng, SeedableRng, prelude::StdRng};
 
 pub fn test_generic_single_tensor_expand<
@@ -896,5 +897,58 @@ pub fn test_map_kernels<F, Hal, ComputeHolderType>(
 
 	for (i, output) in output_host.iter_mut().enumerate() {
 		assert_eq!(*output, input_1_host[i] + input_2_host[i]);
+	}
+}
+
+pub fn test_generic_pairwise_product_reduce<F, Hal, ComputeHolderType>(
+	mut compute_holder: ComputeHolderType,
+	log_len: usize,
+) where
+	F: Field,
+	Hal: ComputeLayer<F>,
+	ComputeHolderType: ComputeHolder<F, Hal>,
+{
+	let mut rng = StdRng::seed_from_u64(0);
+
+	let ComputeData {
+		hal,
+		host_alloc,
+		dev_alloc,
+		..
+	} = compute_holder.to_data();
+
+	let input = host_alloc.alloc(1 << log_len).unwrap();
+	input.fill_with(|| F::random(&mut rng));
+
+	let mut round_outputs = Vec::new();
+	let mut current_len = input.len() / 2;
+	while current_len >= 1 {
+		round_outputs.push(dev_alloc.alloc(current_len).unwrap());
+		current_len /= 2;
+	}
+
+	let mut dev_input = dev_alloc.alloc(input.len()).unwrap();
+	hal.copy_h2d(input, &mut dev_input).unwrap();
+	hal.execute(|exec| {
+		exec.pairwise_product_reduce(Hal::DevMem::as_const(&dev_input), round_outputs.as_mut())
+			.unwrap();
+		Ok(vec![])
+	})
+	.unwrap();
+	let mut working_input = input.to_vec();
+	let mut round_idx = 0;
+	while working_input.len() >= 2 {
+		let mut round_results = (0..working_input.len() / 2).map(|_| F::ZERO).collect_vec();
+		for idx in 0..round_results.len() {
+			round_results[idx] = working_input[idx * 2] * working_input[idx * 2 + 1];
+		}
+
+		let actual_round_result = host_alloc.alloc(working_input.len() / 2).unwrap();
+		hal.copy_d2h(Hal::DevMem::as_const(&round_outputs[round_idx]), actual_round_result)
+			.unwrap();
+		assert_eq!(round_results, actual_round_result);
+
+		working_input = round_results;
+		round_idx += 1;
 	}
 }

--- a/crates/fast_compute/src/layer.rs
+++ b/crates/fast_compute/src/layer.rs
@@ -603,6 +603,15 @@ impl<'a, T: TowerFamily, P: PackedTop<T>> ComputeLayerExecutor<T::B128>
 
 		result.into_iter().map(|(_, out)| out).collect()
 	}
+
+	fn pairwise_product_reduce(
+		&mut self,
+		_input: <Self::DevMem as ComputeMemory<T::B128>>::FSlice<'_>,
+		_round_outputs: &mut [<Self::DevMem as ComputeMemory<T::B128>>::FSliceMut<'_>],
+	) -> Result<(), Error> {
+		// TODO(SYS-350)
+		todo!()
+	}
 }
 
 /// In case when `P1` and `P2` are the same type, this function performs the extrapolation


### PR DESCRIPTION
[piop] Fix failing PIOP case when there are no evaluation claims (#221)

Previously, when a committed column had no evaluation claims, the PIOP compiler would throw a Math(PiecewiseMultilinearIncompatibleEvals error. While an unconstrained committed is bad, this should get warned about at a higher level, not throw a confusing error deep in the stack.

[piop] Handle arbitrarily small committed polynomials (#227)

This relaxes the ring_switch and piop modules to handle committed polynomials that are smaller than the size of a packed large element and eliminates the OracleTooSmall error. We handle this case by committing the polynomial as it's MLE over the larger hypercube, which corresponds to repeating it's evaluations. The integration test in ring_switch module is updated to exercise this code path.

[m3]: add test for U32Add gadget (#229)

Add fixing generics for `DeserializeBytes` derive macro (#212)

This PR fixes the issue #88 by adding a custom attribute eval_generics for the derive macro.

Change MultilinearExtension::from_vales to MultilinearExtension::new (#234)

[m3] chore add u32 mod (#233)

Creates a module in anticipation of other 32-bit ALU gadgets, e.g. U32Sub.

[m3] Fix the small-table flushing bug for lookups (#230)

This issue is caused by the solution of #170, which makes it possible for tables to be automatically allocated capacity exceeding their event count. That works fine for regular tables, but not lookup tables that are power_of_two_sized. However, that solution is now obsolete because of an alternative fix in #227, so this adds a test and assertion and rolls the change back.

[fri] Fix shape of terminal FRI oracle (#231)

Update the batch_size of the terminate_codeword Merkle tree so that it has exactly inv_rate leaves.

[m3] fix OOB in Display impl of ConstraintSystem (#237)

[math] Fast (single pass) algorithm for `ArithExpr::linear_normal_form` (#224)

[evalcheck] Add documentation for Evalcheck (#226)

[m3] u32 sub gadget (#242)

[ntt] Remove overly conservative domain size check in AdditiveNTT (#236)

Always sample 4 bytes during `sample_bits` (#225)

[circuits] Optimised Blake3 compression (#222)

[m3] u32 gadgets follow-up (#243)

1. Tidy the lingering dbg! in u32sub
2. Move u32add to the same test approach as u32sub

[serialization] Serialize usize as u32 instead of u64 (#245)

[compute] Interface for host memory allocation (#240)

Improve instrumentation (#238)

fix: inf-178: fix nightly benchmarks (#246)

[math] Common expression extraction in `ArithExpr` (#235)

[evalcheck] fix ZeroPadded (#247)

SYS-110:: define ComputeAllocator trait (#248)

Accelerated compute backends will provide custom implementations for
host and device allocations. Define a trait for bump allocators that
will be used throughout Binius for compute buffer allocations.

[M3] Add barrel shifter gadget (#249)

[gadgets] Adds unsigned multiplication gadgets to M3 (#239)

This MR adds unsigned multiplication gadgets to M3, as well as expose GKR exponentiation into M3.

[toolchain] nightly-2025-04-24 (#252)

bump toolchain version

[m3] Revert the #230 related to the small lookup table (#256)

This change caused issues that we are still investigating.

[deps] Bump tracing-profile version (#251)

ci: INF-176 oom fix (#264)

[zerocheck] Improve univariate skip (#244)

Fixes the zerocheck univariate round soundness hole by always skipping the same number of rounds, resulting in same-sized round polynomials in Lagrange basis. Remaining rounds are "right justified" using front-loaded batching, resulting in a peculiar reduction shape where projection happens on the low variables (that underwent "univariate skip") and possibly a suffix of high variables, potentially leaving a "gap" in between. The primary reason for this contrived arrangement is to be able to reuse high projection from univariatizing reduction witness generation in ring switching.

[m3] Port keccak-f to M3 (#259)

[m3] Test utility to simplify testing systems & gadgets (#262)

validate_system_witness by default just does naive witness validation, but an environment variable can be toggled to perform proving + proof verification.

[examples] Keccak-f example using M3 (#260)

[oracle] Generalize ZeroPadding (#255)

Generalize the ZeroPadded virtual oracle with

- num_extra_variables: number of additional variables.
- start_index: variable index (within the set of all variables) where the padding starts
- nonzero_index: the index (between 0 and (1 << num_extra variables) - 1) of the block (of size 1 << start_index) where the values are those of the original column.

Move tower from core to field (#272)

[M3] Fix single-element tables (#271)

Fixes evalcheck and gkr_gpa to support poly with n_vars=0

[m3] Public method for ZeroPadding with nonzero_index as an argument (#273)

Public method with nonzero_index as an argument

[m3] Add structured column type (#269)

This adds dynamically-sized structured columns. In a future change, we will add fixed-size structured columns as well.

[compute] Extend with functionality for multilinear evaluation (#266)

Extends ComputeLayer with test suite (generalised over compute layer) for some multilinear evaluation and needed functionality in the layer trait itself.

[reed_solomon] Extract NTT from ReedSolomonCode (#274)

[channels] Handle selector logic with CompositeMLE (#270)

Change the manual handling of flushes with selectors into evalcheck using composite MLE.

[chore] tidy keccakf example (#279)

- removes the old keccakf_circuit.rs,
- uses the new keccakf M3 port as the nightly benchmark target,
- cleans up the new keccak wrt seq/par table filling.

[m3] use only referenced oracle ids for zero check (#278)

Instead of unconditionally adding the whole list of per partition oracle ids into the constraint set, we check which ones are actually getting used.

Fixes #265

[evalcheck] Write duplicate claim advice directly to transcript (#277)

This removes most of the serialization/deserialization & proof struct pattern matching logic from evalcheck.

[m3] Fixed-size structured columns (#280)

[field] please clippy (#283)

This one is the same change as in #257 but isolated for faster merging.

[m3] fix rustdoc for the keccak module (#284)

[m3] add TableBuilder doc focusing on nesting (#285)

Also actually add a test for checking if the nesting works properly.

[fri] Simplify the FRI folding code (#282)

This simplifies the FRI folding code in a few ways. The improvements are:

* Remove the requirement that fold_challenges be non-empty
* Remove the fold_codeword prover function and use the more general fold_interleaved in all cases
* Pass log_len instead of round parameter so that the code will work with NTT instances with larger domains

Fix zero pad check and improve error message (#288)

[arith_expr] Use `ArithExpr` as a builder only (#250)

All other operations are now moved to `ArithCircuit`.

[m3] namespace zero constraints (#286)

This is important because otherwise instantiations of the same gadget will have all the constraints having the same name.

[gadgets] Signed Multiplication Gadgets (#257)

* This MR adds MulSU32, MulSS32, TwosComplement, Incr, SignConverter gadgets.
* Added better testing which can possibly be reused in other gadgets.

[m3] display assert_zero costs per table. (#289)

This changeset aims to give more insight for the approximate cost of a given table.

The cost of assert_zero constraints is:

(Degree - 1) x (# of muls in expr) x V.

Then that is multiplied by the bits in the field (with 8-bit as floor).

[m3] Stat returns bits per row (#292)

[evalcheck] Handle composite MLEs separately from projected bivariate sumchecks (#290)

They are different and should be handled differently. Composite MLE evaluations are not bivariate, and they don't use projection. In the future, we shouldn't handle them as regular sumchecks, we should prove them as MLEchecks, which have a more efficient proving algorithm.

[compute] Reduce duplication in CpuLayer using macro (#295)

[field] Optimized byte sliced `spread` implementation (#276)

[examples] Fix the bitwise XOR example (#296)

[m3] emulate Channel relax Default constraint (#298)

Channel prior to this PR is overconstrained. It requires T to implement Default all the while the Channel does not actually contain any T by default.

[M3] Allow core constraint system to handle flushes with multiple selectors (#294)

[Fix] Match the order of processing bivariate sumcheck claims in evalcheck (#297)

The verifier processes claims successively, while the prover processes all projected claims first, followed by all composite. As a result, if a projected and a composite claim have the same n_vars, the order of sumcheck_claims will differ between the verifier and prover.

Replace backloaded with frontloaded sumchecks (#281)

Replaces some backloaded sumchecks with frontloaded suchecks, towards keeping only frontloaded sumchecks. The goal is to simplify and reduce code.

[M3] Automatic witness population for constants (#304)

Small MR to automatically populate with witness index for constants.

[m3] Surface error when lookup count is too high (#302)

[compute] Define HAL operation for fold_left (#293)

[ntt] Add skip_rounds parameter to AdditiveNTT (#306)



This generalizes the AdditiveNTT operation to be able to perform a truncated NTT, which skips rounds at the beginning of a forward transform and the end of an inverse transform. This is useful for Reed-Solomon encoding, where we want to run a large NTT but know apriori that the first few rounds have the effect of simply copying data.

This resolves a limitation of ReedSolomonCode::encode, which imposes a packing length restriction on the encoded message and also complicates the multithreading around the NTT with an additional Rayon loop. Now the multithreading is delegated to the AdditiveNTT implementation, which can size the matrix more appropriately.

[m3] Fix bug in filling structured columns (#305)

[evalcheck] Fix ZeroPadded memoization (#308)

[gadgets] Division gadgets for M3 (#258)

[m3] emulate::Channel::assert_balanced (#309)

This allows to actually print what values are unbalanced which could aid debugging.

[compute] Introduce `accumulate_kernels` (#299)

[gkr_gpa] Switch to front-loaded batch sumcheck (#312)

[m3] destruct gadgets::u32 module (#311)

As you may see already in the u32::add and u32::sub modules, those are no longer
32-bit only but support 64-bit ops as well.

As was discussed elsewhere categorizing gadgets based on operation and treating
the width as that op's parameter is the way forward.

[arith_expr] Fix `pow` step evaluation in `ArithCircuit` (#315)

[tracing] Add data dimensions tracing (#263)

[utils] remove unsound thread_local_mut (#317)

The thread_local_mut utility is unsound as it can provide multiple exclusive
references to the inner value as shown by the test below:

	#[test]
	fn evil() {
		let tlm = super::ThreadLocalMut::new();

		tlm.with_mut(
			|| vec![1, 2, 3],
			|exclusive_1| {
				tlm.with_mut(
					|| vec![],
					|exclusive_2| {
						exclusive_1.push(1);
						exclusive_2.push(1);
					},
				)
			},
		);
	}

Since it seemingly is not used anywhere, removing it.

[bug] Fix bug with exponentiation constraints on small tables (#313)

[ci] Run M3 integration tests in CI (#320)

[compute] Add FRI fold operation to ComputeLayer (#314)

[evalcheck] Serialize evalcheck proofs using u32s instead of bytes and usize (#323)

[m3] High-level model for Grøstl-256 hash function (#310)

Implementation of the high-level model of Grøstl-256. The presented version is specialized to a fixed length input size: 1024 bytes. This is done because otherwise it would be harder to arithmetize the logic of adding padding. It would be easy to change the length of the input as long as it is a multiple of Grøstl-256 block size (64 byte).

[m3] eval_expr bug fix (#321)

[core] FRI fold include num_challenges in dimensions trace (#319)

[fri] Improve early FRI termination optimization (#300)

[fri] Add FRI folding tower level logging (#328)

[m3] Test coverage & cleanups for multiplication gadget (#318)

Add unit test to catch issue with compilation bug. Also test cleanups in mul gadget.

[m3] enforce the fixed power-of-two table size constraint (#324)

[m3] log_capacity does not depend on &self (#325)

Small refactor and docs update to avoid confusion.

Why I didn't just inline it? Well then there won't be a platform for the
documentation.

[rustfmt] Enforce maximum comment width (#326)

[Fix] gkr_exp claims descending order (#330)

Descending claim order was disrupted when dynamic claims began being processed after static ones — this PR restores the correct order.

[core] newtype OracleId (#327)

OracleId becomes a newtype. This is a non-functional change.

As a bonus: turns out there were quite a bit of clones of MultilinearPolyOracle
struct. Each one is, if instantiated with e.g. F=BinaryField32b is 160 bytes.
Not too much but definitely annoying, especially considering why it was
happening. In one instance the whole clone of the structure would be done
just to get the name/label.

Update github CI pull_request types to support graphite (#335)

The graphite docs recommend this change to the github action `on` spec:

https://graphite.dev/docs/github-configuration-guidelines#github-actions

This is because PRs are stacked and you want to run CI tests on all PRs
in the stack, not just those that are based on the main.

The `edited` type is excluded here because this event is triggered when
Graphite makes changes to PR metadata and we don't want this to trigger
a CI run.

[compute] Fold right HAL operation (#334)

[evalcheck] Reduce CompositeMLE evaluations to MLEchecks (#307)

Use EqIndSumcheckProver (MLECheck) to prove CompositeMLE oracles; deduplication is driven by advice tape.

[m3] Exposed input and output columns for Keccak-f[1600] gadget. (#329)

Updated the keccak gadget to:
* Expose the input and output columns to the gadget.
* Change the interface for the constructor and populate methods.

[ci]: Allow manual trigger of benchmark job (#340)

[compute] Add `kernel_add` operation (#336)

[compute] Simplify reference fri_fold operation (#333)

The fold interleaved step is invariant to the selected batch size. Refactor the reference CPU implementation to make this property clear. Hardware implementations will benefit from the ability to select different batch sizes based on the properties of the target device.

[m3] Indexed lookups with tallying (#331)



Indexed lookup tables are fixed-size tables where every entry is easily determined by its index.

Indexed lookup tables cover a large and useful class of tables, such as lookup tables for bitwise operations, addition of small integer values, multiplication, etc. The entry encodes an input and an output, where the index encodes the input. For example, a bitwise AND table would have 2 8-bit input values and one 8-bit output value. The index encodes the input by concatenating the 8-bit inputs into a 16-bit unsigned integer.

Before a lookup table witness can be filled, the number of times each entry is read must be known. Reads from indexed lookup tables are a special case where the counts are difficult to track during emulation, because the use of the lookup tables is an arithmetization detail. For example, emulation of the system model should not need to know whether integer additions within a table are constraint using zero constraints or a lookup table for the limbs. In most cases of practical interest, the lookup table is indexed.

The method to tally counts is to scan all tables in the constraint system and boundaries values, and identify those that pull from the lookup table's channel. Then we iterate over the values read from the table and count all the indices.

[m3] fix underconstraining bug in U32Sub (#349)

Closes [CRY-347].

[CRY-347]: https://linear.app/irreducible/issue/CRY-347/m3-u32sub-gadgets-doesnt-constrain-borrow-out

[gkr_gpa] Change sumcheck order to high-to-low (#339)

Changed the evaluation order in grand product argument from `LowToHigh` to `HighToLow`.

[deps]: bump `bytesize` and `hex-literal` (#347)

[CODEOWNERS] Add Dmytro as codeowner (#350)

[examples] Use fill_table_parallel instead of sequential (#344)

This will speed up witness generation for examples in multithreaded configurations.

[rust] Update from Rust 2021 to Rust 2024 edition (#351)

Most of the file changes are due to rustfmt sorting dependencies differently in Rust 2024 edition.
- `rng.gen()` had to be changed to `rng.r#gen()` since gen is now a reserved keyword in Rust 2024.
- All unsafe functions must now wrap any unsafe code it calls in explicit unsafe blocks

[m3] Update indexed_lookup incr example with column permutation (#332)

This makes the incr lookup table example more realistic by adding the column permutation. The only change to the library code is the addition of an index_to_entry method on IndexedLookup.

[ring_switch] Ring-Switch EQ Indicator using evaluate_partial_low (#348)

Using evaluate_partial_low (a HAL operation) instead of the current inner_product_subfield to calculate the coefficients of the MLE of the ring-switch EQ indicator .

[utils] remove mod examples (#352)

It does not seem that this code is used anywhere.

[m3] Optimize the LookupGadget using the special truncated sumcheck (#343)

Added automatic zero suffix detection for CompositeMLE in evalcheck and optimized make_masked_flush_witnesses

[m3] slap track_caller on assert_balanced (#364)

Add `actual` to every query size error (#366)

This is mostly a mechanical change.

[m3] Document some TableBuilder methods (#360)

INF-194: Run cargo docs tests (#365)

[utils] introduce mem::slice_uninit_mut (#355)

As per @GraDKh request in this [comment].

I did not use the suggested identifier as, unlike in `assume_init`, we don't
really assume anything here, we are just converting a definitely inited slice
into a maybe uninited slice. Also to make it inline with the follow-up I
decided to call it `slice_uninit_mut` (put slice in the front).

[comment]: https://app.graphite.dev/github/pr/IrreducibleOSS/binius/353/%5Bcore%5D-miri

[utils] prefer homegrown slice_assume_init (#356)

We already have slice_assume_init at home.

[m3] Binary Merkle Tree (#362)

This PR adds a high-level model for binary Merkle trees using the Grøstl-256 output transformation as a 2-to-1 compression function.

[pre-commit] Fix rustfmt pre-commit hook (#372)

Use cargo fmt instead of rustfmt for pre-commit hook

[zerocheck] Step towards reusing ntt (#373)

This make a step towards reusing the already-created NTT object in extrapolate_round_evals. We still can't actually use it because of extension field nonsense, but at least this ensures that the NTT domains are consistent.

[m3] don't assume oracle id order in witness (#357)

This changeset aims to fix the implicit dependency of the witness on the order
of oracles added in `ConstraintSystem::compile`.. See [CRY-356] for more
details.

This does several things:

1. Prefers using ColumnId over indices
2. Introduction of `OracleLookup`

This starts using the ColumnId where possible. This change should really make
much less likely to confuse indices and improve general type-safety, and as well
as simplify the code a bit (one type is better than multiple). However, this
makes the column IDs to carry table_id around, but I don't think this is a
problem since the code is not hot.

Introduction the `OracleLookup` type. Prior this changeset
the data about which oracle came from which columns was lost. This type
is meant to store this information explicitly to be read by the witness
handling code.

This opens up for other use-cases where you might want to pass some data
from the compilation process into the witness generation, as that seems to be
inherently important: compilation creates oracles from columns and witness
filling operates on oracles.

Ideally though IMO we should really introduce a special type that represents
the compilation output:

1. `TableStat` should be a function of the compiled constraint system. That
   said, we can easily account for that.
2. Warnings. Optionally catch silly things like a committed column that is not
   referenced in a virtual column or a constraint.
3. It will also contain the data similiar to OracleLookup.

[CRY-356]: https://linear.app/irreducible/issue/CRY-356/dont-assume-the-order-of-compilation-of-oracles

[ntt] Add coset_bits parameter to AdditiveNTT (#371)

Modify the AdditiveNTT behavior so that the evaluation domains for differently-sized transforms are FRI-compatible. By FRI-compatible, we mean that encoding then FRI folding commutes with tensor folding then encoding. This is checked with a proptest in the `fri` module.

The interfaces for AdditiveNTT should be cleaned up to use structs with named fields and Default impls instead of many parameters. I'm leaving this for future work.

Fixes CRY-71

Fix `CompositionPoly::batch_evaluate` (#368)

Remove outdated condition that prevented 1b optimization to happen (#379)

This condition was mistakenly left since the times this function was multithreaded.

This rolls back the slowdown that happened after https://github.com/IrreducibleOSS/binius/commit/57a4d56a4723c30683e384a8e35d1be5d68e1e84

deps: rm unused deps (#380)

deps: bump criterion (#381)

[m3] rename flush column indices to columns (#383)

As now we are using the column IDs instead of indices.

Extract compute level helper functions to a separate crate (#377)

Expose ComputeLayer tests from the crate.

I first tried the proposed solution with feature-gated test functions, but to me it adds additional complexity to track the dependencies needed for tests only, so decided to go with extracting a separate crate.

[m3] Fixed Column for Increment Lookup tests (#385)

Added `ArithCircuit`s for the Incr lookup table expression, and changed it from a committed to a fixed column in the lookup test.

Environment variable flag to dump transcript to a file (#367)

### TL;DR

Added functionality to dump proof transcripts to a file when the `BINIUS_DUMP_PROOF` environment variable is set.

### What changed?

- Modified the `finalize` method in `ProverTranscript` to check for the `BINIUS_DUMP_PROOF` environment variable
- When the environment variable is set, the proof transcript is written to the file specified by the variable's value
- Added necessary imports for file operations (`std::fs::File`, `io::Write`)
- Made a minor refactoring in `into_verifier` method to store the transcript in a variable before passing it to the constructor

### How to test?

1. Set the environment variable `BINIUS_DUMP_PROOF` to a file path:
   ```
   export BINIUS_DUMP_PROOF=/path/to/output/proof.bin
   ```
2. Run a process that generates a proof
3. Verify that the proof has been written to the specified file

### Why make this change?

This change enables easier debugging and analysis of proof transcripts by allowing them to be dumped to a file for inspection. This is particularly useful during development and testing of cryptographic protocols, as it allows for offline examination of the proof data.

[ci] Bump GitHub runners (#387)

fix calculation of fold arities. add larger test (#390)

there is a very subtle issue in the current calculation of `fold_arities`; see the recent PR https://github.com/IrreducibleOSS/binius/pull/300.

the issue only arises in an essentially impossible-case---i.e., in which the `log_inv_rate` is strictly more than the `merkle_cap_height`, i.e., $\mathcal{R} > c$, where $c$ is the Merkle cap height. this will virtually never happen in real life, unless $\mathcal{R}$ is enormous---7 or 8 or so.

if this _were_ the case, then the current implementation can lead to a nonsensical scenario where sum(fold_arities) is > total_vars. this makes no sense, since we need to ship the terminal codeword before or equal to the point at which the message has become fully folded, and not after. in fact this gets caught in the current codebase, with a `InvalidFoldAritySequence`.

I've added a test which triggers this error in the current codebase but doesn't once the present proposed update is in place.

the way we fix this is by replacing
```rust
(commit_meta.total_vars + log_inv_rate).saturating_sub(cap_height) / arity,
```
with
```rust
(commit_meta.total_vars).saturating_sub(cap_height.saturating_sub(log_inv_rate)) / arity,
```
when `cap_height >= log_inv_rate`, these are equivalent. in the opposite case `cap_height < log_inv_rate`, this has the effect of setting `fold_arities` to be `arity` repeated `floor(total_vars / arity)` times, which is a safe choice.

[ntt] Make multithreaded use NTT methods (#374)

This is less hacky

[ci] Trigger benchmarks manually (#361)

Part of INF-163

New workflow tested here: https://github.com/IrreducibleOSS/binius/actions/runs/15117258700

[compute] Add ComputeMemory::split_at (#388)

[ntt] Clean up OddInterpolate interface (#375)

Now it accesses the NTT directly instead of exposing the TwiddleAccess
interface.

Add last_perfetto_trace_path to gitignore (#398)

[chore] typos (#395)

Fixing a bunch of typos that I've gathered throughout several past weeks.

[field] fix rust doc (for mac) (#396)

Running

  cargo doc -p binius_field --no-deps

did not work for me on mac because of multiple errors. This changeset fixes
them.

[m3] Add privacy to ColumnId and Col (#358)

This essentially hides ColumnIndex and ColumnPartitionIndex from the outside
world.

[compute] Fix docs & and use `SubfieldSlice` in `inner_product` (#382)

Implement SerializeBytes and DeserializeBytes for PackedPrimitiveType and ScaledPackedField (#214)

[m3] eval_expr doesn't conjure Col out of thin air (#363)

Creating an Col out of thin air is discouraged and we don't need it there in any
case. This changeset just inlines the `get` removing all the unnecessary logic.

[pre-commit] Add typos pre-commit hook (#403)

[CRY-364] Add bivariate_product round calculation function (#389)

This PR adds a new `v3` module to the sumcheck protocol implementation, which contains a specialized function for calculating round evaluations for bivariate product compositions. The implementation leverages the `binius_compute` crate for hardware acceleration.

Key changes:
- Add new `calculate_round_evals` function that computes batched evaluations of products of pairs of partially specialized multilinear polynomials
- Re-export `layer` and `memory` modules from the compute crate
- Add `binius_compute` dependency to the core crate
- Add getters for the `indices` field in `IndexComposition`

This is the first step toward a V3 sumcheck prover implementation that will eventually replace the current V2 prover.

[compute] Introduce ComputeLayer::extrapolate_line operation (#391)

# Introduce ComputeLayer::extrapolate_line operation

This PR adds a new `extrapolate_line` operation to the `ComputeLayer` trait. This operation extrapolates a line between evaluations at 0 and evaluations at 1, computing `y_z = y_0 + (y_1 - y_0) * z` for a given point `z`. The operation is performed in parallel over vectors of field elements.

The implementation includes:
- Adding the `extrapolate_line` method to the `ComputeLayer` trait
- Implementing the method for `CpuLayer<T>`
- Adding test utilities and a test case to verify correctness
- Making `ComputeLayer<F: Field>` and `TowerFamily` require `'static`

The operation is useful for interpolating between two points on a line and evaluating at arbitrary positions.

[compute] Fix allocation lifetime issue (#392)

Objects allocated by an allocator must not outlive the allocator. This precludes allocators from owning data and allocating parts of it. The new interface matches the bumpalo [alloc](https://docs.rs/bumpalo/latest/bumpalo/struct.Bump.html#method.alloc) method now.

[sumcheck] Introduce BivariateSumcheckProver using ComputeLayer (#393)

# Implement BivariateSumcheckProver for Bivariate Product Compositions

This PR implements a specialized sumcheck prover for bivariate product compositions over large-field multilinears. The implementation uses a `ComputeLayer` instance for expensive operations, with input multilinears provided as device memory slices.

Key additions:
- Added `BivariateSumcheckProver` that implements the `SumcheckProver` interface
- Implemented memory management for both host and device allocations
- Added proper error handling for compute and allocation errors
- Enhanced documentation for the `n_vars()` method to clarify it represents remaining variables
- Implemented comprehensive test for the prover-verifier interaction

The implementation includes methods for:
- Calculating round evaluations and coefficients
- Folding multilinears using `extrapolate_line`
- Managing state transitions between execution, folding, and finishing phases

The PR also includes a test that verifies the entire sumcheck protocol flow, including proving and verification with random multilinear polynomials.

[core] miri (#353)

This changeset is related to [CRY-341]. Specifically it patches some cheesy
spots but it also highlights the issue using miri.

To run the test you need to execute the command below:

    RUSTFLAGS="-C target-feature=-neon" cargo miri test -p binius_core -- batch_evaluate_add_mul

Disabling -neon is required for apple silicon hardware as the code tries to use
the SIMD optimized versions of field math. For intel hardware you might need
to do a similiar tweak and is left as an exercise for the reader.

Besides that, the stackalloc was also wrapped as `alloca` is not recognized
by miri.

[CRY-341]: https://linear.app/irreducible/issue/CRY-341/check-funny-business-in-arith-circuit

Fix annoying clippy warnings (#413)

[m3] Binary merkle tree example internal nodes deduped.  (#386)

Deduped internal nodes in Binary Merkle tree example, addressed nits.

Revert "[m3] Binary merkle tree example internal nodes deduped.  (#386)" (#417)

* Revert "[m3] Binary merkle tree example internal nodes deduped.  (#386)"

This reverts commit 1240014c55ce66bdc0660e957a4e3794c5331a13.

[evalcheck] Fix for ZeroPadded zero-variable polynomials (#384)

Edge case when the evaluation is 0 due to zero padding.

[ci] Upload Perfetto Traces to s3 (#404)

[evalcheck] Avoid redundant evaluations (#401)

This PR refactors the evaluation logic for `Repeating`, `Projected`, `LinearCombination`, and `ZeroPadded` polys.

Instead of evaluating this poly directly, we now first evaluate their descendants.
After all descendants are evaluated, the top-level node is computed using internal_evals.

Imrovments:

- Significant performance gains for large numbers of Repeating, Projected, LinearCombination, and ZeroPadded
- More evaluations can now be deduplicated than before
- Descendants can have fewer variables and therefore be evaluated faster.

single-threaded keccakf evalcheck : 27s -> 23s

[compute] Add `binius_fast_compute` crate (#408)

Add `binius_fast_compute` crate with a basic implementation of `ComputeLayer`.

AVX2 Parallel 4-instance Groestl Hasher  (#394)

Byte-sliced hasing of 4 groestl instances in parallel on AVX2 machines.

[m3] actually mark `build_witness` as deprecated (#422)

[circuits] deprecate binius_circuits (#423)

`binius_circuits` is the legacy frontend for binius and is now being phased out
in favor of the newer `binius_m3` library.

[ci] Collect timing for five top phases (#421)

evalcheck mle position switch advice to message (#434)

### TL;DR

Changed transcript method from `decommitment()` to `message()` in evalcheck protocol.

### What changed?

Updated the transcript handling in the evalcheck protocol implementation:
- In `prove.rs`, changed `transcript.decommitment().write(&(position as u32))` to `transcript.message().write(&(position as u32))`
- In `verify.rs`, changed `transcript.decommitment().read::<u32>()?` to `transcript.message().read::<u32>()?`

### How to test?

Run the existing test suite for the evalcheck protocol to ensure that the protocol still functions correctly with the updated transcript method calls.

### Why make this change?

Nitpicking, but this change is necessary for maintaining a deterministic verifier. Otherwise the prover has control over how sumcheck claims are grouped together which influences other parts of the protocol.

[CODEOWNERS] Destroy it (#437)

We are removing the CODEOWNERS file. Pull requests still require one approval to be merged, but there are no specially designated "code owners" who are given the rights to approve.

All Binius developers are now entrusted to act as code owners. They means we will all monitor new PRs against the repo. Any PRs that we believe we are capable of reviewing well, we will assign ourselves to. If it looks good, every developer has permission to approve and merge.

[core] MultilinearPolyVariant::is_committed (#432)

A small cleanup.

[core] ensure valid oracle ID (#433)

Another small drive-by cleanup.

[core] Add Rayon cargo feature (#431)

This will let us run benchmarks in the `binius_core` package with multithreading.

[compute] Use ComputeLayer::map for bivariate products (#399)

### TL;DR

Added a new `map` method to the `ComputeLayer` trait to support concurrent execution of operations.

### What changed?

- Added a corresponding test in the compute crate that uses the new map function with multilinear evaluations
- Updated the bivariate product implementation to use the new map method instead of sequential processing

### Why make this change?

This change enables more efficient parallel processing of operations by providing a higher-level abstraction for mapping operations across multiple inputs. It allows the compute layer implementations to potentially optimize concurrent execution of similar operations, which can lead to better performance, especially on hardware that supports parallelism.

[constraint_system] Trace more proving phases (#436)

Add tracing spans for the GKR exponentiation and GKR GPA proving
phases.

[Evalcheck] use partial_evals to improve evalcheck performance (#447)

### TL;DR

Optimize Evalcheck prover by implementing partial evaluation caching for multilinear polynomials with shared suffixes.

### What changed?

- Added `try_get_prefix` method to `EvalPoint` to extract prefix when a suffix is known
- Implemented a caching system for partial evaluations of multilinear polynomials
- Added tracking of oracle suffixes to identify opportunities for reusing partial evaluations
- Modified `make_new_eval_claim` to leverage cached partial evaluations when available
- Refactored `calculate_projected_mles` to `collect_projected_mles` to better reflect its purpose
- Updated the bivariate sumcheck processing to use the partial evaluation cache

This optimization reduces redundant computation by caching partial evaluations of multilinear polynomials. When multiple evaluation points share the same suffix, we can compute the partial evaluation for the suffix once and reuse it across all points with that suffix. This is particularly beneficial for shifted and projected polynomial variants, where the same suffix appears frequently in different evaluation contexts.

### Singlehanded evalcheck results:
keccak: 22s -> 5s
groestl  36s ->6.49s
sha256: 5s -> 5s

[sumcheck] BivariateProductSumcheck borrows host allocator (#442)

The host allocator is no longer consumed, by the BivariateSumcheckProver on creation.

[prove] Fix tracing span label for flushes (#450)

[prove] Eliminate mistake data copy (#451)

This previously did an expensive copy of witness data because `concat` clones. Instead we just recollect the vector elements.

[Evalcheck] remove redundant query memoization (#452)

It appears that the performance boost is not primarily due to storing partial_eval, but rather due to splitting the computation into two parts. When replacing the suffix+prefix split with a simple mid split, performance only slightly degrades.

My hypothesis is that this behavior is related to cache usage. For example, the tensor product of a point with 25 variables takes around 500MB, whereas with only half the variables it's approximately 0.13MB — a dramatic difference that likely affects memory locality and cache efficiency.

In any case, this PR improves performance from 2x (Groestl) up to 10x (SHA-256) compared to the previous implementation.

It's also quite possible that similar optimizations could be applied to other parts of the codebase in the future.

[compute] Add Map to ComputeLayer (#420)

[compute] Stacked allocation pattern for ComputeLayer memory (#444)

Adds `remaining` method to ComputeLayer allocators to create stack frames of ComputeLayer memory that are freed once the memory returned by remaining goes out of scope.

[core] Introduce structured oracle type (#461)

Structured is an oracle type that is very similar to Transparent, but is
defined by an ArithCircuit of some upper bound of n_vars.

This oracle type is mainly motivated by the needs of structured columns. The
idea is that such a structured column will define an arith expression up to some
maximum size. The frontend can supply any table size up to that maximum.

See [CRY-396] for more details.

[CRY-396]: https://linear.app/irreducible/issue/CRY-396/transparent-oracle-type-based-on-arithcircuit

Expose bivariate sumcheck generic tests (#456)

[compute] Parametrize bivariate sumcheck tests size (#457)

[constraint_system] Optimize make_masked_flush_witnesses (#453)

# [prove] Optimize make_masked_flush_witnesses

This PR optimizes the `make_masked_flush_witnesses` function by replacing the general composition function evaluation with a more direct approach. Since we know the evaluation is a selected value, we can compute it more efficiently.

Key improvements:
- Directly computes the linear combination of oracles with mixing powers
- Handles constant terms separately from oracle terms
- Optimizes the case where selectors are zero (returning ONE)
- Avoids unnecessary computations when selectors disable parts of the computation

For PetraVM on Fibonacci example, this reduced single-threaded operation latency by ~75%.

[hash] Removed AVX512 Instruction from AVX2 Groestl (#473)

Removed the accidental use of an AVX512 instruction from AVX2 hasher

[typo] Fix stray typo (#471)

[keccak] Apply selector to packed state column (#472)

Applying the selector to the packed state column results in fewer constraint evaluations.

[evalcheck] Remove ComputationBackend usage (#470)

Also remove it from ring_switch::prove

[compute] Implement `FastCpuLayer::accumulate_kernels` (#409)

Implement the following `FastCpuLayer` methods:
 - accumulate_kernels
 - kernel_add
 - sum_composition_evals

[Evalcheck] Correct the logic for splitting evaluation point (#482)

Fix illegal instruction error when running Groestl hash with AVX2 but without AVX512 (#488)

[compute] Implement `FastCpuLayer::fold_left` (#410)

Implement `FastCpuLayer::fold_left` and the all necessary changes for that

[hash] Benchmarks for AVX2 parallel Groestl (#397)

* avx2 parallel groestl utils

* starting multi-digest impl

* temporary debugging tools added

* hash works for short pads

* clean

* fix main block crunch routine

* efficient byteslicing

* clean prints

* bitslicing with intrinsics

* comments

* clean

* good tests

* clippy

* fmt

* fmt

* copyright

* more clippy

* review

* fix formatting

* clippy

* clippy

* cleaning

* clippy

* maybeuninit

* multi digest fallback impl

* rebase

* mod file fix

* updatable

* multi digest unparallelize and clean

* fmt

* doc string

* clippy

* paralleldigest impl exported

* rebase to avx2 fix

* fmt

* spelling

* avx spelling fix

* rebase

* quick repair

* review suggestions

* allow hasher to have empty lanes

* merge avx2 instruction changes

* fix propagated name issue from rebase

* unite benches

---------

Co-authored-by: jsk11235 <kirmayerjacob@gmail.com>

SYS-258: fix `test_generic_fri_fold` host buffer (#491)

* SYS-258: fix `test_generic_fri_fold` host buffer

The prior version invoked `copy_h2d` with a host buffer that was not
allocated with the host allocator. Using a buffer allocated with the
default allocator results in incorrect behavior if the hardware
implementation derives additional addressing information during copies
from the provided slice assuming that the slice was allocated by the
implementation's host allocator.

* Fix clippy

docs (CONTRIBUTING.md): fix link to "good first issue" label (#487)

fix link to "good first issue" label

[compute] Implement `FastCpuLayer::fold_right ` (#411)

Implement `FastCpuLayer::fold_right`

[compute] Implement `FastCpuLayer::fri_fold` (#412)

Implement `FastCpuLayer::fri_fold`

[core] remove fn no_base_constraints (#476)

it does not do anything and seems to be a relic of some past change.

[core] remove fn oracle (#475)

As you can see in the changeset, this function was overused, which lead to
copying the entire oracle data which could be, IIRC, up to 180 bytes. Hence we
just remove that function. In case, the actual copy is required `Clone::clone`
is suggested, or better, surgical copy of only data required.

[core] remove fn get_from_set (#483)

Practically the same reasons as the previous PR:

https://app.graphite.dev/github/pr/IrreducibleOSS/binius/475

SYS-274:  host allocated slice in generic `left_fold` test (#498)

* SYS-274:  host allocated slice in generic `left_fold` test

Hardware implementations require host buffers to be allocated with the
HAL's host buffer allocator to compute addressing information correctly
in host<->device copy functions.

* Fix clippy

[constraint_system] Optimize flush witness conversion to POLYVAL (#454)

Renamed `make_fast_unmasked_flush_witnesses` to `convert_witnesses_to_fast_ext` with comprehensive (AI-generated) documentation explaining its purpose and behavior. The function converts witness representations from base extension field to fast extension field format for optimized grand product calculations.

The implementation now:
- Returns a `Vec<MultilinearExtension>` instead of tuples
- Uses `IndexEntry` to access polynomial data and nonzero prefix information
- Properly allocates memory based on the actual polynomial size
- Truncates results more efficiently

This change improves reduced conversion time by ~35% on PetraVM Fibonacci example single-threaded.

[Benchmarks] update u32_mul to u32_mul_gkr (#500)

u32_mul is outdated, u32_mul_gkr 3x faster

Simplify packed field construction with more macros (#425)

[hash] Minor optimization of `ParallelDigest` implementation for the `Digest` (#511)

Updated `ParallelDigest` implementation to use `HashBuffer` for more efficient serialization.  `BytesMut` is actilng like a `Vec` reallocating the memory on request which is inefficient when hashing big chunks of data while `HashBuffer` stores only one block of additional memory and never allocates.

[compute] HAL operation for parallel composition evaluation (#509)

# Add `compute_composite` method to `ComputeLayer` trait

### TL;DR

Adds a new `compute_composite` method to the `ComputeLayer` trait that applies a compiled arithmetic expression to multiple input slices element-wise.

### What changed?

- Added a new `compute_composite` method to the `ComputeLayer` trait with detailed documentation
- Implemented the method for `CpuLayer` and `FastCpuLayer` types
- Added a test utility function `test_generic_compute_composite` to verify the implementation
- Added a test case for the new functionality in the fast_compute crate

The new method allows applying a composition function to multiple input slices element-wise, where each element in the output is the result of applying the function to the corresponding elements from each input slice.

### How to test?

Run the new test in the fast_compute crate:

```bash
cargo test -p binius-fast-compute test_compute_composite
```

The test verifies that the implementation correctly computes the product of two input vectors element-wise using a bivariate product expression.

### Why make this change?

This addition enables more efficient computation of composite expressions across multiple polynomial evaluations, which is a common operation in zero-knowledge proof systems. By providing this as a first-class operation in the compute layer, it allows for optimized implementations on different hardware backends.

[merkle tree example] Basis change for compression function used in merkle tree model. (#504)

# Modify Merkle tree test to match Groestl gadget basis representation

Updates the `compress` function in the Merkle tree test to transform byte representations between Fan-Paar basis and AESTowerField8b basis, ensuring consistency with the Groestl gadget implementation.

[merkle tree example] Add `root()` method to MerkleTree  (#505)

# Add `root()` method to MerkleTree

Added a public method to get the root of the merkle tree and updated all tests to use this method instead of accessing the root field directly.

[merkle tree example] Add Copy trait to MerklePathEvent and MerkleRootEvent structs (#506)

### TL;DR

Added `Copy` trait to Merkle tree event structs.

### What changed?

Added the `Copy` trait to the `MerklePathEvent` and `MerkleRootEvent` structs in the Merkle tree tests. These structs already derive other traits like `Debug`, `Clone`, `PartialEq`, `Eq`, and `Hash`.

[merkle tree example] Make generate and validate methods public (#507)

# Make `generate` and `validate` methods public in `MerkleTreeTrace`

This PR changes the visibility of two methods in the `MerkleTreeTrace` struct from private to public:
- `generate`: Creates a trace from roots and paths
- `validate`: Validates the trace

These changes allow these methods to be accessed from outside the module for the arithmetisation.

Fix `log_chunks_range` (#525)

[chore] typos 2025-05-22 (#519)

typos I gathered throughout the last weeks

[sumcheck] Log more info in calculate_round_evals span (#518)

Remove unnecessary optimization passes in `determine_const_eval_suffixes` (#527)

In `determine_const_eval_suffixes` we are calling `optimize` for the expressions where we only need to get a constant value from. This involves deduplicating steps operation which becomes quite slow in case when there are many expressions to process.

What we need is to only perform a constant folding, so in this PR this method is exposed to be public.

Change ComputeLayer::compile_expr method to accept ArithCircuit (#530)

### TL;DR

Replace `ArithExpr` with `ArithCircuit` throughout the codebase.

### What changed?

- Updated function signatures in `ComputeLayer` trait to use `ArithCircuit` instead of `ArithExpr`
- Modified implementations in CPU and FastCPU layers to work with `ArithCircuit`
- Updated test utilities and protocol implementations to use the new type
- Changed how expressions are compiled and handled in various compute layers

### How to test?

Run the existing test suite to ensure all functionality continues to work with the new `ArithCircuit` type. The changes should be transparent to users of the API, so no specific test cases need to be added.

### Why make this change?

This change standardizes the codebase on `ArithCircuit` as the primary representation for arithmetic expressions. This likely provides better consistency and may offer improved capabilities compared to the previous `ArithExpr` type. The change is part of an effort to unify the expression handling across the codebase.

[MLEcheck] opimize-determine_const_eval_suffixes (#493)

This took 5% of the total sha256 proving time, but all the suffixes are zero

[m3] move the current keccak gadget to stacked (#514)

This is done in preparation to adding another version of the keccak gadget, that
does not use stacking.

This is not a functional change.

[m3] stat fix committed vs. stacked (#520)

[m3] ensure committed bits per row for keccak arithmetization (#534)

Used for experiments like here.
https://linear.app/irreducible/issue/CRY-411/keccak-f-arithmetization-without-shifts#comment-86121c91
This is not necessary to land.

[Evalcheck] improve collect_projected_mles (#492)

1)Deduplicate (suffix, inner_id) pairs
2)Try to build partial_evals from children

Slight speedup for Keccak, ~15% for SHA-256.

[compute] Create V3 BivariateMLECheckProver (#485)

[merkle tree example] Add arithmetisation module for Merkle tree inclusion proofs (#508)

### TL;DR

Added arithmetization module for Merkle tree inclusion proofs using Groestl-256 as the compression function.

### What changed?

Added a new `arithmetisation` module to the Merkle tree tests that provides a complete implementation of the constraint system for verifying Merkle tree inclusion proofs. The implementation includes:

- `MerkleTreeCS`: A constraint system with tables and channels for Merkle tree verification
- `NodesTable`: Table for handling Merkle path steps with different child pull strategies (left, right, or both)
- `RootTable`: Table for verifying root consistency
- Table filling logic for witness generation
- Boundary construction for circuit input/output consistency
- Helper functions for data conversion and flushing
- Comprehensive test suite to validate the implementation

The module uses Groestl-256 as the compression function and supports verification of multiple inclusion proofs in a single circuit.

### How to test?

The implementation includes several unit tests that can be run with:

Key tests include:
- `check_ordering` and `check_state_orientation`: Verify correct byte ordering
- `test_nodes_table_constructor` and `test_root_table_constructor`: Verify table construction
- `test_node_table_filling` and `test_root_table_filling`: Test table filling logic
- `test_merkle_tree_cs_fill_tables`: Test the complete constraint system table filling
- `test_merkle_tree_cs_end_to_end`: End-to-end test with random Merkle trees

### Why make this change?

This implementation provides a reference for implementing Merkle tree inclusion proofs in the Binius M3 framework. It demonstrates how to:
1. Define constraint systems for cryptographic primitives
2. Handle complex data structures like Merkle trees
3. Implement witness generation for zero-knowledge proofs
4. Create proper boundary conditions for circuit inputs/outputs

The module serves both as a test for the Merkle tree implementation and as a reference for developers implementing similar cryptographic primitives in the framework.

[m3] Handle non-linear expressions in add_computed by committing and asserting (#552)

# Optimize computed column handling for non-linear expressions

This PR changes how non-linear computed columns are handled. Instead of resolving non-linear expressions through sumcheck reduction, we now:

1. For linear expressions (degree ≤ 1): Continue using the existing efficient approach
2. For non-linear expressions (degree > 1):
   - Create a committed column
   - Assert that the expression is zero using a zerocheck.

[m3] Incr lookup extracted into gadgets. (#538)

# Refactor indexed lookup test into a reusable gadget

This PR extracts the increment lookup test code from `indexed_lookup.rs` into a reusable gadget in `gadgets/indexed_lookup/incr.rs`.

- Moved the increment lookup implementation from test code to a dedicated module
- Made key functions and structs public so they can be used elsewhere

[math] Export binary tower type aliases (#555)

This is the first change in a stack to remove the TowerFamily trait. This exports tower field aliases from `binius_math`. They are exported from `binius_math` instead of `binius_field` because the field crate should be more agnostic about how the developer uses binary fields in their protocol. `binius_math` is upstream of many other crates that need the tower aliases.

[m3] AND table gadget (#539)

# Add AND lookup gadget

This PR adds a new indexed lookup gadget for computing the logical AND of two boolean columns.

[chore] change rustdoc type (#560)

[m3] require sync for ClosureFiller (#561)

I am not sure if this is the best solution, but we can roll it back in case
it's not.

Add samply profiler file to gitignore (#563)

Add samply profiler output file (`profile.json.gz`) to `.gitignore`

[chore] add profile.json to .gitignore as well (#569)

On macOS I am getting profile.json, i.e. without compression, for some reason.

Replace MIN_SLICE_LEN with ALIGNMENT in the device memory (#503)

This main purpose of this change to support arbitrary small slices of the "device" memory in `FastCpuComputeLayer`.

The main idea is to represent `FSlice`/`FSliceMut` as an enum with two options:
 - Borrowed slice, when the number of elements is a multiple of `P::WIDTH`
 - Owned storage with a single packed element for the case when the length is strictly less than `P::WIDTH`.

We still can't represent slices bigger than `P::WIDTH` which aren't aligned by the `P::WIDTH` border but that seems to be sufficient for our needs, e.g. we are always able to split pow of two length slices by half.

The changes introduced by this PR:
 - replace `ComputeMemory::MIN_SLICE_LEN` with `ComputeMemory::ALIGNMENT`
 - relax conditions for all the slice spliting method, now the slices with the non-aligned length are allowed when their length is strictly less than the alignment
 - change the implementation of `FSlice` and `FSliceMut` in the `binius_fast_compute` crate.

The HW and `CPULayer` implementations of the memory do not need to change anything apart from applying the renaming.

Test sumcheck_v3 with binius_fast_compute (#513)

Add tests for sumcheck_v3 using `FastCpuLayer`.

Add benchmarks for sumcheck_v3 (#554)

Add benchmarks for sumcheck_v3

Here are the results I'm getting at the moment:

```
RAYON_NUM_THREADS=1 cargo bench --bench sumcheck -- --discard-baseline
    Finished `bench` profile [optimized + debuginfo] target(s) in 0.07s
     Running benches/sumcheck.rs (target/x86_64-unknown-linux-gnu/release/deps/sumcheck-a33925454133ce40)

Benchmarking Sumcheck/BinaryField128b/n_vars=20/LowToHigh:
Sumcheck/BinaryField128b/n_vars=20/LowToHigh
                        time:   [124.49 ms 124.95 ms 125.46 ms]

Sumcheck/BinaryField128bPolyval/n_vars=20/LowToHigh
                        time:   [23.067 ms 23.232 ms 23.393 ms]

Benchmarking Sumcheck/ByteSlicedAES32x128b/n_vars=20/LowToHigh:
Sumcheck/ByteSlicedAES32x128b/n_vars=20/LowToHigh
                        time:   [89.935 ms 90.211 ms 90.496 ms]

Benchmarking Sumcheck/BinaryField128b/n_vars=20/HighToLow:
Sumcheck/BinaryField128b/n_vars=20/HighToLow
                        time:   [75.062 ms 75.534 ms 76.042 ms]

Sumcheck/BinaryField128bPolyval/n_vars=20/HighToLow
                        time:   [14.658 ms 14.845 ms 15.032 ms]

Sumcheck/ByteSlicedAES32x128b/n_vars=20/HighToLow
                        time:   [18.739 ms 18.993 ms 19.243 ms]

Benchmarking SumcheckV3/BinaryField128b/n_vars=20:
SumcheckV3/BinaryField128b/n_vars=20
                        time:   [72.834 ms 73.338 ms 73.816 ms]

Benchmarking SumcheckV3/ByteSlicedAES32x128b/n_vars=20:
SumcheckV3/ByteSlicedAES32x128b/n_vars=20
                        time:   [364.97 ms 367.87 ms 370.75 ms]
```

Optimize kernel memory allocations in FastCPULayer (#557)

It appeared that allocating memory (even a rayon-thread local) can be hot. Introducing thread-local memory buffers in the `FastCPUCore` show signifficant improvement in sumcheck_v3 benchmarks:

```
SumcheckV3/BinaryField128b/n_vars=20
                        time:   [56.705 ms 57.130 ms 57.606 ms]
                        change: [−2.5240% −1.6333% −0.6557%] (p = 0.00 < 0.05)
                        Change within noise threshold.

SumcheckV3/ByteSlicedAES32x128b/n_vars=20
                        time:   [14.317 ms 14.397 ms 14.482 ms]
                        change: [−90.718% −90.649% −90.584%] (p = 0.00 < 0.05)
                        Performance has improved.

```

[core] introduce SizedConstraintSet (#480)

As part of
[CRY-363: Table-Aware Constraint System](https://linear.app/irreducible/issue/CRY-363/table-aware-constraint-system)
we want to make the constraint system description into the transcript. What
prevents us from doing so is that the sizes of a particular instance are
embedded in the constraint system. Besides MultilinearOracleSet the sizes
are present in the ConstraintSet. The changeset presented here aims to
reduce the scope of n_vars usage just to the proving/verifying, where the
newly introduced SizedConstraintSet is used now.

Note that we still have the n_vars in the ConstraintSet, but removing it should
be pretty straightforward in a follow-up PR that will actually switch over to
passing the table sizes through the transcript.

[core] deserialize composite mle as well (#499)

We've never deserialized it it seems.

[core] instead of max_channel_id use channel count directly (#571)

This seems to be a more logical approach, but it will also for the consistency
with the to-be-added table_count

This is part of [CRY-363: Table-Aware Constraint System](https://linear.app/irreducible/issue/CRY-363/table-aware-constraint-system)

[fri] Choose FRI domains to be folding compatible (#549)

This PR changes the FRI parameter selection logic to choose Reed-Solomon evaluation domains that are NTT-compatible, regardless of the trace size.

Previously, the evaluation subspace depended on the trace size. Now, we choose the FRI domains to be the push-forwards of a stable domain (the T_5 basis) under the q maps. This will assist with batch FRI arguments with pre-committed tables.

SYS-274: fix bivariate sumcheck host alloc (#564)

Allocate the host evaluations data using the HAL-specific host
allocator. Doing so is required for compatibility with `host_alloc`
across implementations.

[macros] get rid of composition poly (#583)

Part of [CRY-382: Migrate away from the deprecated items where needed.](https://linear.app/irreducible/issue/CRY-382/migrate-away-from-the-deprecated-items-where-needed)

[macros] remove arith_expr (#584)

Part of [CRY-382: Migrate away from the deprecated items where needed.](https://linear.app/irreducible/issue/CRY-382/migrate-away-from-the-deprecated-items-where-needed)

I did not care too much about cleaning up the binius_circuits as it is going away soon.

[macros] remove artih circuit poly (#585)

A part of [CRY-382: Migrate away from the deprecated items where needed.](https://linear.app/irreducible/issue/CRY-382/migrate-away-from-the-deprecated-items-where-needed)

[compute] Create KernelBuilder trait (#570)

Move kernel construction methods from ComputeLayer onto a new trait, which is an associated type. This helps move towards an API where ComputeLayer can be sync while allowing for multithreaded backends.

[compute] Remove all kernel methods on ComputeLayer (#572)

[examples] migrate groestl to m3 (#595)

Actually, this was wrong.

Closes [CRY-429: groestl](https://linear.app/irreducible/issue/CRY-429/groestl)

[bench] kill vision32b benchmark (#596)

See [CRY-430: kill vision32b benchmark](https://linear.app/irreducible/issue/CRY-430/kill-vision32b-benchmark)

[compute] Add KernelBuilder::add_assign (#591)

[sumcheck v3] Remove unnecessary local memory for folding (#592)

[compute] Relax requirement on kernel memory (#594)

Kernel memory buffers don't need to be the same type as global memory buffers.

Add a CI job to check that we don't accidently use unsupported x86 instructions (#550)

[ring_switch] Remove usage of TowerFamily (#556)

Replace TowerFamily with exported tower type aliases.

[bench] kill sha256 benchmark (#597)

See [CRY-431: kill sha256 benchmark](https://linear.app/irreducible/issue/CRY-431/kill-sha256-benchmark)

[m3] Indexed lookup structs made public (#615)

Made `BitAndIndexedLookup` and `IncrIndexedLookup` structs public.

[merkle tree example] Child depth constraint fixed. (#616)

# Implement Depth Increment Verification in Merkle Tree

This PR adds a constraint to verify that the child depth is exactly one more than the parent depth in the Merkle tree implementation. It:

1. Adds an `IncrLookup` table and related channels to enforce the depth increment constraint
2. Changes the depth columns from `B32` to `B8` since depths are small values
3. Implements the increment verification using the `Incr` gadget
4. Updates the witness population to properly handle the increment verification

The implementation ensures that Merkle tree paths maintain proper depth relationships, improving the soundness of the verification system.

SYS-287: move HAL operations to exec (#617)

Remove the `Sync` requirement from the HAL. This property was only required by the optimized CPU implementation.

[fix] flush oracles with n_vars less P::LOG_WIDTH (#619)

Added a bounds check in the constraint system proving code to ensure that when the number of variables of flash oracles is less than `P::LOG_WIDTH`, we fill the remaining scalars with zeroes instead of attempting to access out-of-bounds indices

[examples] [hash] Parallelized architecture-specific hashing used in examples (#609)

### TL;DR

Updated the constraint system to use parallel Groestl256 hashing for improved performance.

### What changed?

- Modified the constraint system's `prove` function to use `ParallelDigest` trait instead of the `Digest` trait for its hasher
- Updated the `Groestl256Multi` implementation to handle empty data arrays by filling them with zeroes
- Changed all examples to use `Groestl256Parallel` instead of `Groestl256` for hashing

### How to test?

Run any of the example programs to verify they still work correctly with the parallel hashing implementation. The examples should execute faster due to the parallel hashing optimization.

### Why make this change?

This change improves performance by using parallel hashing capabilities. The parallel Groestl256 implementation can process multiple data streams simultaneously, which speeds up the proving process. The modification to handle empty data arrays also makes the implementation more robust by allowing it to process inputs of varying lengths.

[core] push TableId down to core (#581)

As part of [CRY-363: Table-Aware Constraint
System](https://linear.app/irreducible/issue/CRY-363/table-aware-constraint-system),
we would need to introduce the concept of tables into core and we would need
a way to address them via those IDs.

Proper structurification and rustdoc should come in a follow-up (specifically it's tracked [here](https://linear.app/irreducible/issue/CRY-350/newtype-tableid)).

Use transformation to byte sliced and back in `FastCpuLayer::extrapolate_lines` (#606)

# Optimize extrapolate_line for binary fields using byte-sliced representation

### TL;DR

Optimize the `extrapolate_line` operation for binary fields by leveraging byte-sliced representation transformations.

### What changed?

- Added a specialized implementation of `extrapolate_line` for binary field types (`PackedBinaryField1x128b`, `PackedBinaryField2x128b`, and `PackedBinaryField4x128b`)
- Created a macro `extrapolate_line_byte_sliced` that transforms data to byte-sliced representation, performs the operation, and transforms back
- Modified the `extrapolate_line` method to use the optimized implementation for specific binary field types
- Made `HEIGHT_BYTES` constant public in byte-sliced implementations
- Added additional imports to support the new implementation

### How to test?

Added three test cases to verify the optimized implementation:
- `test_extrapolate_line_128b` for `PackedBinaryField1x128b`
- `test_extrapolate_line_256b` for `PackedBinaryField2x128b`
- `test_extrapolate_line_512b` for `PackedBinaryField4x128b`

Run these tests to ensure the optimized implementation produces correct results.

### Why make this change?

The byte-sliced representation allows for more efficient field multiplication that is the hottest part of `extrapolate_line` for big fields

This change improves the sumcheck_v3 benchmark for dense packed field by 20%

[bench] migrate u32_add to m3 (#600)

See [CRY-433: u32_add](https://linear.app/irreducible/issue/CRY-433/u32-add)

[bench] migrate b32_mul to m3 (#602)

See [CRY-432: b32_mul](https://linear.app/irreducible/issue/CRY-432/b32-mul)

[bench] u32_mul_gkr cleanup (#610)

Didn't require a port just a cleanup.

See [CRY-434: u32_mul_gkr](https://linear.app/irreducible/issue/CRY-434/u32-mul-gkr)

[bench] migrate bitwise_ops to m3 (#611)

See [CRY-438: bitwise](https://linear.app/irreducible/issue/CRY-438/bitwise)

cleanup (#612)

- Remove the examples that are based on binius_circuits but are not used
  as benchmarks.
- Remove README.md as it is incredibly outdated. Removing it improves status
  quo.
- Fix the rest OptimalUnderlier128b and U uses.

[circuits] Kill it. (#613)

Good night sweet prince, you served well.

[field] Add Rng import to test modules (#661)

### TL;DR

Added missing `Rng` import in two test modules. This was breaking CI after updated dependencies.

### What changed?

Added the `Rng` trait to the import statements in two test modules:
- `crates/field/src/arch/portable/byte_sliced/mod.rs`
- `crates/field/src/packed_binary_field.rs`

[core] Replace RegularSumcheckProver with BivaraiteSumcheckProver in piop::prove (#512)

### TL;DR

Refactored the PIOP proving system to use the new compute layer abstraction, enabling GPU acceleration for sumcheck proofs.

### What changed?

- Added `Debug` trait bounds to