### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,7 +48,7 @@ jobs:
                 os: [c7a-2xlarge, c8g-2xlarge, supermicro]
         steps:
             - name: Checkout Repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   fetch-depth: 0 # Fetch all history to include all git information in traces
             - name: Set safe directory
@@ -94,7 +94,7 @@ jobs:
                 os: [c7a-2xlarge, c8g-2xlarge, supermicro]
         steps:
             - name: Checkout Repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
             - name: Setup Bencher
               uses: bencherdev/bencher@v0.4.37 # Pin to specific version to avoid breaking changes
             - name: Download raw results for Bencher

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             name: "pre-commit"
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -70,7 +70,7 @@ jobs:
             cmd: 'scripts/check_cpu_extensions_sets.sh'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install deps
         run: sudo yum -y install gcc openssl-devel curl jq
       - name: Setup Rust
@@ -120,7 +120,7 @@ jobs:
             cmd: 'RUSTFLAGS="-C target-cpu=generic" ./scripts/run_tests_and_examples.sh'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install deps
         run: sudo yum -y install gcc openssl-devel
       - name: Setup Rust
@@ -146,7 +146,7 @@ jobs:
             cmd: 'RUSTFLAGS="-C target-cpu=native" BINIUS_M3_TEST_PROVE_VERIFY=1 cargo test --package binius_m3'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install deps
         run: sudo yum -y install gcc openssl-devel
       - name: Setup Rust

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -12,7 +12,7 @@ jobs:
     name: Mirror Repository to GitLab
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: shimataro/ssh-key-action@v2

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -22,7 +22,7 @@ jobs:
         os: [ c7a-2xlarge, c8g-2xlarge, supermicro ]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0