### PR TITLE
feat: add ColumnId to WitnessBorrow and WitnessBorrowMut errors

### DIFF
--- a/crates/m3/src/builder/error.rs
+++ b/crates/m3/src/builder/error.rs
@@ -37,15 +37,15 @@ pub enum Error {
 	TableSizePowerOfTwoRequired { table_id: TableId, size: usize },
 	#[error("table {table_id} is required to have a fixed power-of-two size, instead got {size}")]
 	TableSizeFixedRequired { table_id: TableId, size: usize },
-	// TODO: These should have column IDs
+
 	#[error(
-		"witness borrow error: {0}. Note that packed columns are aliases for the unpacked column when accessing witness data"
+		"witness borrow error for column {column_id:?}: {source}. Note that packed columns are aliases for the unpacked column when accessing witness data"
 	)]
-	WitnessBorrow(#[source] BorrowError),
+	WitnessBorrow { column_id: ColumnId, #[source] source: BorrowError },
 	#[error(
-		"witness borrow error: {0}. Note that packed columns are aliases for the unpacked column when accessing witness data"
+		"witness borrow error for column {column_id:?}: {source}. Note that packed columns are aliases for the unpacked column when accessing witness data"
 	)]
-	WitnessBorrowMut(#[source] BorrowMutError),
+	WitnessBorrowMut { column_id: ColumnId, #[source] source: BorrowMutError },
 	#[error(
 		"the table index was initialized for {expected} events; attempted to fill with {actual}"
 	)]


### PR DESCRIPTION
Addresses TODO comment in error.rs by adding ColumnId information to witness borrow errors for better debugging.

## Changes
- Update WitnessBorrow and WitnessBorrowMut error variants to include ColumnId
- Update all usage sites in witness.rs to pass appropriate ColumnId
- Update tests to match new error structure
- Remove TODO comment