### PR TITLE
FastCompute implementation of GPA witness layer low-to-high HAL op

### DIFF
--- a/crates/fast_compute/src/memory.rs
+++ b/crates/fast_compute/src/memory.rs
@@ -286,10 +286,6 @@ impl<P: PackedField> SmallOwnedChunk<P> {
 	fn iter_scalars(&self) -> impl Iterator<Item = P::Scalar> {
 		self.data.iter().take(self.len)
 	}
-
-	pub fn fill(&mut self, value: P::Scalar) {
-		self.data = P::broadcast(value)
-	}
 }
 
 /// Memory slice that can be either a borrowed slice or an owned small chunk (with length <

--- a/crates/fast_compute/tests/layer.rs
+++ b/crates/fast_compute/tests/layer.rs
@@ -167,3 +167,23 @@ fn test_map_kernels() {
 		log_len,
 	);
 }
+
+#[test]
+fn test_pairwise_product_reduce_single_round() {
+	type P = PackedBinaryField4x128b;
+	let log_len = 1;
+	binius_compute_test_utils::layer::test_generic_pairwise_product_reduce(
+		FastCpuLayerHolder::<CanonicalTowerFamily, P>::new(1 << (log_len + 4), 1 << (log_len + 3)),
+		log_len,
+	);
+}
+
+#[test]
+fn test_pairwise_product_reduce() {
+	type P = PackedBinaryField4x128b;
+	let log_len = 8;
+	binius_compute_test_utils::layer::test_generic_pairwise_product_reduce(
+		FastCpuLayerHolder::<CanonicalTowerFamily, P>::new(1 << (log_len + 4), 1 << (log_len + 3)),
+		log_len,
+	);
+}


### PR DESCRIPTION
### TL;DR

Implemented the `pairwise_product_reduce` function for the FastCpuLayer and added tests for it.

### What changed?

- Implemented the previously unimplemented `pairwise_product_reduce` function in the `ComputeLayerExecutor` trait for `FastCpuLayer`
- Added input validation to ensure the input length is a power of 2 and greater than or equal to 2
- Implemented the pairwise product reduction algorithm using parallel chunks processing
- Removed the unused `fill` method from `SmallOwnedChunk`
- Simplified the `fill_constant` implementation to use the new slice abstraction
- Added necessary imports (`Itertools` and `PackedMemorySlice`)
- Added tests for the new functionality with both single round and multi-round reductions

### How to test?

Run the new tests:
```
cargo test -p fast_compute test_pairwise_product_reduce
cargo test -p fast_compute test_pairwise_product_reduce_single_round
```

### Why make this change?

This change implements a previously unimplemented function that is needed for computing pairwise products and reducing them, which is a common operation in cryptographic protocols. The implementation is optimized for CPU execution using parallel processing where possible.