### PR TITLE
SYS-348: add pairwise product reduction HAL op

### DIFF
--- a/crates/compute/src/layer.rs
+++ b/crates/compute/src/layer.rs
@@ -462,6 +462,51 @@ pub trait ComputeLayerExecutor<F: Field> {
 		output: &mut <Self::DevMem as ComputeMemory<F>>::FSliceMut<'_>,
 		composition: &Self::ExprEval,
 	) -> Result<(), Error>;
+
+	/// Reduces a slice of elements to a single value by recursively applying pairwise
+	/// multiplication.
+	///
+	/// Given an input slice `x` of length `n = 2^k` for some integer `k`,
+	/// this function computes the result:
+	///
+	/// $$
+	/// y = \prod_{i=0}^{n-1} x_i
+	/// $$
+	///
+	/// However, instead of a flat left-to-right reduction, the computation proceeds
+	/// in ⌈log₂(n)⌉ rounds, halving the number of elements each time:
+	///
+	/// - Round 0: $$ x_{i,0} = x_{2i} \cdot x_{2i+1} \quad \text{for } i = 0 \ldots \frac{n}{2} - 1
+	///   $$
+	///
+	/// - Round 1: $$ x_{i,1} = x_{2i,0} \cdot x_{2i+1,0} $$
+	///
+	/// - ...
+	///
+	/// - Final round: $$ y = x_{0,k} = \prod_{i=0}^{n-1} x_i $$
+	///
+	/// This binary tree-style reduction is mathematically equivalent to the full product,
+	/// but structured for efficient parallelization.
+	///
+	/// ## Arguments
+	///
+	/// * `input`` - A slice of input field elements provided to the first reduction round
+	/// * `round_outputs` - A mutable slice of preallocated output field elements for each reduction
+	///   round. `round_outputs.len()` must equal log₂(input.len()) - 1. The length of the FSlice at
+	///   index i must equal input.len() / 2**(i + 1) for i in 0..round_outputs.len().
+	///
+	/// ## Throws
+	///
+	/// * Returns an error if the length of `input` is not a power of 2.
+	/// * Returns an error if the length of `input` is less than 2 (no reductions are possible).
+	/// * Returns an error if `round_outputs.len()` != log₂(input.len())
+	/// * Returns an error if any element in `round_outputs` does not satisfy
+	///   `round_outputs[i].len() == input.len() / 2**(i + 1)` for i in 0..round_outputs.len()
+	fn pairwise_product_reduce(
+		&mut self,
+		input: <Self::DevMem as ComputeMemory<F>>::FSlice<'_>,
+		round_outputs: &mut [<Self::DevMem as ComputeMemory<F>>::FSliceMut<'_>],
+	) -> Result<(), Error>;
 }
 
 /// An interface for defining execution kernels.

--- a/crates/compute/tests/layer.rs
+++ b/crates/compute/tests/layer.rs
@@ -145,3 +145,21 @@ fn test_map_kernels() {
 		log_len,
 	);
 }
+
+#[test]
+fn test_pairwise_product_reduce_single_round() {
+	let log_len = 1;
+	binius_compute_test_utils::layer::test_generic_pairwise_product_reduce(
+		CpuLayerHolder::<B128>::new(1 << (log_len + 4), 1 << (log_len + 3)),
+		log_len,
+	);
+}
+
+#[test]
+fn test_pairwise_product_reduce() {
+	let log_len = 8;
+	binius_compute_test_utils::layer::test_generic_pairwise_product_reduce(
+		CpuLayerHolder::<B128>::new(1 << (log_len + 4), 1 << (log_len + 3)),
+		log_len,
+	);
+}

--- a/crates/compute_test_utils/Cargo.toml
+++ b/crates/compute_test_utils/Cargo.toml
@@ -18,4 +18,5 @@ binius_math = { path = "../math", default-features = false }
 binius_ntt = { path = "../ntt", default-features = false }
 binius_utils = { path = "../utils", default-features = false }
 bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
+itertools.workspace = true
 rand.workspace = true

--- a/crates/fast_compute/src/layer.rs
+++ b/crates/fast_compute/src/layer.rs
@@ -619,6 +619,15 @@ impl<'a, T: TowerFamily, P: PackedTop<T>> ComputeLayerExecutor<T::B128>
 
 		result.into_iter().map(|(_, out)| out).collect()
 	}
+
+	fn pairwise_product_reduce(
+		&mut self,
+		_input: <Self::DevMem as ComputeMemory<T::B128>>::FSlice<'_>,
+		_round_outputs: &mut [<Self::DevMem as ComputeMemory<T::B128>>::FSliceMut<'_>],
+	) -> Result<(), Error> {
+		// TODO(CRY-490)
+		todo!()
+	}
 }
 
 /// In case when `P1` and `P2` are the same type, this function performs the extrapolation


### PR DESCRIPTION
This operation produces the partial products for each intermediate claim
in the grand product argument.