### PR TITLE
[utils] fix ensure macro

### DIFF
--- a/crates/utils/src/error_utils.rs
+++ b/crates/utils/src/error_utils.rs
@@ -20,7 +20,7 @@ macro_rules! bail {
 macro_rules! ensure {
 	($cond:expr, $err:expr) => {
 		if !$cond {
-			bail!($err);
+			$crate::bail!($err);
 		}
 	};
 }


### PR DESCRIPTION
The macro is unhygienic and tries to pull `bail` from the existing scope. It
worked mostly because every use `bail` around.