### PR TITLE
fix: channel_id range checks when channel_count is zero

### DIFF
--- a/crates/core/src/constraint_system/channel.rs
+++ b/crates/core/src/constraint_system/channel.rs
@@ -112,7 +112,7 @@ where
 			direction,
 			multiplicity,
 		} = boundary;
-		if channel_id > max_channel_id {
+		if channel_id >= channel_count {
 			return Err(Error::ChannelIdOutOfRange {
 				max: max_channel_id,
 				got: channel_id,
@@ -132,7 +132,7 @@ where
 			log_values_per_row,
 		} = flush;
 
-		if channel_id > max_channel_id {
+		if channel_id >= channel_count {
 			return Err(Error::ChannelIdOutOfRange {
 				max: max_channel_id,
 				got: channel_id,


### PR DESCRIPTION
 Replace max-index comparison using saturating_sub with a direct length-based guard. This prevents out-of-bounds panics when channel_count == 0 by rejecting channel_id >= channel_count. Keeps error payload consistent by still reporting the computed max.